### PR TITLE
add e2e tests and fix IPMI 2.0 RMCP+ session handshake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,73 @@
+---
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    types:
+    - opened
+    - synchronize
+  workflow_dispatch:
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Client E2E: goipmi → ipmi-simulator
+  # ---------------------------------------------------------------------------
+  client-e2e:
+    name: Client E2E (go-ipmi → ipmi-simulator)
+    runs-on: ubuntu-latest
+
+    services:
+      ipmi-simulator:
+        image: vaporio/ipmi-simulator:master
+        ports:
+          - 9623:623/udp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run client E2E tests
+        run: make test-e2e-client
+
+  # ---------------------------------------------------------------------------
+  # Server E2E: ipmitool → goipmi-server
+  # ---------------------------------------------------------------------------
+  server-e2e:
+    name: Server E2E (ipmitool → go-ipmi server)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run server E2E tests
+        run: make test-e2e-server
+
+  # ---------------------------------------------------------------------------
+  # Self E2E: goipmi → goipmi-server (both from this repo)
+  # ---------------------------------------------------------------------------
+  self-e2e:
+    name: Self E2E (goipmi → goipmi-server)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run self E2E tests
+        run: make test-e2e-self

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ _output
 
 goipmitest
 cmd/goipmi/goipmi
+goipmi-server
 
 # asdf
 .tool-versions

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ test: fmt vet
 			--cover --coverprofile cover.out --trace --progress  $(TEST_ARGS)\
 			./pkg/... ./cmd/...
 
-# Build goipmi binary
+# Build goipmi and goipmi-server binaries
 build: fmt vet
 	go build -ldflags "$(LDFLAGS)" -o $(OUTPUT_DIR)/goipmi ./cmd/goipmi
+	go build -o $(OUTPUT_DIR)/goipmi-server ./cmd/goipmi-server
 
 # Cross compiler
 build-all: fmt vet
@@ -51,3 +52,22 @@ dependencies:
 	GOBIN=$(BINDIR) go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(BINDIR) latest
+
+# ---------------------------------------------------------------------------
+# E2E tests
+# ---------------------------------------------------------------------------
+#   make test-e2e-client  — goipmi → ipmi-simulator
+#   make test-e2e-server  — ipmitool → goipmi-server
+#   make test-e2e-self    — goipmi → goipmi-server
+#   make test-e2e         — run all three
+
+test-e2e-client: build
+	./test/e2e/client_test.sh
+
+test-e2e-server: build
+	./test/e2e/server_test.sh
+
+test-e2e-self: build
+	./test/e2e/self_test.sh
+
+test-e2e: test-e2e-client test-e2e-server test-e2e-self

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -1,0 +1,98 @@
+// goipmi-server is a minimal IPMI BMC server for e2e testing.
+//
+// It uses the in-memory mock HAL and serves on UDP port 623.  By default it
+// creates a single user "ADMIN" with password "ADMIN" so that external tools
+// such as ipmitool can connect via lanplus.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/server"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "goipmi-server: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// BMC identity (used in Get Device ID).
+	info := bmc.DeviceInfo{
+		DeviceID:                32,
+		DeviceRevision:          1,
+		FirmwareMajor:           1,
+		FirmwareMinor:           0,
+		IPMIVersion:             0x20, // IPMI 2.0
+		ManufacturerID:          0x000157,
+		ProductID:               0x0001,
+		AdditionalDeviceSupport: 0x3D,
+	}
+	var guid [16]byte
+	copy(guid[:], "go-ipmi-e2e\x00\x00\x00\x00")
+
+	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clock.Real))
+
+	// User credentials for IPMI session authentication.
+	userName := os.Getenv("GOIPMI_SERVER_USER")
+	if userName == "" {
+		userName = "ADMIN"
+	}
+	userPass := os.Getenv("GOIPMI_SERVER_PASS")
+	if userPass == "" {
+		userPass = "ADMIN"
+	}
+
+	// Add the user with Administrator privilege on LAN channel 1.
+	user, err := b.Users.Add(2, userName)
+	if err != nil {
+		return fmt.Errorf("add user: %w", err)
+	}
+	user.SetPassword([]byte(userPass))
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	// Bind UDP on the configured port.
+	port := os.Getenv("GOIPMI_SERVER_PORT")
+	if port == "" {
+		port = "623"
+	}
+	addr := ":" + port
+	conn, err := udp.Listen(addr)
+	if err != nil {
+		return fmt.Errorf("listen udp: %w", err)
+	}
+	defer conn.Close()
+
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Close the server when the process receives a signal to unblock Serve().
+	go func() {
+		<-ctx.Done()
+		srv.Close()
+	}()
+
+	fmt.Printf("goipmi-server: listening on %s (lanplus, user=%s, pass=%s)\n", addr, userName, userPass)
+	if err := srv.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("serve: %w", err)
+	}
+	fmt.Println("goipmi-server: stopped")
+	return nil
+}

--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -326,7 +326,14 @@ func (c *Client) Connect20(ctx context.Context) error {
 		c.maxPrivilegeLevel = ipmi.PrivilegeLevelAdministrator
 	}
 
