### PR TITLE
Bug Fix: Use correct IntegrityAlg

### DIFF
--- a/client_auth_code.go
+++ b/client_auth_code.go
@@ -354,7 +354,7 @@ func (c *Client) generate_rakp4_authcode() ([]byte, error) {
 	hmacKey := c.session.v20.sik
 	c.DebugBytes("rakp4 auth code key", hmacKey, 16)
 
-	b, err := generate_auth_hmac(AuthAlg(c.session.v20.integrityAlg), input, hmacKey)
+	b, err := generate_auth_hmac(c.session.v20.integrityAlg, input, hmacKey)
 	if err != nil {
 		return nil, fmt.Errorf("generate hmac failed, err: %s", err)
 	}

--- a/helpers_hmac.go
+++ b/helpers_hmac.go
@@ -48,22 +48,37 @@ func generate_hmac(alg string, data []byte, key []byte) ([]byte, error) {
 	}
 }
 
-func generate_auth_hmac(authAlg AuthAlg, data []byte, key []byte) ([]byte, error) {
-	switch authAlg {
-	case AuthAlgRAKP_None:
+func generate_auth_hmac(authAlg interface{}, data []byte, key []byte) ([]byte, error) {
+	algorithm := ""
+	switch authAlg.(type) {
+	case AuthAlg:
+		switch authAlg {
+		case AuthAlgRAKP_HMAC_SHA1:
+			algorithm = "sha1"
+		case AuthAlgRAKP_HMAC_MD5:
+			algorithm = "md5"
+		case AuthAlgRAKP_HMAC_SHA256:
+			algorithm = "sha256"
+		default:
+			return nil, fmt.Errorf("not support for authentication algorithm %x", authAlg)
+		}
+	case IntegrityAlg:
+		switch authAlg {
+		case IntegrityAlg_HMAC_SHA1_96:
+			algorithm = "sha1"
+		case IntegrityAlg_HMAC_MD5_128:
+			algorithm = "md5"
+		case IntegrityAlg_HMAC_SHA256_128:
+			algorithm = "sha256"
+		default:
+			return nil, fmt.Errorf("not support for integrity algorithm %x", authAlg)
+		}
+	}
+
+	if len(algorithm) == 0 {
 		return []byte{}, nil
-
-	case AuthAlgRAKP_HMAC_MD5:
-		return generate_hmac("md5", data, key)
-
-	case AuthAlgRAKP_HMAC_SHA1:
-		return generate_hmac("sha1", data, key)
-
-	case AuthAlgRAKP_HMAC_SHA256:
-		return generate_hmac("sha256", data, key)
-
-	default:
-		return nil, fmt.Errorf("not support for authentication algorithm %x", authAlg)
+	} else {
+		return generate_hmac(algorithm, data, key)
 	}
 }
 


### PR DESCRIPTION
The code was assuming the mappings for IntegrityAlg and AuthAlg are the same. When HMAC_SHA256 was used, the alg was not known.