### PR TITLE
fix: fix byte index of `MaxPrivLevel` in `SetUserAccessRequest`

### DIFF
--- a/cmd_set_user_access.go
+++ b/cmd_set_user_access.go
@@ -44,7 +44,7 @@ func (req *SetUserAccessRequest) Pack() []byte {
 	}
 	packUint8(b, out, 0)
 	packUint8(req.UserID&0x3f, out, 1)
-	packUint8(req.MaxPrivLevel&0x3f, out, 1)
+	packUint8(req.MaxPrivLevel&0x3f, out, 2)
 	packUint8(req.SessionLimit&0x0f, out, 3)
 
 	return out


### PR DESCRIPTION
I believe it was a mistake to overwrite the user ID byte with the `MaxPrivLevel`.