### PR TITLE
fix: ignore response error in fillSensorDiscrete

### DIFF
--- a/cmd_get_sensors.go
+++ b/cmd_get_sensors.go
@@ -173,6 +173,10 @@ func (c *Client) fillSensorReading(sensor *Sensor) error {
 func (c *Client) fillSensorDiscrete(sensor *Sensor) error {
 	statusRes, err := c.GetSensorEventStatus(sensor.Number)
 	if err != nil {
+		if _canSafelyIgnoredResponseError(err) {
+			c.Debug(fmt.Sprintf("GetSensorEventStatus for sensor %#02x failed but skipped", sensor.Number), err)
+			return nil
+		}
 		return fmt.Errorf("GetSensorEventStatus for sensor %#02x failed, err: %s", sensor.Number, err)
 	}
 	sensor.OccuredEvents = statusRes.SensorEventFlag.TrueEvents()


### PR DESCRIPTION
fillSensorDiscrete 遗漏了一处 _canSafelyIgnoredResponseError 的处理，会导致当获取不到 sensor 数据时，GetSensors 整个返回错误。

2024/06/24 16:11:06 [E] Failed to get sensors: sdrToSensor failed, err: fillSensorDiscrete failed, err: GetSensorEventStatus for sensor 0x72 failed, err: Raw command failed, err: Requested sensor, data, or record not found
