### PR TITLE
Use the correct form of `md5.Sum`.

### DIFF
--- a/types_session.go
+++ b/types_session.go
@@ -564,7 +564,7 @@ func (c *Client) encryptPayload(rawPayload []byte, iv []byte) ([]byte, error) {
 		out = append(out, confidentialityHeader...)
 
 		input := append(c.session.v20.k2, iv...)
-		keyRC := md5.New().Sum(input)
+		keyRC := md5.Sum(input)
 
 		var cipherKey []byte
 		switch c.session.v20.cryptAlg {
@@ -620,7 +620,7 @@ func (c *Client) decryptPayload(data []byte) ([]byte, error) {
 
 		iv := c.session.v20.rc4DecryptIV[:]
 		input := append(c.session.v20.k2, iv...)
-		keyRC := md5.New().Sum(input)
+		keyRC := md5.Sum(input)
 		var cipherKey []byte
 		switch c.session.v20.cryptAlg {
 		case CryptAlg_xRC4_40:


### PR DESCRIPTION
`md5.New().Sum(foo)` appends the MD5 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk (different algo but same issue).