### PR TITLE
getSystemInfoStringMeta: clamp stringDataLength to avoid slice-bounds panic

### DIFF
--- a/cmd_get_system_info_params.go
+++ b/cmd_get_system_info_params.go
@@ -381,7 +381,20 @@ func getSystemInfoStringMeta(params []any) (s string, stringDataRaw []byte, stri
 		allBlockData = append(allBlockData, blockData[:]...)
 	}
 
-	stringDataRaw = allBlockData[2 : stringDataLength+2]
+	// Some BMCs (observed on HPE iLO5/iLO6) report a stringDataLength that
+	// exceeds what they actually deliver in the follow-up blocks, which
+	// would panic the slice on hosts with more than a handful of system
+	// info params. Cap the length to what we have so the caller gets a
+	// truncated string instead of a crash; the sensor collector can still
+	// surface a warning through its own error paths.
+	end := int(stringDataLength) + 2
+	if end > len(allBlockData) {
+		end = len(allBlockData)
+	}
+	if end < 2 {
+		return
+	}
+	stringDataRaw = allBlockData[2:end]
 
 	switch stringDataType {
 	// 0h = ASCII+Latin1


### PR DESCRIPTION
## Summary

The slice expression `allBlockData[2 : stringDataLength+2]` in `getSystemInfoStringMeta` panics when the BMC reports a `stringDataLength` larger than what it actually delivered across the follow-up parameter blocks. Observed downstream as:

```
panic: runtime error: slice bounds out of range [:17] with capacity 16

goroutine 30 [running]:
github.com/bougou/go-ipmi.getSystemInfoStringMeta(...)
    cmd_get_system_info_params.go:387
github.com/bougou/go-ipmi.(*SystemInfoParams).ToSystemInfo(...)
    types_system_info_params.go:104
```

Reported by Prometheus ipmi_exporter users against HPE iLO5 and iLO6 BMCs ([ipmi_exporter#328](https://github.com/prometheus-community/ipmi_exporter/issues/328)); `--native-ipmi` crashes the collector repeatedly, which takes the metrics down with it.

## Fix

Clamp the end index to `len(allBlockData)` so the caller gets a truncated string in the bad-BMC case instead of a crash, and short-circuit when we have fewer than the 2 header bytes at all. Well-behaved BMCs (where `stringDataLength+2 <= len(allBlockData)`) are untouched.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manually simulated a bad-length response (`stringDataLength=17`, `allBlockData` with capacity 16) and confirmed the function now returns a truncated string rather than panicking
