### PR TITLE
make `Invalid Command` error can be safely ignored.

### DIFF
--- a/cmd_get_sensors.go
+++ b/cmd_get_sensors.go
@@ -312,7 +312,7 @@ func (c *Client) fillSensorThreshold(sensor *Sensor) error {
 func _canSafelyIgnoredResponseError(err error) bool {
 	if respErr, ok := err.(*ResponseError); ok {
 		cc := respErr.CompletionCode()
-		if cc == CompletionCodeRequestedDataNotPresent || cc == CompletionCodeIllegalCommand {
+		if cc == CompletionCodeRequestedDataNotPresent || cc == CompletionCodeIllegalCommand || cc == CompletionCodeInvalidCommand {
 			// above completion codes CAN be ignored
 			// it normally means the sensor device does not exist or the sensor device does not recognize the IPMI command
 			return true


### PR DESCRIPTION
We use `GetSensors()` to get sensor info, it will return error when ipmi returns `Invalid Command` error. I think this error should be ignored, because if we use `ipmitool sensor list`, there will be `Invalid Command` in the debug info and being ignored.

error logs are:
```
Get Sensor: 
Sensor Name: UID, Sensor Number: 0xae

>>> Run cmd: 
>>> /usr/bin/ipmitool raw 0x04 0x2d 0xae
>>> Run cmd: 
>>> /usr/bin/ipmitool raw 0x04 0x2b 0xae
2024/11/26 16:09:30 ERROR failed to get sensors from ipmi tool error="sdrToSensor failed, err: fillSensorDiscrete failed, err: GetSensorEventStatus for sensor 0xae failed, err: Raw command failed, err: Invalid command"
sdrToSensor failed, err: fillSensorDiscrete failed, err: GetSensorEventStatus for sensor 0xae failed, err: Raw command failed, err: Invalid command
```