### PR TITLE
fix(system-info): clamp stringDataLength to allBlockData length

### DIFF
--- a/cmd_get_system_info_params.go
+++ b/cmd_get_system_info_params.go
@@ -381,7 +381,19 @@ func getSystemInfoStringMeta(params []any) (s string, stringDataRaw []byte, stri
 		allBlockData = append(allBlockData, blockData[:]...)
 	}
 
-	stringDataRaw = allBlockData[2 : stringDataLength+2]
+	// BMCs (notably HPE iLO6 on DL380a Gen12) have been observed to
+	// report a stringDataLength that exceeds the number of bytes the
+	// BMC actually returned across all blocks. Clamp the upper bound
+	// to len(allBlockData) instead of panicking with
+	// "slice bounds out of range [:N] with capacity M".
+	if len(allBlockData) < 2 {
+		return
+	}
+	end := int(stringDataLength) + 2
+	if end > len(allBlockData) {
+		end = len(allBlockData)
+	}
+	stringDataRaw = allBlockData[2:end]
 
 	switch stringDataType {
 	// 0h = ASCII+Latin1


### PR DESCRIPTION
Downstream bug report: prometheus-community/ipmi_exporter#328.

## Problem

`getSystemInfoStringMeta` trusts the `stringDataLength` reported in the first block and slices `allBlockData[2 : stringDataLength+2]`. Some BMCs — observed on HPE iLO6 on a DL380a Gen12 — report a length that exceeds what the BMC actually delivered across the blocks, so:

```
panic: runtime error: slice bounds out of range [:17] with capacity 16
go-ipmi.getSystemInfoStringMeta cmd_get_system_info_params.go:387
go-ipmi.(*SystemInfoParams).ToSystemInfo types_system_info_params.go:104
```

ipmi_exporter's scrape goroutine dies every time that sensor is polled, effectively forcing operators off `--native-ipmi`.

## Fix

Clamp the upper bound to `len(allBlockData)` and return early if fewer than 2 bytes of data arrived. The happy path (compliant BMCs) is unchanged.

## Test

`go test ./...` passes locally.