### PR TITLE
Add DCMI "Get Power Reading" and "Get Asset Tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,16 @@ The implementation logic of IPMI commands is almost same. See [Contributing](./C
 | ----------- | ------ | ---------------------------- |
 | ErrorReport |        |
 
+### DCMI Commands
+
+| Method              | Status             | corresponding ipmitool usage |
+| ------------------- | ------------------ | ---------------------------- |
+| GetDCMIPowerReading | :white_check_mark: | dcmi power reading           |
+| GetDCMIAssetTag     | :white_check_mark: | dcmi asset_tag               |
+
 ## Reference
 
 - [Intelligent Platform Management Interface Specification Second Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf)
 - [Platform Management FRU Information Storage Definition](https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-platform-mgt-fru-info-storage-def-v1-0-rev-1-3-spec-update.pdf)
 - [PC SDRAM Serial Presence Detect (SPD) Specification](https://cdn.hackaday.io/files/10119432931296/Spdsd12b.pdf)
+- [DCMI Group Extension Specification v1.5](https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf)

--- a/cmd/goipmi/commands/dcmi.go
+++ b/cmd/goipmi/commands/dcmi.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdDCMI() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dcmi",
+		Short: "dcmi",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return initClient()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			return closeClient()
+		},
+	}
+	cmd.AddCommand(NewCmdDCMIPower())
+	cmd.AddCommand(NewCmdDCMIAssetTag())
+
+	return cmd
+}
+
+func NewCmdDCMIPower() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "power",
+		Short: "power",
+		Run: func(cmd *cobra.Command, args []string) {
+		},
+	}
+	cmd.AddCommand(NewCmdDCMIRead())
+	return cmd
+}
+
+func NewCmdDCMIRead() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reading",
+		Short: "reading",
+		Run: func(cmd *cobra.Command, args []string) {
+			resp, err := client.GetDCMIPowerReading()
+			if err != nil {
+				CheckErr(fmt.Errorf("GetDCMIPowerReading failed, err: %s", err))
+			}
+			fmt.Println(resp.Format())
+		},
+	}
+	return cmd
+}
+
+func NewCmdDCMIAssetTag() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "asset_tag",
+		Short: "asset_tag",
+		Run: func(cmd *cobra.Command, args []string) {
+			var assetTag string
+			var offset uint8
+			for {
+				resp, err := client.GetDCMIAssetTag(offset)
+				if err != nil {
+					CheckErr(fmt.Errorf("GetDCMIAssetTag failed, err: %s", err))
+				}
+				assetTag += string(resp.AssetTag)
+				if resp.TotalLength <= offset+uint8(len(resp.AssetTag)) {
+					break
+				}
+				offset += uint8(len(resp.AssetTag))
+			}
+			fmt.Printf("Asset tag: %s\n", assetTag)
+		},
+	}
+	return cmd
+}

--- a/cmd/goipmi/commands/root.go
+++ b/cmd/goipmi/commands/root.go
@@ -107,6 +107,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(NewCmdFRU())
 	rootCmd.AddCommand(NewCmdSOL())
 	rootCmd.AddCommand(NewCmdPEF())
+	rootCmd.AddCommand(NewCmdDCMI())
 
 	rootCmd.AddCommand(NewCmdX())
 

