### PR TITLE
fix cipher suites param too short issue

### DIFF
--- a/cmd_get_lan_config_params.go
+++ b/cmd_get_lan_config_params.go
@@ -265,22 +265,20 @@ func FillLanConfig(lanConfig *LanConfig, paramSelector LanParamSelector, paramDa
 		lanConfig.RMCPCipherSuitesCount = paramData[0] & 0x1f
 
 	case LanParam_CipherSuiteEntries:
-		if len(paramData) <= 17 {
-			ids := []CipherSuiteID{}
-			var count uint8 = 0
-			for i, v := range paramData {
-				if i == 0 {
-					// first byte is Reserved
-					continue
-				}
-				if count+1 > lanConfig.RMCPCipherSuitesCount {
-					break
-				}
-				ids = append(ids, CipherSuiteID(v))
-				count += 1
+		ids := []CipherSuiteID{}
+		var count uint8 = 0
+		for i, v := range paramData {
+			if i == 0 {
+				// first byte is Reserved
+				continue
 			}
-			lanConfig.RMCPCipherSuiteEntries = ids
+			if count+1 > lanConfig.RMCPCipherSuitesCount {
+				break
+			}
+			ids = append(ids, CipherSuiteID(v))
+			count += 1
 		}
+		lanConfig.RMCPCipherSuiteEntries = ids
 
 	case LanParam_CipherSuitePrivilegeLevels:
 		levels := []PrivilegeLevel{}

--- a/cmd_get_lan_config_params.go
+++ b/cmd_get_lan_config_params.go
@@ -265,20 +265,22 @@ func FillLanConfig(lanConfig *LanConfig, paramSelector LanParamSelector, paramDa
 		lanConfig.RMCPCipherSuitesCount = paramData[0] & 0x1f
 
 	case LanParam_CipherSuiteEntries:
-		ids := []CipherSuiteID{}
-		var count uint8 = 0
-		for i, v := range paramData {
-			if i == 0 {
-				// first byte is Reserved
-				continue
+		if len(paramData) <= 17 {
+			ids := []CipherSuiteID{}
+			var count uint8 = 0
+			for i, v := range paramData {
+				if i == 0 {
+					// first byte is Reserved
+					continue
+				}
+				if count+1 > lanConfig.RMCPCipherSuitesCount {
+					break
+				}
+				ids = append(ids, CipherSuiteID(v))
+				count += 1
 			}
-			if count+1 > lanConfig.RMCPCipherSuitesCount {
-				break
-			}
-			ids = append(ids, CipherSuiteID(v))
-			count += 1
+			lanConfig.RMCPCipherSuiteEntries = ids
 		}
-		lanConfig.RMCPCipherSuiteEntries = ids
 
 	case LanParam_CipherSuitePrivilegeLevels:
 		levels := []PrivilegeLevel{}

--- a/types_lan_params.go
+++ b/types_lan_params.go
@@ -103,7 +103,7 @@ var LanParams = []LanParam{
 	{Selector: LanParam_VLANID, DataSize: 2, Name: "802.1q VLAN ID"},
 	{Selector: LanParam_VLANPriority, DataSize: 1, Name: "802.1q VLAN Priority"},
 	{Selector: LanParam_CipherSuiteEntrySupport, DataSize: 1, Name: "RMCP+ Cipher Suite Count"},
-	{Selector: LanParam_CipherSuiteEntries, DataSize: 17, Name: "RMCP+ Cipher Suites"},
+	{Selector: LanParam_CipherSuiteEntries, DataSize: 1, Name: "RMCP+ Cipher Suites"},
 	{Selector: LanParam_CipherSuitePrivilegeLevels, DataSize: 9, Name: "Cipher Suite Priv Max"},
 	{Selector: LanParam_BadPasswordThreshold, DataSize: 4, Name: "Bad Password Threshold"},
 }

--- a/types_lan_params.go
+++ b/types_lan_params.go
@@ -103,7 +103,7 @@ var LanParams = []LanParam{
 	{Selector: LanParam_VLANID, DataSize: 2, Name: "802.1q VLAN ID"},
 	{Selector: LanParam_VLANPriority, DataSize: 1, Name: "802.1q VLAN Priority"},
 	{Selector: LanParam_CipherSuiteEntrySupport, DataSize: 1, Name: "RMCP+ Cipher Suite Count"},
-	{Selector: LanParam_CipherSuiteEntries, DataSize: 1, Name: "RMCP+ Cipher Suites"},
+	{Selector: LanParam_CipherSuiteEntries, DataSize: 0, Name: "RMCP+ Cipher Suites"},
 	{Selector: LanParam_CipherSuitePrivilegeLevels, DataSize: 9, Name: "Cipher Suite Priv Max"},
 	{Selector: LanParam_BadPasswordThreshold, DataSize: 4, Name: "Bad Password Threshold"},
 }


### PR DESCRIPTION
meet below error if parameter length is less than 17

error: GetLanConfig failed, err: get lan config param (RMCP+ Cipher Suites) failed, err: the data for param (RMCP+ Cipher Suites) is too short, input (12), required (17)

according to lib/ipmi_lanp.c
```
        p = get_lan_param(intf, chan, IPMI_LANP_RMCP_CIPHERS);
        if (!p)
            return -1;

        printf("%-24s: ", p->desc);

        /* Now we're dangerous.  There are only 15 fixed cipher
           suite IDs, but the spec allows for 16 in the return data.*/
        if (p->data && p->data_len <= 17)
        {
            unsigned int i;
            for (i = 0; (i < 16) && (i < cipher_suite_count); ++i)
            {
                printf("%s%d",
                       (i > 0? ",": ""),
                       p->data[i + 1]);
            }
            printf("\n");
        }
        else
        {
            printf("None\n");
        }
```
parameter length must be less than 17