### PR TITLE
Allow Multiple Cipher Suites Declaration and Use User-Declared Suites by Default

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,9 +182,13 @@ func (c *Client) WithRetry(retryCount int, retryInterval time.Duration) *Client 
 // WithCipherSuiteID sets a custom cipher suite which is used during OpenSession command.
 // It is only valid for client with IPMI lanplus interface.
 // For the custom cipherSuiteID to take effect, you must call WithCipherSuiteID before calling Connect method.
-func (c *Client) WithCipherSuiteID(cipherSuiteID CipherSuiteID) *Client {
+func (c *Client) WithCipherSuiteID(cipherSuiteID ...CipherSuiteID) *Client {
 	if c.session != nil {
-		c.session.v20.cipherSuiteID = cipherSuiteID
+		if len(cipherSuiteID) > 1 {
+			c.session.v20.customSuiteIDs = cipherSuiteID
+		} else {
+			c.session.v20.cipherSuiteID = cipherSuiteID[0]
+		}
 	}
 	return c
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bougou/go-ipmi
+module github.com/AndySpf/go-ipmi
 
 replace github.com/bougou/go-ipmi v0.0.0 => ./
 


### PR DESCRIPTION
## What does this PR do?

1. The `findBestCipherSuites()` function can cause timeouts on some legacy servers. Therefore, after explicitly specifying cipher suites, the system will now use the declared cipher suites by default, instead of always performing a query.
2. Multiple cipher suites can now be specified when declaring them. This enables automatic fallback handling when managing multiple servers.

## Motivation

- Improve reliability and compatibility with older servers by avoiding unnecessary timeouts caused by cipher suite probing.
- Enhance flexibility in configuration, allowing administrators to specify multiple cipher suites for automatic fallback, making management of large server clusters easier and more robust.

## Related Issues

N/A

## Checklist

- [x] Tests added or updated where appropriate
- [x] Documentation updated if needed
- [x] All existing and new tests pass

## Additional Context

If you have any feedback or suggestions, please leave a comment!