--- a/cmd_get_dcmi_asset_tag.go
+++ b/cmd_get_dcmi_asset_tag.go
@@ -1,0 +1,65 @@
+package ipmi
+
+import "fmt"
+
+// GetDCMIAssetTagRequest represents a "Get Asset Tag" request according
+// to section 6.4.2 of the [DCMI specification v1.5].
+//
+// While the asset tag is allowed to be up to 64 bytes, each request will always
+// return at most 16 bytes. The response also indicates the total length of the
+// asset tag. If it is greater than 16 bytes, additional requests have to be
+// performed, setting the offset accordingly.
+//
+// [DCMI specification v1.5]: https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf
+type GetDCMIAssetTagRequest struct {
+	Offset uint8
+}
+
+type GetDCMIAssetTagResponse struct {
+	// At most 16 bytes of the asset tag, starting from the request's offset
+	AssetTag []byte
+	// The total length of the asset tag
+	TotalLength uint8
+}
+
+func (req *GetDCMIAssetTagRequest) Pack() []byte {
+	return []byte{GroupExtensionDCMI, req.Offset, 0x0F}
+}
+
+func (req *GetDCMIAssetTagRequest) Command() Command {
+	return CommandGetDCMIAssetTag
+}
+
+func (res *GetDCMIAssetTagResponse) CompletionCodes() map[uint8]string {
+	return map[uint8]string{}
+}
+
+func (res *GetDCMIAssetTagResponse) Unpack(msg []byte) error {
+	if len(msg) < 2 {
+		return ErrUnpackedDataTooShortWith(len(msg), 2)
+	}
+
+	if grpExt, _, _ := unpackUint8(msg, 0); grpExt != GroupExtensionDCMI {
+		return fmt.Errorf("unexpected group extension ID in response: expected %d, found %d", GroupExtensionDCMI, grpExt)
+	}
+
+	res.TotalLength, _, _ = unpackUint8(msg, 1)
+	if len(msg) > 2 {
+		res.AssetTag, _, _ = unpackBytesMost(msg, 2, 16)
+	}
+
+	return nil
+}
+
+func (res *GetDCMIAssetTagResponse) Format() string {
+	return fmt.Sprintf("%s (total length: %d)", string(res.AssetTag), res.TotalLength)
+}
+
+// GetDCMIAssetTag sends a DCMI "Get Asset Tag" command.
+// See [GetDCMIAssetTagRequest] for details.
+func (c *Client) GetDCMIAssetTag(offset uint8) (response *GetDCMIAssetTagResponse, err error) {
+	request := &GetDCMIAssetTagRequest{Offset: offset}
+	response = &GetDCMIAssetTagResponse{}
+	err = c.Exchange(request, response)
+	return
+}

