### PR TITLE
feat: Support ipmitool interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ const (
 	InterfaceLan     Interface = "lan"
 	InterfaceLanplus Interface = "lanplus"
 	InterfaceOpen    Interface = "open"
+	InterfaceTool    Interface = "tool"
 
 	DefaultExchangeTimeoutSec int = 20
 	DefaultBufferSize         int = 1024
@@ -46,6 +47,14 @@ func NewOpenClient() (*Client, error) {
 			myAddr:     myAddr,
 			targetAddr: myAddr,
 		},
+	}, nil
+}
+
+func NewToolClient(path string) (*Client, error) {
+
+	return &Client{
+		Host:      path,
+		Interface: "tool",
 	}, nil
 }
 
@@ -137,6 +146,10 @@ func (c *Client) Connect() error {
 		var devnum int32 = 0
 		return c.ConnectOpen(devnum)
 
+	case InterfaceTool:
+		var devnum int32 = 0
+		return c.ConnectTool(devnum)
+
 	case InterfaceLanplus:
 		c.v20 = true
 		return c.Connect20()
@@ -155,6 +168,9 @@ func (c *Client) Close() error {
 	case "", InterfaceOpen:
 		return c.closeOpen()
 
+	case InterfaceTool:
+		return c.closeTool()
+
 	case InterfaceLan, InterfaceLanplus:
 		return c.closeLAN()
 	}
@@ -166,6 +182,9 @@ func (c *Client) Exchange(request Request, response Response) error {
 	switch c.Interface {
 	case "", InterfaceOpen:
 		return c.exchangeOpen(request, response)
+
+	case InterfaceTool:
+		return c.exchangeTool(request, response)
 
 	case InterfaceLan, InterfaceLanplus:
 		return c.exchangeLAN(request, response)

--- a/interface_tool.go
+++ b/interface_tool.go
@@ -55,6 +55,7 @@ func (c *Client) exchangeTool(request Request, response Response) error {
 func rawDecode(data string) []byte {
 	var buf bytes.Buffer
 
+	data = strings.ReplaceAll(data, "\n", "")
 	for _, s := range strings.Split(data, " ") {
 		b, err := hex.DecodeString(s)
 		if err != nil {

--- a/interface_tool.go
+++ b/interface_tool.go
@@ -1,0 +1,83 @@
+package ipmi
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ConnectTool try to initialize the client.
+func (c *Client) ConnectTool(devnum int32) error {
+	return nil
+}
+
+// closeTool closes the ipmi dev file.
+func (c *Client) closeTool() error {
+	return nil
+}
+
+func (c *Client) exchangeTool(request Request, response Response) error {
+	data := request.Pack()
+	msg := make([]byte, 2+len(data))
+	msg[0] = uint8(request.Command().NetFn)
+	msg[1] = uint8(request.Command().ID)
+	copy(msg[2:], data)
+
+	args := append([]string{"raw"}, rawEncode(msg)...)
+
+	path := c.Host
+	if path == "" {
+		path = "ipmitool"
+	}
+
+	cmd := exec.Command(path, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("ipmitool run failed, err: %s", err)
+	}
+
+	output := stdout.String()
+	resp := rawDecode(strings.TrimSpace(output))
+	if err := response.Unpack(resp); err != nil {
+		return fmt.Errorf("unpack response failed, err: %s", err)
+	}
+
+	return nil
+}
+
+func rawDecode(data string) []byte {
+	var buf bytes.Buffer
+
+	for _, s := range strings.Split(data, " ") {
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = buf.Write(b)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return buf.Bytes()
+}
+
+func rawEncode(data []byte) []string {
+	n := len(data)
+	buf := make([]string, 0, n)
+
+	// ipmitool needs every byte to be a separate argument
+	for i := 0; i < n; i++ {
+		buf = append(buf, "0x"+hex.EncodeToString(data[i:i+1]))
+	}
+
+	return buf
+}

--- a/interface_tool.go
+++ b/interface_tool.go
@@ -44,7 +44,10 @@ func (c *Client) exchangeTool(request Request, response Response) error {
 	}
 
 	output := stdout.String()
-	resp := rawDecode(strings.TrimSpace(output))
+	resp, err := rawDecode(strings.TrimSpace(output))
+	if err != nil {
+		return fmt.Errorf("decode response failed, err: %s", err)
+	}
 	if err := response.Unpack(resp); err != nil {
 		return fmt.Errorf("unpack response failed, err: %s", err)
 	}
@@ -52,23 +55,23 @@ func (c *Client) exchangeTool(request Request, response Response) error {
 	return nil
 }
 
-func rawDecode(data string) []byte {
+func rawDecode(data string) ([]byte, error) {
 	var buf bytes.Buffer
 
 	data = strings.ReplaceAll(data, "\n", "")
 	for _, s := range strings.Split(data, " ") {
 		b, err := hex.DecodeString(s)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		_, err = buf.Write(b)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 func rawEncode(data []byte) []string {


### PR DESCRIPTION
Add a new interface type, which calls the ipmitool binary for ipmi functions.

The advantage of this: the go process is running with unprivileged user, but we can call ipmitool with a sudo wrapper script to allow access to ipmi.