+	// Per IPMI 2.0 spec §13.15, the initial Get Channel Authentication
+	// Capabilities command is sent in IPMI 1.5 packet format before the
+	// RMCP+ session is established.  Some BMC implementations (notably
+	// ipmi_sim) do not respond to this command when framed inside an
+	// RMCP+ session-zero (AuthType 0x06) header.
+	c.v20 = false
 	_, err = c.GetChannelAuthenticationCapabilities(ctx, channelNumber, c.maxPrivilegeLevel)
+	c.v20 = true
 	if err != nil {
 		return fmt.Errorf("cmd: Get Channel Authentication Capabilities failed, err: %w", err)
 	}

--- a/pkg/cmd/app/cmd_get_channel_authentication_capabilities.go
+++ b/pkg/cmd/app/cmd_get_channel_authentication_capabilities.go
@@ -146,11 +146,13 @@ func (*GetChannelAuthenticationCapabilitiesResponse) CompletionCodes() map[uint8
 }
 
 func (res *GetChannelAuthenticationCapabilitiesResponse) ChooseAuthType() ipmi.AuthType {
-	if res.AuthTypeMD2Supported {
-		return ipmi.AuthTypeMD2
-	}
+	// Prefer MD5 over MD2 when both are available, matching ipmitool behaviour
+	// (password supplied → use MD5 if supported).
 	if res.AuthTypeMD5Supported {
 		return ipmi.AuthTypeMD5
+	}
+	if res.AuthTypeMD2Supported {
+		return ipmi.AuthTypeMD2
 	}
 	if res.AuthTypePasswordSupported {
 		return ipmi.AuthTypePassword

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -15,6 +15,8 @@ const (
 	CmdActivateSession            uint8 = 0x3A
 	CmdSetSessionPrivilegeLevel   uint8 = 0x3B
 	CmdCloseSession               uint8 = 0x3C
+
+	lanChannelNumber uint8 = 1
 )
 
 // RegisterSessionHandlers adds IPMI 1.5 session and v2.0 RAKP handlers to r.
@@ -22,6 +24,7 @@ const (
 // a session exists); see [HandleOpenSession], [HandleRAKP1], [HandleRAKP3].
 func RegisterSessionHandlers(r *Registry) {
 	r.Register(NetFnAppRequest, CmdGetChannelAuthCapabilities, HandlerFunc(handleGetChannelAuthCaps))
+	r.Register(NetFnAppRequest, CmdGetChannelCipherSuites, HandlerFunc(handleGetChannelCipherSuites))
 	r.Register(NetFnAppRequest, CmdSetSessionPrivilegeLevel, HandlerFunc(handleSetSessionPrivilegeLevel))
 	r.Register(NetFnAppRequest, CmdCloseSession, HandlerFunc(handleCloseSession))
 }
@@ -31,26 +34,90 @@ func RegisterSessionHandlers(r *Registry) {
 // ---------------------------------------------------------------------------
 
 // handleGetChannelAuthCaps implements Get Channel Authentication Capabilities (App 0x38).
-// The server currently advertises IPMI 2.0 only (RAKP-HMAC-SHA1 + AES-CBC-128).
+// Handles the pre-session probe that lanplus clients send in IPMI 1.5 framing,
+// while advertising only IPMI 2.0/RMCP+ session support.
 func handleGetChannelAuthCaps(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
 	if len(req) < 2 {
 		return nil, CodeRequestDataTruncated, nil
 	}
-	// req[0] bits 5:0 = channel number (0x0E = current)
+	// req[0] bits 3:0 = channel number (0x0E = current)
 	// req[1] bits 3:0 = requested privilege level
 
 	resp := make([]byte, 8)
-	resp[0] = 0x01 // channel number (1 = LAN)
-	resp[1] = 0x00 // auth types supported (none for v2.0-only)
-	resp[2] = 0x22 // bit 5: IPMI 2.0 supported; bit 1: user-level auth disabled allowed
-	resp[3] = 0x00 // per-message auth support flags
+	// resp[0] — channel number the capabilities are returned for.  The request
+	// may use 0x0E to mean "the channel this request was received on".
+	resp[0] = resolveChannelNumber(req[0])
+	// resp[1] — auth type support (IPMI spec Table 22-15, byte 3):
+	//   bit 7 = IPMI v2.0 extended capabilities available
+	//   bits 5:0 = enabled IPMI v1.5 auth types
+	// We support only IPMI v2.0/RMCP+ sessions, so no v1.5 auth type is
+	// advertised; only the extended-capabilities bit is set.
+	resp[1] = 0x80 // 0b1000_0000: IPMI v2.0 ext only, no v1.5 auth types
+	// resp[2] — byte 4 of Table 22-15:
+	//   bit 5 = KgStatus (1b = Kg set to non-zero value)
+	//   bit 2 = Non-Null usernames enabled
+	resp[2] = 0x04 // 0b0000_0100: Non-Null usernames enabled
+	if hctx.BMC != nil && len(hctx.BMC.KG) > 0 {
+		resp[2] |= 0x20 // Kg is set to a non-zero value
+	}
+	// resp[3] — extended capabilities (byte 5):
+	//   bit 1 = IPMI v2.0 connections supported; bit 0 = IPMI v1.5 supported
+	resp[3] = 0x02 // IPMI v2.0 connections only
 	resp[4] = 0x00 // OEM ID byte 1
 	resp[5] = 0x00 // OEM ID byte 2
 	resp[6] = 0x00 // OEM ID byte 3
 	resp[7] = 0x00 // OEM auxiliary data
+	return resp, CodeOK, nil
+}
 
-	// Bit 5 of byte 2 = IPMI v2.0/RMCP+ support
-	resp[2] = resp[2] | 0x20
+// resolveChannelNumber maps the channel number field of a channel-scoped
+// request to the concrete channel number.  Per IPMI spec, 0x0E means "the
+// channel this request was received on"; the reference server only serves the
+// LAN channel, so it resolves to lanChannelNumber.
+func resolveChannelNumber(reqByte uint8) uint8 {
+	ch := reqByte & 0x0F
+	if ch == 0x0E {
+		return lanChannelNumber
+	}
+	return ch
+}
+
+// handleGetChannelCipherSuites implements Get Channel Cipher Suites (App 0x54).
+// Returns a single record for cipher suite 3 (RAKP-HMAC-SHA1 + HMAC-SHA1-96 +
+// AES-CBC-128) — the suite the server actually supports in its RMCP+ handshake.
+func handleGetChannelCipherSuites(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if len(req) < 2 {
+		return nil, CodeRequestDataTruncated, nil
+	}
+	// Byte 0: channel number (bits 3:0; 0x0E = current channel)
+	// Byte 1: payload type (0x00 = IPMI)
+	// Byte 2: bits 5:0 = list index; bit 6 = list mode flag (echoed unused here)
+	//
+	// The cipher suite records are returned in chunks of at most 16 bytes per
+	// request.  The list index addresses the next 16-byte window; the remote
+	// console keeps incrementing it until fewer than 16 record bytes are
+	// returned.  We expose a single standard record for cipher suite 3:
+	//   0xC0           start-of-record (standard)
+	//   0x03           cipher suite ID 3
+	//   0x01           auth alg  RAKP-HMAC-SHA1   (tag 00b)
+	//   0x41           integ alg HMAC-SHA1-96     (tag 01b)
+	//   0x81           crypt alg AES-CBC-128      (tag 10b)
+	record := []byte{0xC0, 0x03, 0x01, 0x41, 0x81}
+
+	var listIndex int
+	if len(req) >= 3 {
+		listIndex = int(req[2] & 0x3F)
+	}
+
+	resp := []byte{resolveChannelNumber(req[0])}
+	start := listIndex * 16
+	if start < len(record) {
+		end := start + 16
+		if end > len(record) {
+			end = len(record)
+		}
+		resp = append(resp, record[start:end]...)
+	}
 	return resp, CodeOK, nil
 }
 
@@ -132,9 +199,9 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	consoleID := binary.LittleEndian.Uint32(data[4:8])
 
 	// Parse algorithm payloads (3 x 8-byte records at offsets 8, 16, 24).
-	authAlg := bmc.AuthAlg(data[11])     // byte 3 of auth payload
-	intAlg := bmc.IntegrityAlg(data[19]) // byte 3 of integrity payload
-	cryptAlg := bmc.CryptAlg(data[27])   // byte 3 of crypt payload
+	authAlg := bmc.AuthAlg(data[12])     // byte 4 of auth payload
+	intAlg := bmc.IntegrityAlg(data[20]) // byte 4 of integrity payload
+	cryptAlg := bmc.CryptAlg(data[28])   // byte 4 of crypt payload
 
 	// Validate algorithm support.  We support RAKP-HMAC-SHA1 (0x01),
 	// HMAC-SHA1-96 (0x01), AES-CBC-128 (0x01) as the reference cipher suite.
@@ -156,6 +223,7 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	if sess.MaxPrivilege == 0 {
 		sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
 	}
+	sess.Channel = lanChannelNumber
 
 	resp := make([]byte, 36)
 	resp[0] = tag
@@ -164,33 +232,18 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	resp[3] = 0x00 // reserved
 	binary.LittleEndian.PutUint32(resp[4:8], consoleID)
 	binary.LittleEndian.PutUint32(resp[8:12], sess.BMCID)
-	// Auth algorithm payload (8 bytes at offset 12)
-	resp[12] = 0x00 // payload type = auth
-	resp[13] = 0x00
-	resp[14] = 0x00
-	resp[15] = uint8(authAlg)
-	resp[16] = 0x00
-	resp[17] = 0x00
-	resp[18] = 0x00
-	resp[19] = 0x00
-	// Integrity algorithm payload (8 bytes at offset 20)
-	resp[20] = 0x01 // payload type = integrity
-	resp[21] = 0x00
-	resp[22] = 0x00
-	resp[23] = uint8(intAlg)
-	resp[24] = 0x00
-	resp[25] = 0x00
-	resp[26] = 0x00
-	resp[27] = 0x00
-	// Confidentiality algorithm payload (8 bytes at offset 28)
-	resp[28] = 0x02 // payload type = confidentiality
-	resp[29] = 0x00
-	resp[30] = 0x00
-	resp[31] = uint8(cryptAlg)
-	resp[32] = 0x00
-	resp[33] = 0x00
-	resp[34] = 0x00
-	resp[35] = 0x00
+	// Algorithm payloads (3 × 8 bytes).  resp is zero-initialised, so only
+	// the non-zero fields need to be set.
+	//   [PayloadType][reserved×2][0x08][Algorithm][reserved×3]
+	resp[12] = 0x00 // auth
+	resp[15] = 0x08 // payload length
+	resp[16] = uint8(authAlg)
+	resp[20] = 0x01 // integrity
+	resp[23] = 0x08
+	resp[24] = uint8(intAlg)
+	resp[28] = 0x02 // confidentiality
+	resp[31] = 0x08
+	resp[32] = uint8(cryptAlg)
 
 	return resp, nil
 }
@@ -246,6 +299,12 @@ func HandleRAKP1(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, error) {
 		user = nil
 	}
 	sess.User = user
+	if user != nil {
+		if status, ok := authorizeSessionPrivilege(b, sess); !ok {
+			_ = b.Sessions.Close(bmcSessionID)
+			return rakp2Error(tag, sess.ConsoleID, status), nil
+		}
+	}
 
 	// Generate BMC random number.
 	if _, err := rand.Read(sess.BMCRand[:]); err != nil {
@@ -321,6 +380,10 @@ func HandleRAKP3(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, error) {
 		_ = b.Sessions.Close(bmcSessionID)
 		return rakp4Error(tag, sess.ConsoleID, 0x0D), nil // Unauthorized name
 	}
+	if status, ok := authorizeSessionPrivilege(b, sess); !ok {
+		_ = b.Sessions.Close(bmcSessionID)
+		return rakp4Error(tag, sess.ConsoleID, status), nil
+	}
 
 	// Derive SIK, K1, K2.
 	if err := deriveSessKeys(sess, b); err != nil {
@@ -351,4 +414,55 @@ func rakp4Error(tag uint8, consoleID uint32, status uint8) []byte {
 	resp[1] = status
 	binary.LittleEndian.PutUint32(resp[4:8], consoleID)
 	return resp
+}
+
+func authorizeSessionPrivilege(b *bmc.BMC, sess *bmc.Session) (uint8, bool) {
+	if sess.User == nil || !sess.User.Enabled {
+		return 0x0D, false // Unauthorized name
+	}
+
+	requested, ok := requestedSessionPrivilege(sess)
+	if !ok {
+		return 0x09, false // Invalid role
+	}
+	if requested > sess.MaxPrivilege {
+		return 0x0A, false // Unauthorized role or privilege level
+	}
+
+	ch, err := b.Channels.Get(sess.Channel)
+	if err != nil || ch.AccessMode == bmc.ChannelAccessDisabled {
+		return 0x0A, false
+	}
+	if requested > ch.MaxPrivilege {
+		return 0x0A, false
+	}
+
+	access, ok := sess.User.ChannelAccess[sess.Channel]
+	if !ok || !access.Enabled {
+		return 0x0D, false // User is not enabled for this channel.
+	}
+	if access.CallbackOnly && requested != bmc.PrivilegeLevelCallback {
+		return 0x0A, false
+	}
+	if access.MaxPrivilege == bmc.PrivilegeLevelNoAccess || requested > access.MaxPrivilege {
+		return 0x0A, false
+	}
+	return 0x00, true
+}
+
+func requestedSessionPrivilege(sess *bmc.Session) (bmc.PrivilegeLevel, bool) {
+	requested := bmc.PrivilegeLevel(sess.Role & 0x0F)
+	if requested == 0 {
+		requested = sess.MaxPrivilege
+	}
+	switch requested {
+	case bmc.PrivilegeLevelCallback,
+		bmc.PrivilegeLevelUser,
+		bmc.PrivilegeLevelOperator,
+		bmc.PrivilegeLevelAdministrator,
+		bmc.PrivilegeLevelOEM:
+		return requested, true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/server/integrity.go
+++ b/pkg/server/integrity.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/binary"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+const (
+	rmcpHeaderSize        = 4
+	rmcpPlusHeaderSize    = 12
+	rmcpPlusPayloadOffset = rmcpHeaderSize + rmcpPlusHeaderSize
+	rmcpPlusNextHeader    = 0x07
+)
+
+func appendRMCPPlusIntegrity(pkt []byte, sess *bmc.Session) ([]byte, bool) {
+	authCodeLen, ok := rmcpPlusIntegrityAuthCodeLen(sess.IntegrityAlg)
+	if !ok {
+		return nil, false
+	}
+	if authCodeLen == 0 {
+		return pkt, true
+	}
+	if len(sess.K1) == 0 || len(pkt) < rmcpPlusPayloadOffset {
+		return nil, false
+	}
+
+	padLen := rmcpPlusIntegrityPadLen(len(pkt[rmcpHeaderSize:rmcpPlusPayloadOffset]), len(pkt[rmcpPlusPayloadOffset:]))
+	out := make([]byte, 0, len(pkt)+padLen+2+authCodeLen)
+	out = append(out, pkt...)
+	for i := 0; i < padLen; i++ {
+		out = append(out, 0xff)
+	}
+	out = append(out, byte(padLen), rmcpPlusNextHeader)
+
+	authCode := rmcpPlusIntegrityAuthCode(sess.IntegrityAlg, out[rmcpHeaderSize:], sess.K1)
+	out = append(out, authCode...)
+	return out, true
+}
+
+func verifyRMCPPlusIntegrity(pkt []byte, sess *bmc.Session, authenticated bool) bool {
+	authCodeLen, ok := rmcpPlusIntegrityAuthCodeLen(sess.IntegrityAlg)
+	if !ok {
+		return false
+	}
+	if authCodeLen == 0 {
+		return true
+	}
+	if !authenticated || len(sess.K1) == 0 || len(pkt) < rmcpPlusPayloadOffset {
+		return false
+	}
+
+	payloadLen := int(binary.LittleEndian.Uint16(pkt[14:16]))
+	payloadEnd := rmcpPlusPayloadOffset + payloadLen
+	if len(pkt) < payloadEnd {
+		return false
+	}
+
+	padLen := rmcpPlusIntegrityPadLen(rmcpPlusHeaderSize, payloadLen)
+	authCodeStart := payloadEnd + padLen + 2
+	if len(pkt) != authCodeStart+authCodeLen {
+		return false
+	}
+
+	for _, b := range pkt[payloadEnd : payloadEnd+padLen] {
+		if b != 0xff {
+			return false
+		}
+	}
+	if pkt[payloadEnd+padLen] != byte(padLen) || pkt[payloadEnd+padLen+1] != rmcpPlusNextHeader {
+		return false
+	}
+
+	expected := rmcpPlusIntegrityAuthCode(sess.IntegrityAlg, pkt[rmcpHeaderSize:authCodeStart], sess.K1)
+	return hmac.Equal(expected, pkt[authCodeStart:])
+}
+
+func rmcpPlusIntegrityPadLen(sessionHeaderLen, payloadLen int) int {
+	n := sessionHeaderLen + payloadLen + 1 + 1
+	if n%4 == 0 {
+		return 0
+	}
+	return 4 - n%4
+}
+
+func rmcpPlusIntegrityAuthCodeLen(alg bmc.IntegrityAlg) (int, bool) {
+	switch alg {
+	case bmc.IntegrityAlgNone:
+		return 0, true
+	case bmc.IntegrityAlgHMACSHA1_96:
+		return 12, true
+	default:
+		return 0, false
+	}
+}
+
+func rmcpPlusIntegrityAuthCode(alg bmc.IntegrityAlg, data, key []byte) []byte {
+	switch alg {
+	case bmc.IntegrityAlgHMACSHA1_96:
+		h := hmac.New(sha1.New, key)
+		h.Write(data)
+		return h.Sum(nil)[:12]
+	default:
+		return nil
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bougou/go-ipmi/pkg/handlers"
 	"github.com/bougou/go-ipmi/pkg/protocol"
 	"github.com/bougou/go-ipmi/pkg/transport"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 // Payload type aliases from pkg/protocol for readability within this file.
@@ -182,9 +183,55 @@ func (s *Server) handleIPMI(_ context.Context, addr net.Addr, pkt []byte) {
 	if authTypeByte == 0x06 {
 		s.handleRMCPPlus(addr, pkt)
 	} else {
-		// IPMI 1.5 is not yet implemented in the reference server.
-		// Silently drop to avoid confusing the client.
+		s.handleIPMIv15(addr, pkt)
 	}
+}
+
+// handleIPMIv15 provides minimal IPMI 1.5 support for the pre-session phase.
+//
+// Only unauthenticated (AuthType NONE) packets with session ID zero are
+// dispatched — this covers the Get Channel Authentication Capabilities
+// command that clients send before deciding whether to proceed with IPMI
+// 1.5 or upgrade to RMCP+ (IPMI 2.0).
+//
+// Authenticated IPMI 1.5 sessions, Activate Session, Get Session Challenge,
+// and all other IPMI 1.5 stateful operations remain unimplemented.  Packets
+// that do not match the narrow pre-session criteria are silently dropped.
+func (s *Server) handleIPMIv15(addr net.Addr, pkt []byte) {
+	if len(pkt) < 14 {
+		return
+	}
+
+	// Reuse Session15.Unpack to parse the IPMI 1.5 session wrapper.
+	var sess ipmi.Session15
+	if err := sess.Unpack(pkt[4:]); err != nil {
+		return
+	}
+	if sess.SessionHeader15.AuthType != ipmi.AuthTypeNone {
+		return
+	}
+
+	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(sess.Payload)
+	if !ok {
+		return
+	}
+
+	ctx := context.Background()
+	hctx := &handlers.HandlerContext{BMC: s.bmc}
+	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
+
+	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
+
+	// Build IPMI 1.5 response header (AuthType NONE).
+	respHdr := ipmi.SessionHeader15{
+		AuthType:      ipmi.AuthTypeNone,
+		PayloadLength: uint8(len(ipmiResp)),
+	}
+
+	rmcp := []byte{pkt[0], pkt[1], 0xFF, pkt[3]}
+	out := append(rmcp, respHdr.Pack()...)
+	out = append(out, ipmiResp...)
+	_, _ = s.conn.WriteTo(out, addr)
 }
 
 // handleRMCPPlus routes RMCP+ (IPMI 2.0) packets.
@@ -194,6 +241,7 @@ func (s *Server) handleRMCPPlus(addr net.Addr, pkt []byte) {
 		return
 	}
 	encrypted := flags&protocol.PayloadEncryptedFlag != 0
+	authenticated := flags&protocol.PayloadAuthenticatedFlag != 0
 
 	ctx := context.Background()
 
@@ -227,6 +275,9 @@ func (s *Server) handleRMCPPlus(addr net.Addr, pkt []byte) {
 		}
 		sess, err := s.bmc.Sessions.Get(sessionID)
 		if err != nil {
+			return
+		}
+		if !verifyRMCPPlusIntegrity(pkt, sess, authenticated) {
 			return
 		}
 		if !bmc.InboundSeqValid(sess.InboundSeq, inboundSeq) {
@@ -283,7 +334,7 @@ func (s *Server) dispatchIPMISession(ctx context.Context, addr net.Addr, sess *b
 			return
 		}
 		finalPayload = enc
-		flags |= 0x80 // encrypted bit
+		flags |= protocol.PayloadEncryptedFlag
 	} else {
 		finalPayload = rawResp
 	}
@@ -300,7 +351,15 @@ func (s *Server) sendRMCPPlus(addr net.Addr, payloadType, flags uint8, payload [
 
 // sendRMCPPlusSession sends an authenticated / optionally encrypted RMCP+ packet.
 func (s *Server) sendRMCPPlusSession(addr net.Addr, payloadType, flags uint8, sess *bmc.Session, payload []byte) {
+	if sess.IntegrityAlg != bmc.IntegrityAlgNone {
+		flags |= protocol.PayloadAuthenticatedFlag
+	}
 	pkt := protocol.BuildRMCPPlusPacket(payloadType, flags, sess.ConsoleID, sess.OutboundSeq, payload)
+	var ok bool
+	pkt, ok = appendRMCPPlusIntegrity(pkt, sess)
+	if !ok {
+		return
+	}
 	_, _ = s.conn.WriteTo(pkt, addr)
 }
 

--- a/test/e2e/client_test.sh
+++ b/test/e2e/client_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# client_test.sh — E2E test for go-ipmi as an IPMI client.
+#
+# Connects to an IPMI peer (default 127.0.0.1:623).  If no peer is reachable
+# and Docker is available, the script automatically starts an ipmi-simulator
+# container and removes it on exit.
+#
+# Exercises both IPMI v2.0 (-I lanplus) and IPMI v1.5 (-I lan) against the
+# peer.
+#
+# Environment variables:
+#   GOIPMI_HOST       – IPMI peer hostname      (default: 127.0.0.1)
+#   GOIPMI_PORT       – IPMI peer port          (default: 623)
+#   GOIPMI_USER       – IPMI username           (default: ADMIN)
+#   GOIPMI_PASS       – IPMI password           (default: ADMIN)
+#   IPMI_SIM_IMAGE    – simulator Docker image  (default: vaporio/ipmi-simulator:master)
+#   GOIPMI_NO_DOCKER  – if set to 1, never auto-start Docker
+#
+# Requires: make build  (or: make test-e2e-client)
+#
+# Usage:
+#   ./test/e2e/client_test.sh
+#   GOIPMI_HOST=10.0.0.1 ./test/e2e/client_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+GOIPMI_HOST="${GOIPMI_HOST:-127.0.0.1}"
+GOIPMI_PORT="${GOIPMI_PORT:-9623}"
+GOIPMI_USER="${GOIPMI_USER:-ADMIN}"
+GOIPMI_PASS="${GOIPMI_PASS:-ADMIN}"
+IPMI_SIM_IMAGE="${IPMI_SIM_IMAGE:-vaporio/ipmi-simulator:master}"
+SIM_CONTAINER="goipmi-e2e-sim"
+
+DOCKER_STARTED=false
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+cleanup() {
+	if [ "${DOCKER_STARTED}" = true ]; then
+		echo "==> Stopping ipmi-simulator container ..."
+		docker rm -f "${SIM_CONTAINER}" >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+peer_reachable() {
+	# Try a quick UDP probe to see if something is listening.
+	if command -v ss &>/dev/null && [ "${GOIPMI_HOST}" = "127.0.0.1" -o "${GOIPMI_HOST}" = "localhost" ]; then
+		ss -uln | grep -q ":${GOIPMI_PORT} " && return 0
+	fi
+	# Fallback: assume reachable for remote hosts (test will fail with a clear error).
+	return 1
+}
+
+ensure_peer() {
+	if peer_reachable; then
+		return 0
+	fi
+
+	if [ "${GOIPMI_NO_DOCKER:-0}" = "1" ] || ! command -v docker &>/dev/null; then
+		echo -e "${RED}ERROR: No IPMI peer on ${GOIPMI_HOST}:${GOIPMI_PORT} and Docker unavailable.${NC}" >&2
+		echo "  Start an IPMI simulator manually or install Docker." >&2
+		exit 1
+	fi
+
+	echo "==> Starting ipmi-simulator (${IPMI_SIM_IMAGE}) ..."
+	docker run -d --name "${SIM_CONTAINER}" -p "${GOIPMI_PORT}:623/udp" "${IPMI_SIM_IMAGE}" >/dev/null
+	DOCKER_STARTED=true
+
+	# Wait for the simulator to be ready (up to 10 s).
+	local i=0
+	while [ $i -lt 20 ]; do
+		if peer_reachable; then
+			echo "==> Simulator is ready."
+			return 0
+		fi
+		sleep 0.5
+		i=$((i + 1))
+	done
+	echo -e "${RED}ERROR: Simulator did not become ready in time.${NC}" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+GOIPMI_BASE=(
+	"${GOIPMI}"
+	-H "${GOIPMI_HOST}" -p "${GOIPMI_PORT}"
+	-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}"
+)
+
+echo "========================================"
+echo " Client E2E: go-ipmi → ${GOIPMI_HOST}:${GOIPMI_PORT}"
+echo "========================================"
+
+ensure_peer
+
+failures=0
+
+echo ""
+echo "========================================"
+echo " IPMI v2.0 / RMCP+ (-I lanplus)"
+echo "========================================"
+e2e_run_chassis_cases failures "${GOIPMI_BASE[@]}" -I lanplus
+
+echo ""
+echo "========================================"
+echo " IPMI v1.5 / RMCP (-I lan)"
+echo "========================================"
+e2e_run_chassis_cases failures "${GOIPMI_BASE[@]}" -I lan
+
+e2e_report "Client E2E" "${failures}"

--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -1,0 +1,51 @@
+# common.sh — shared helpers for go-ipmi E2E test scripts.
+# Source from test/e2e/*.sh; do not execute directly.
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOIPMI="${E2E_DIR}/../../_output/goipmi"
+SERVER_BIN="${E2E_DIR}/../../_output/goipmi-server"
+
+e2e_init() {
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	NC='\033[0m'
+}
+
+e2e_run_test() {
+	local name="$1"
+	shift
+	echo ""
+	echo "--- ${name} ---"
+	if "$@"; then
+		echo -e "${GREEN}✓ ${name}${NC}"
+	else
+		echo -e "${RED}✗ ${name}${NC}" >&2
+		return 1
+	fi
+}
+
+# Run the three standard chassis cases.  Increments the caller's failures counter
+# (pass the variable name as the first argument).
+e2e_run_chassis_cases() {
+	local -n _fail="${1:?failures counter variable name required}"
+	shift
+	e2e_run_test "chassis status" "$@" chassis status || ((_fail++)) || true
+	e2e_run_test "chassis power on" "$@" chassis power on || ((_fail++)) || true
+	e2e_run_test "chassis power off" "$@" chassis power off || ((_fail++)) || true
+}
+
+e2e_report() {
+	local suite="$1"
+	local failures="$2"
+	echo ""
+	if [ "${failures}" -eq 0 ]; then
+		echo -e "${GREEN}========================================"
+		echo " ${suite}: PASSED"
+		echo -e "========================================${NC}"
+	else
+		echo -e "${RED}========================================"
+		echo " ${suite}: ${failures} test(s) FAILED"
+		echo -e "========================================${NC}"
+		exit 1
+	fi
+}

--- a/test/e2e/self_test.sh
+++ b/test/e2e/self_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# self_test.sh — go-ipmi self-test: use goipmi (client) to talk to
+# goipmi-server (server), validating both ends in a single test.
+#
+# Environment variables:
+#   GOIPMI_SERVER_PORT – server listen port (default: random high port)
+#
+# Requires: make build  (or: make test-e2e-self)
+#
+# Usage:
+#   ./test/e2e/self_test.sh
+#   GOIPMI_SERVER_PORT=9623 ./test/e2e/self_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+# Pick a random high port to avoid conflicts.
+PORT="${GOIPMI_SERVER_PORT:-$((9623 + RANDOM % 1000))}"
+USER="${GOIPMI_USER:-ADMIN}"
+PASS="${GOIPMI_PASS:-ADMIN}"
+
+# ---------------------------------------------------------------------------
+# Start server
+# ---------------------------------------------------------------------------
+cleanup() {
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo "==> Stopping goipmi-server (pid ${SERVER_PID}) ..."
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+echo "==> Starting goipmi-server on :${PORT} ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	"${SERVER_BIN}" &
+SERVER_PID=$!
+sleep 1
+
+if ! ss -uln | grep -q ":${PORT} "; then
+	echo -e "${RED}ERROR: server failed to start${NC}" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Self E2E: goipmi → goipmi-server (:${PORT})"
+echo "========================================"
+
+failures=0
+e2e_run_chassis_cases failures \
+	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus
+
+e2e_report "Self E2E" "${failures}"

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# server_test.sh — E2E test for go-ipmi as an IPMI BMC server.
+#
+# Starts goipmi-server, then connects with ipmitool (local or Docker) to
+# verify basic chassis commands.
+#
+# Environment variables:
+#   GOIPMI_SERVER_PORT – port for the server to listen on (default: 623)
+#                         Use a port >1024 to avoid sudo when testing locally.
+#   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
+#   IPMITOOL_IMAGE     – Docker image to use when ipmitool is not found
+#                         (default: ghcr.io/halfcrazy/ipmitool:eecd64f)
+#
+# Requires: make build  (or: make test-e2e-server)
+#
+# Usage:
+#   ./test/e2e/server_test.sh                          # port 623   (needs root)
+#   GOIPMI_SERVER_PORT=9623 ./test/e2e/server_test.sh  # port 9623 (no root needed)
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-9623}"
+GOIPMI_USER="${GOIPMI_USER:-ADMIN}"
+GOIPMI_PASS="${GOIPMI_PASS:-ADMIN}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+
+# ---------------------------------------------------------------------------
+# Find or choose an ipmitool
+# ---------------------------------------------------------------------------
+IPMITOOL_BIN="${IPMITOOL_BIN:-}"
+if [ -z "${IPMITOOL_BIN}" ]; then
+	if command -v ipmitool &>/dev/null; then
+		IPMITOOL_BIN="ipmitool"
+	fi
+fi
+
+if [ -n "${IPMITOOL_BIN}" ]; then
+	echo "==> Using ipmitool: ${IPMITOOL_BIN}"
+	IPMITOOL_RUN="${IPMITOOL_BIN}"
+else
+	echo "==> ipmitool not found locally, will use Docker: ${IPMITOOL_IMAGE}"
+	# We need --network host only when the server is on localhost AND the
+	# port is not reachable from the default Docker bridge.  For port 623
+	# bound to 0.0.0.0 the bridge works as long as we use the host IP.
+	IPMITOOL_RUN="docker run --rm --network host ${IPMITOOL_IMAGE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Start the server
+# ---------------------------------------------------------------------------
+cleanup() {
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo "==> Stopping goipmi-server (pid ${SERVER_PID}) ..."
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+# Use sudo only when binding to a privileged port.
+USE_SUDO=""
+if [ "${GOIPMI_SERVER_PORT}" -lt 1024 ]; then
+	USE_SUDO="sudo"
+fi
+
+echo "==> Starting goipmi-server on :${GOIPMI_SERVER_PORT} ..."
+${USE_SUDO} env \
+	GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT}" \
+	GOIPMI_SERVER_USER="${GOIPMI_USER}" \
+	GOIPMI_SERVER_PASS="${GOIPMI_PASS}" \
+	"${SERVER_BIN}" &
+SERVER_PID=$!
+sleep 2
+
+# Verify the server is listening.
+if ! ss -uln | grep -q ":${GOIPMI_SERVER_PORT} "; then
+	echo "ERROR: server failed to bind port ${GOIPMI_SERVER_PORT}" >&2
+	exit 1
+fi
+echo "==> Server is listening on :${GOIPMI_SERVER_PORT}"
+
+# ---------------------------------------------------------------------------
+# Run the tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Server E2E: ipmitool → goipmi-server"
+echo "========================================"
+
+IPMITOOL_ARGS=(-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus)
+
+run_ipmitool() {
+	# shellcheck disable=SC2086
+	${IPMITOOL_RUN} "${IPMITOOL_ARGS[@]}" "$@"
+}
+
+failures=0
+e2e_run_chassis_cases failures run_ipmitool
+
+e2e_report "Server E2E" "${failures}"


### PR DESCRIPTION
Add goipmi-server, shell-based e2e suite, Makefile targets, and CI workflow to exercise client/server interoperability with ipmitool.

Fix session establishment and authentication on both sides:

Client:
- Send pre-session Get Channel Authentication Capabilities in IPMI 1.5
  framing (v20=false) per spec §13.15
- Prefer MD5 over MD2 when both are available

Server:
- Handle IPMI 1.5 pre-session probe (unauthenticated session-zero packets)
- Correct Get Channel Authentication Capabilities response bytes
- Implement Get Channel Cipher Suites (App 0x54)
- Fix Open Session algorithm payload layout and parsing offsets
- Add RMCP+ integrity (HMAC-SHA1-96) on outbound packets and verify inbound
- Enforce user/channel privilege authorization during RAKP1/RAKP3