--- a/cmd_get_dcmi_power_reading.go
+++ b/cmd_get_dcmi_power_reading.go
@@ -1,0 +1,99 @@
+package ipmi
+
+import (
+	"fmt"
+	"time"
+)
+
+// GetDCMIPowerReadingRequest represents a "Get Power Reading" request according
+// to section 6.6.1 of the [DCMI specification v1.5].
+//
+// Currently, only the basic "System Power Statistics" mode is supported, not
+// the extended mode.
+//
+// [DCMI specification v1.5]: https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf
+type GetDCMIPowerReadingRequest struct {
+	// TODO add support for extended mode...
+}
+
+// GetDCMIPowerReadingResponse represents a response to a [GetDCMIPowerReadingRequest].
+type GetDCMIPowerReadingResponse struct {
+	// Current Power in watts
+	CurrentPower uint16
+	// Minimum Power over sampling duration in watts
+	MinimumPower uint16
+	// Maximum Power over sampling duration in watts
+	MaximumPower uint16
+	// Average Power over sampling duration in watts
+	AveragePower uint16
+	// IPMI Specification based Time Stamp
+	//
+	// For Mode 02h (not yet supported), the time stamp specifies the end of the
+	// averaging window.
+	Timestamp uint32
+	// Statistics reporting time period
+	//
+	// For Mode 01h, timeframe in milliseconds, over which the controller
+	// collects statistics. For Mode 02h (not yet supported), timeframe reflects
+	// the Averaging Time period in units.
+	ReportingPeriod uint32
+	// True if power measurements are available, false otherwise.
+	PowerMeasurementActive bool
+}
+
+func (req *GetDCMIPowerReadingRequest) Pack() []byte {
+	// second byte 0x01 = "basic" System Power Statistics
+	return []byte{GroupExtensionDCMI, 0x01, 0x00, 0x00}
+}
+
+func (req *GetDCMIPowerReadingRequest) Command() Command {
+	return CommandGetDCMIPowerReading
+}
+
+func (res *GetDCMIPowerReadingResponse) CompletionCodes() map[uint8]string {
+	return map[uint8]string{}
+}
+
+func (res *GetDCMIPowerReadingResponse) Unpack(msg []byte) error {
+	if len(msg) < 18 {
+		return ErrUnpackedDataTooShortWith(len(msg), 19)
+	}
+
+	var off int
+
+	if grpExt, _, _ := unpackUint8(msg, 0); grpExt != GroupExtensionDCMI {
+		return fmt.Errorf("unexpected group extension ID in response: expected %d, found %d", GroupExtensionDCMI, grpExt)
+	}
+
+	res.CurrentPower, off, _ = unpackUint16L(msg, 1)
+	res.MinimumPower, off, _ = unpackUint16L(msg, off)
+	res.MaximumPower, off, _ = unpackUint16L(msg, off)
+	res.AveragePower, off, _ = unpackUint16L(msg, off)
+	res.Timestamp, off, _ = unpackUint32L(msg, off)
+	res.ReportingPeriod, off, _ = unpackUint32L(msg, off)
+
+	state, _, _ := unpackUint8(msg, off)
+	res.PowerMeasurementActive = isBit6Set(state)
+
+	return nil
+}
+
+func (res *GetDCMIPowerReadingResponse) Format() string {
+	ts := time.Unix(int64(res.Timestamp), 0)
+	return "Instantaneous power reading:                 " + fmt.Sprintf("%5d", res.CurrentPower) + " Watts\n" +
+		"Minimum during sampling period:              " + fmt.Sprintf("%5d", res.MinimumPower) + " Watts\n" +
+		"Maximum during sampling period:              " + fmt.Sprintf("%5d", res.MaximumPower) + " Watts\n" +
+		"Average power reading over sample period:    " + fmt.Sprintf("%5d", res.CurrentPower) + " Watts\n" +
+		"IPMI timestamp:                           " + ts.Format("01/02/06 15:04:05 UTC") + "\n" +
+		"Sampling period:                          " + fmt.Sprintf("%08d", res.ReportingPeriod/1000) + " Seconds\n" +
+		"Power reading state is:                   " + formatBool(res.PowerMeasurementActive, "activated", "deactivated")
+}
+
+// GetDCMIPowerReading sends a DCMI "Get Power Reading" command.
+// See [GetDCMIPowerReadingRequest] for details.
+func (c *Client) GetDCMIPowerReading() (response *GetDCMIPowerReadingResponse, err error) {
+	request := &GetDCMIPowerReadingRequest{}
+	response = &GetDCMIPowerReadingResponse{}
+	err = c.Exchange(request, response)
+	return
+}

--- a/types_command.go
+++ b/types_command.go
@@ -267,6 +267,10 @@ var (
 	// Other Bridge Commands
 	CommandErrorReport = Command{ID: 0xff, NetFn: NetFnBridgeRequest, Name: "Error Report (optional)"}
 
+	// Intel DCMI extensions (https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf)
+	CommandGetDCMIPowerReading = Command{ID: 0x02, NetFn: NetFnGroupExtensionRequest, Name: "GetDCMIPowerReading"}
+	CommandGetDCMIAssetTag     = Command{ID: 0x06, NetFn: NetFnGroupExtensionRequest, Name: "GetDCMIAssetTag"}
+
 	// Vendor Specific Commands
 	CommandGetSupermicroBiosVersion = Command{ID: 0xAC, NetFn: NetFnOEMSupermicroRequest, Name: "Get Supermicro BIOS Version"}
 )

--- a/types_netfn.go
+++ b/types_netfn.go
@@ -36,3 +36,9 @@ const (
 
 	NetFnOEMSupermicroRequest NetFn = 0x30
 )
+
+// Group Extensions
+const (
+	// Intel DCMI extensions (https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf)
+	GroupExtensionDCMI uint8 = 0xDC
+)


### PR DESCRIPTION
This commit adds support for two commands from the Intel DCMI [1] extenstions for IPMI. DCMI uses the Net Function "Group Extension", ID `0xDC`. Two commands implemented in the library, `GetDCMIPowerReading` and `GetDCMIAssetTag`. The corresponding commands are added to the CLI tool and the documentation in the README.

Tested against SuperMicro hardware.

[1] https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/dcmi-v1-5-rev-spec.pdf