### PR TITLE
feat(chassis): typed codec handlers, PowerCycle dispatch, Set/Get System Boot Options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,7 @@ test-e2e-server: build
 test-e2e-self: build
 	./test/e2e/self_test.sh
 
-test-e2e: test-e2e-client test-e2e-server test-e2e-self
+test-e2e-chassis-codec: build
+	./test/e2e/chassis_codec_test.sh
+
+test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec

--- a/pkg/cmd/chassis/chassis_codec_test.go
+++ b/pkg/cmd/chassis/chassis_codec_test.go
@@ -8,23 +8,23 @@ import (
 
 func TestGetChassisStatusResponse_PackUnpackRoundTrip(t *testing.T) {
 	original := &GetChassisStatusResponse{
-		PowerRestorePolicy:          PowerRestorePolicyAlwaysOn,
-		PowerControlFault:           true,
-		PowerFault:                  false,
-		InterLock:                   true,
-		PowerOverload:               false,
-		PowerIsOn:                   true,
-		LastPowerOnByCommand:        true,
-		LastPowerDownByPowerFault:   false,
-		ACFailed:                    true,
-		ChassisIdentifySupported:    true,
-		ChassisIdentifyState:        ChassisIdentifyStateTemporaryOn,
-		CollingFanFault:             true,
-		DriveFault:                  false,
-		FrontPanelLockoutActive:     true,
-		ChassisIntrusionActive:      false,
-		SleepButtonDisableAllowed:   true,
-		ResetButtonDisabled:         true,
+		PowerRestorePolicy:           PowerRestorePolicyAlwaysOn,
+		PowerControlFault:            true,
+		PowerFault:                   false,
+		InterLock:                    true,
+		PowerOverload:                false,
+		PowerIsOn:                    true,
+		LastPowerOnByCommand:         true,
+		LastPowerDownByPowerFault:    false,
+		ACFailed:                     true,
+		ChassisIdentifySupported:     true,
+		ChassisIdentifyState:         ChassisIdentifyStateTemporaryOn,
+		CollingFanFault:              true,
+		DriveFault:                   false,
+		FrontPanelLockoutActive:      true,
+		ChassisIntrusionActive:       false,
+		SleepButtonDisableAllowed:    true,
+		ResetButtonDisabled:          true,
 		PoweroffButtonDisableAllowed: true,
 	}
 
@@ -54,15 +54,21 @@ func TestGetChassisStatusResponse_PackUnpackRoundTrip(t *testing.T) {
 	}
 }
 
-func TestGetChassisStatusResponse_PackThreeBytesByDefault(t *testing.T) {
+func TestGetChassisStatusResponse_PackAlwaysFourBytes(t *testing.T) {
+	// Per §28.2 Table 28-3, byte 3 is optional but "Return as 00h if the panel
+	// button disable function is not supported." Pack always emits 4 bytes.
 	res := &GetChassisStatusResponse{PowerIsOn: true}
 	packed := res.Pack()
-	if len(packed) != 3 {
-		t.Fatalf("Pack without front-panel bits: want 3 bytes, got %d", len(packed))
+	if len(packed) != 4 {
+		t.Fatalf("Pack without front-panel bits: want 4 bytes (spec says return as 00h), got %d", len(packed))
 	}
 	// Byte 0 bit 0 must reflect PowerIsOn.
 	if packed[0]&0x01 == 0 {
 		t.Fatalf("PowerIsOn not encoded: byte0=0x%02x", packed[0])
+	}
+	// Byte 3 must be 0x00 when no front-panel button disable bits are set.
+	if packed[3] != 0x00 {
+		t.Fatalf("byte 3 with no front-panel bits: want 0x00, got 0x%02x", packed[3])
 	}
 }
 

--- a/pkg/cmd/chassis/chassis_codec_test.go
+++ b/pkg/cmd/chassis/chassis_codec_test.go
@@ -1,0 +1,108 @@
+package chassis
+
+import (
+	"testing"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGetChassisStatusResponse_PackUnpackRoundTrip(t *testing.T) {
+	original := &GetChassisStatusResponse{
+		PowerRestorePolicy:          PowerRestorePolicyAlwaysOn,
+		PowerControlFault:           true,
+		PowerFault:                  false,
+		InterLock:                   true,
+		PowerOverload:               false,
+		PowerIsOn:                   true,
+		LastPowerOnByCommand:        true,
+		LastPowerDownByPowerFault:   false,
+		ACFailed:                    true,
+		ChassisIdentifySupported:    true,
+		ChassisIdentifyState:        ChassisIdentifyStateTemporaryOn,
+		CollingFanFault:             true,
+		DriveFault:                  false,
+		FrontPanelLockoutActive:     true,
+		ChassisIntrusionActive:      false,
+		SleepButtonDisableAllowed:   true,
+		ResetButtonDisabled:         true,
+		PoweroffButtonDisableAllowed: true,
+	}
+
+	packed := original.Pack()
+	if len(packed) != 4 {
+		t.Fatalf("Pack: want 4 bytes (front-panel bits set), got %d", len(packed))
+	}
+
+	var decoded GetChassisStatusResponse
+	if err := decoded.Unpack(packed); err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if decoded.PowerRestorePolicy != original.PowerRestorePolicy {
+		t.Fatalf("PowerRestorePolicy: want %v, got %v", original.PowerRestorePolicy, decoded.PowerRestorePolicy)
+	}
+	if decoded.PowerIsOn != original.PowerIsOn {
+		t.Fatalf("PowerIsOn: want %v, got %v", original.PowerIsOn, decoded.PowerIsOn)
+	}
+	if decoded.ChassisIdentifyState != original.ChassisIdentifyState {
+		t.Fatalf("ChassisIdentifyState: want %v, got %v", original.ChassisIdentifyState, decoded.ChassisIdentifyState)
+	}
+	if decoded.SleepButtonDisableAllowed != original.SleepButtonDisableAllowed {
+		t.Fatalf("SleepButtonDisableAllowed: want %v, got %v", original.SleepButtonDisableAllowed, decoded.SleepButtonDisableAllowed)
+	}
+	if decoded.PoweroffButtonDisableAllowed != original.PoweroffButtonDisableAllowed {
+		t.Fatalf("PoweroffButtonDisableAllowed: want %v, got %v", original.PoweroffButtonDisableAllowed, decoded.PoweroffButtonDisableAllowed)
+	}
+}
+
+func TestGetChassisStatusResponse_PackThreeBytesByDefault(t *testing.T) {
+	res := &GetChassisStatusResponse{PowerIsOn: true}
+	packed := res.Pack()
+	if len(packed) != 3 {
+		t.Fatalf("Pack without front-panel bits: want 3 bytes, got %d", len(packed))
+	}
+	// Byte 0 bit 0 must reflect PowerIsOn.
+	if packed[0]&0x01 == 0 {
+		t.Fatalf("PowerIsOn not encoded: byte0=0x%02x", packed[0])
+	}
+}
+
+func TestChassisControlRequest_Unpack(t *testing.T) {
+	cases := []struct {
+		in   byte
+		want ChassisControl
+	}{
+		{0x00, ChassisControlPowerDown},
+		{0x01, ChassisControlPowerUp},
+		{0x02, ChassisControlPowerCycle},
+		{0x03, ChassisControlHardReset},
+		{0x05, ChassisControlSoftShutdown},
+		// Upper nibble is reserved and must be ignored.
+		{0xF2, ChassisControlPowerCycle},
+	}
+	for _, tc := range cases {
+		var req ChassisControlRequest
+		if err := req.Unpack([]byte{tc.in}); err != nil {
+			t.Fatalf("Unpack(0x%02x): %v", tc.in, err)
+		}
+		if req.ChassisControl != tc.want {
+			t.Fatalf("Unpack(0x%02x): want %v, got %v", tc.in, tc.want, req.ChassisControl)
+		}
+	}
+
+	var req ChassisControlRequest
+	if err := req.Unpack(nil); err == nil {
+		t.Fatalf("Unpack(nil) should error")
+	}
+
+	// Pack/Unpack symmetry.
+	orig := &ChassisControlRequest{ChassisControl: ChassisControlHardReset}
+	var round ChassisControlRequest
+	if err := round.Unpack(orig.Pack()); err != nil {
+		t.Fatalf("round-trip Unpack: %v", err)
+	}
+	if round.ChassisControl != orig.ChassisControl {
+		t.Fatalf("round-trip: want %v, got %v", orig.ChassisControl, round.ChassisControl)
+	}
+	// Touch ipmi to keep the import meaningful for future helper-based cases.
+	_ = ipmi.CommandChassisControl
+}

--- a/pkg/cmd/chassis/cmd_chassis_control.go
+++ b/pkg/cmd/chassis/cmd_chassis_control.go
@@ -29,6 +29,16 @@ func (req *ChassisControlRequest) Pack() []byte {
 	return out
 }
 
+// Unpack parses a Chassis Control request body (§28.3): a single byte whose
+// lower nibble is the action. Upper nibble is reserved and ignored.
+func (req *ChassisControlRequest) Unpack(msg []byte) error {
+	if len(msg) < 1 {
+		return ipmi.ErrUnpackedDataTooShortWith(len(msg), 1)
+	}
+	req.ChassisControl = ChassisControl(msg[0] & 0x0F)
+	return nil
+}
+
 func (req *ChassisControlRequest) Command() ipmi.Command {
 	return ipmi.CommandChassisControl
 }

--- a/pkg/cmd/chassis/cmd_get_chassis_status.go
+++ b/pkg/cmd/chassis/cmd_get_chassis_status.go
@@ -100,9 +100,9 @@ func (req *GetChassisStatusRequest) Pack() []byte {
 	return []byte{}
 }
 
-// Pack serialises the response per the bit layout in §28.2, the inverse of
-// [Unpack]. It emits 3 bytes when no front-panel button disable field is set,
-// and 4 bytes otherwise so Unpack can round-trip the optional 4th byte.
+// Pack serialises the response per the bit layout in §28.2 Table 28-3, the
+// inverse of [Unpack]. Byte 3 (front-panel button disables) is always emitted
+// per spec: "Return as 00h if the panel button disable function is not supported."
 func (res *GetChassisStatusResponse) Pack() []byte {
 	var b0 uint8
 	b0 |= (uint8(res.PowerRestorePolicy) & 0x07) << 5
@@ -157,41 +157,33 @@ func (res *GetChassisStatusResponse) Pack() []byte {
 		b2 = ipmi.SetBit0(b2)
 	}
 
-	out := []byte{b0, b1, b2}
-
-	hasFrontPanel := res.SleepButtonDisableAllowed || res.DiagnosticButtonDisableAllowed ||
-		res.ResetButtonDisableAllowed || res.PoweroffButtonDisableAllowed ||
-		res.SleepButtonDisabled || res.DiagnosticButtonDisabled ||
-		res.ResetButtonDisabled || res.PoweroffButtonDisabled
-	if hasFrontPanel {
-		var b3 uint8
-		if res.SleepButtonDisableAllowed {
-			b3 = ipmi.SetBit7(b3)
-		}
-		if res.DiagnosticButtonDisableAllowed {
-			b3 = ipmi.SetBit6(b3)
-		}
-		if res.ResetButtonDisableAllowed {
-			b3 = ipmi.SetBit5(b3)
-		}
-		if res.PoweroffButtonDisableAllowed {
-			b3 = ipmi.SetBit4(b3)
-		}
-		if res.SleepButtonDisabled {
-			b3 = ipmi.SetBit3(b3)
-		}
-		if res.DiagnosticButtonDisabled {
-			b3 = ipmi.SetBit2(b3)
-		}
-		if res.ResetButtonDisabled {
-			b3 = ipmi.SetBit1(b3)
-		}
-		if res.PoweroffButtonDisabled {
-			b3 = ipmi.SetBit0(b3)
-		}
-		out = append(out, b3)
+	var b3 uint8
+	if res.SleepButtonDisableAllowed {
+		b3 = ipmi.SetBit7(b3)
 	}
-	return out
+	if res.DiagnosticButtonDisableAllowed {
+		b3 = ipmi.SetBit6(b3)
+	}
+	if res.ResetButtonDisableAllowed {
+		b3 = ipmi.SetBit5(b3)
+	}
+	if res.PoweroffButtonDisableAllowed {
+		b3 = ipmi.SetBit4(b3)
+	}
+	if res.SleepButtonDisabled {
+		b3 = ipmi.SetBit3(b3)
+	}
+	if res.DiagnosticButtonDisabled {
+		b3 = ipmi.SetBit2(b3)
+	}
+	if res.ResetButtonDisabled {
+		b3 = ipmi.SetBit1(b3)
+	}
+	if res.PoweroffButtonDisabled {
+		b3 = ipmi.SetBit0(b3)
+	}
+
+	return []byte{b0, b1, b2, b3}
 }
 
 func (req *GetChassisStatusRequest) Command() ipmi.Command {
@@ -208,8 +200,8 @@ func (res *GetChassisStatusResponse) Unpack(msg []byte) error {
 	}
 
 	b1, _, _ := ipmi.UnpackUint8(msg, 0)
-	// first clear bit 7, then shift right 5 bits
-	b := (b1 & 0x7f) >> 5
+	// Power restore policy occupies bits [7:5] per §28.2 Table 28-3.
+	b := (b1 & 0xE0) >> 5
 	res.PowerRestorePolicy = PowerRestorePolicy(b)
 	res.PowerControlFault = ipmi.IsBit4Set(b1)
 	res.PowerFault = ipmi.IsBit3Set(b1)

--- a/pkg/cmd/chassis/cmd_get_chassis_status.go
+++ b/pkg/cmd/chassis/cmd_get_chassis_status.go
@@ -100,6 +100,100 @@ func (req *GetChassisStatusRequest) Pack() []byte {
 	return []byte{}
 }
 
+// Pack serialises the response per the bit layout in §28.2, the inverse of
+// [Unpack]. It emits 3 bytes when no front-panel button disable field is set,
+// and 4 bytes otherwise so Unpack can round-trip the optional 4th byte.
+func (res *GetChassisStatusResponse) Pack() []byte {
+	var b0 uint8
+	b0 |= (uint8(res.PowerRestorePolicy) & 0x07) << 5
+	if res.PowerControlFault {
+		b0 = ipmi.SetBit4(b0)
+	}
+	if res.PowerFault {
+		b0 = ipmi.SetBit3(b0)
+	}
+	if res.InterLock {
+		b0 = ipmi.SetBit2(b0)
+	}
+	if res.PowerOverload {
+		b0 = ipmi.SetBit1(b0)
+	}
+	if res.PowerIsOn {
+		b0 = ipmi.SetBit0(b0)
+	}
+
+	var b1 uint8
+	if res.LastPowerOnByCommand {
+		b1 = ipmi.SetBit4(b1)
+	}
+	if res.LastPowerDownByPowerFault {
+		b1 = ipmi.SetBit3(b1)
+	}
+	if res.LastPowerDownByPowerInterlockActivated {
+		b1 = ipmi.SetBit2(b1)
+	}
+	if res.LastPowerDownByPowerOverload {
+		b1 = ipmi.SetBit1(b1)
+	}
+	if res.ACFailed {
+		b1 = ipmi.SetBit0(b1)
+	}
+
+	var b2 uint8
+	if res.ChassisIdentifySupported {
+		b2 = ipmi.SetBit6(b2)
+	}
+	b2 |= (uint8(res.ChassisIdentifyState) & 0x03) << 4
+	if res.CollingFanFault {
+		b2 = ipmi.SetBit3(b2)
+	}
+	if res.DriveFault {
+		b2 = ipmi.SetBit2(b2)
+	}
+	if res.FrontPanelLockoutActive {
+		b2 = ipmi.SetBit1(b2)
+	}
+	if res.ChassisIntrusionActive {
+		b2 = ipmi.SetBit0(b2)
+	}
+
+	out := []byte{b0, b1, b2}
+
+	hasFrontPanel := res.SleepButtonDisableAllowed || res.DiagnosticButtonDisableAllowed ||
+		res.ResetButtonDisableAllowed || res.PoweroffButtonDisableAllowed ||
+		res.SleepButtonDisabled || res.DiagnosticButtonDisabled ||
+		res.ResetButtonDisabled || res.PoweroffButtonDisabled
+	if hasFrontPanel {
+		var b3 uint8
+		if res.SleepButtonDisableAllowed {
+			b3 = ipmi.SetBit7(b3)
+		}
+		if res.DiagnosticButtonDisableAllowed {
+			b3 = ipmi.SetBit6(b3)
+		}
+		if res.ResetButtonDisableAllowed {
+			b3 = ipmi.SetBit5(b3)
+		}
+		if res.PoweroffButtonDisableAllowed {
+			b3 = ipmi.SetBit4(b3)
+		}
+		if res.SleepButtonDisabled {
+			b3 = ipmi.SetBit3(b3)
+		}
+		if res.DiagnosticButtonDisabled {
+			b3 = ipmi.SetBit2(b3)
+		}
+		if res.ResetButtonDisabled {
+			b3 = ipmi.SetBit1(b3)
+		}
+		if res.PoweroffButtonDisabled {
+			b3 = ipmi.SetBit0(b3)
+		}
+		out = append(out, b3)
+	}
+	return out
+}
+
 func (req *GetChassisStatusRequest) Command() ipmi.Command {
 	return ipmi.CommandGetChassisStatus
 }

--- a/pkg/hal/hal.go
+++ b/pkg/hal/hal.go
@@ -17,7 +17,11 @@
 //   - Bridges to existing daemon APIs (e.g. OpenBMC D-Bus)
 package hal
 
-import "context"
+import (
+	"context"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
 
 // HAL is the top-level hardware abstraction.  Implementations may return nil
 // for sub-interfaces that are not available on the target.
@@ -44,6 +48,10 @@ type ChassisHAL interface {
 	PowerState(ctx context.Context) (bool, error)
 	// SetPower powers the managed system on or off.
 	SetPower(ctx context.Context, on bool) error
+	// PowerCycle performs a full power cycle of the managed system
+	// (Chassis Control action 0x02, spec Table 28-3). The semantic meaning
+	// for a given BMC is defined by the upper-layer HAL implementation.
+	PowerCycle(ctx context.Context) error
 	// ColdReset performs a hardware cold reset of the managed system.
 	ColdReset(ctx context.Context) error
 	// WarmReset requests an OS-level warm reboot of the managed system.
@@ -55,6 +63,23 @@ type ChassisHAL interface {
 	// IntrusionState returns true when the chassis has been opened since last reset.
 	// Implementations that lack intrusion detection must return ErrNotSupported.
 	IntrusionState(ctx context.Context) (bool, error)
+	// SetBootFlags commits the full boot flags structure (spec Table 28-6).
+	// The upper layer decides which bits it cares about; HAL implementations
+	// must not silently drop fields they ignore. Implementations that do not
+	// maintain boot state return ErrNotSupported.
+	SetBootFlags(ctx context.Context, flags *ipmi.BootOptionParam_BootFlags) error
+	// GetBootFlags reads back the current boot flags, symmetric with
+	// [SetBootFlags]. Implementations that cannot read boot flags back must
+	// return ErrNotSupported; handlers translate that to the
+	// CodeParamNotSupported completion code.
+	GetBootFlags(ctx context.Context) (*ipmi.BootOptionParam_BootFlags, error)
+	// SetBootInfoAcknowledge persists the boot initiator acknowledge data
+	// (spec Table 28-14, param #4).  The HAL may implement this as a no-op
+	// (return nil) if it does not track boot initiator identity.
+	SetBootInfoAcknowledge(ctx context.Context, ack *ipmi.BootOptionParam_BootInfoAcknowledge) error
+	// GetBootInfoAcknowledge reads back the stored acknowledge data.
+	// Implementations that do not persist this return ErrNotSupported.
+	GetBootInfoAcknowledge(ctx context.Context) (*ipmi.BootOptionParam_BootInfoAcknowledge, error)
 }
 
 // SensorDescriptor describes a sensor exposed by the hardware.

--- a/pkg/hal/hal.go
+++ b/pkg/hal/hal.go
@@ -71,7 +71,7 @@ type ChassisHAL interface {
 	// GetBootFlags reads back the current boot flags, symmetric with
 	// [SetBootFlags]. Implementations that cannot read boot flags back must
 	// return ErrNotSupported; handlers translate that to the
-	// CodeParamNotSupported completion code.
+	// CodeBootParamNotSupported completion code.
 	GetBootFlags(ctx context.Context) (*ipmi.BootOptionParam_BootFlags, error)
 	// SetBootInfoAcknowledge persists the boot initiator acknowledge data
 	// (spec Table 28-14, param #4).  The HAL may implement this as a no-op
@@ -148,8 +148,10 @@ type I2CHAL interface {
 }
 
 // ErrNotSupported is returned by HAL methods when the hardware does not
-// support the requested operation.  Handlers map this to IPMI completion code
-// 0xD5 (command not supported in present state).
+// support the requested operation.  Handlers translate this to an appropriate
+// IPMI completion code: CodeBootParamNotSupported 0x80 (§28.12/§28.13) for
+// parameter-level operations, CodeUnspecifiedError 0xFF (§5.2 Table 5-2)
+// via codeFromErr for general error paths.
 var ErrNotSupported = errNotSupported{}
 
 type errNotSupported struct{}

--- a/pkg/hal/mock/mock.go
+++ b/pkg/hal/mock/mock.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/bougou/go-ipmi/pkg/hal"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 // HAL is a fully in-memory [hal.HAL].
@@ -54,7 +55,10 @@ type Chassis struct {
 	Intruded        bool
 	ColdResets      int
 	WarmResets      int
+	PowerCycles     int
 	LastIdentifySec uint8
+	BootFlags       *ipmi.BootOptionParam_BootFlags
+	BootInfoAck     *ipmi.BootOptionParam_BootInfoAcknowledge
 
 	// Hook allows tests to inject custom behaviour.
 	SetPowerHook func(on bool) error
@@ -83,6 +87,17 @@ func (c *Chassis) ColdReset(_ context.Context) error {
 	return nil
 }
 
+// PowerCycle performs a power cycle. The mock counts calls independently so
+// tests can assert that Chassis Control action 0x02 dispatched here rather than
+// to ColdReset. Real noop HALs that lack a distinct power-cycle operation may
+// delegate to ColdReset; the mock keeps the counters separate for clarity.
+func (c *Chassis) PowerCycle(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.PowerCycles++
+	return nil
+}
+
 func (c *Chassis) WarmReset(_ context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -101,6 +116,55 @@ func (c *Chassis) IntrusionState(_ context.Context) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.Intruded, nil
+}
+
+// SetBootFlags stores the full boot flags structure so tests and the
+// reference server can round-trip Set/Get System Boot Options.
+func (c *Chassis) SetBootFlags(_ context.Context, flags *ipmi.BootOptionParam_BootFlags) error {
+	if flags == nil {
+		return hal.ErrNotSupported
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := *flags
+	c.BootFlags = &cp
+	return nil
+}
+
+// GetBootFlags returns the last stored boot flags, or [hal.ErrNotSupported]
+// when none have been set.
+func (c *Chassis) GetBootFlags(_ context.Context) (*ipmi.BootOptionParam_BootFlags, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.BootFlags == nil {
+		return nil, hal.ErrNotSupported
+	}
+	cp := *c.BootFlags
+	return &cp, nil
+}
+
+// SetBootInfoAcknowledge stores the boot info acknowledge data.
+func (c *Chassis) SetBootInfoAcknowledge(_ context.Context, ack *ipmi.BootOptionParam_BootInfoAcknowledge) error {
+	if ack == nil {
+		return hal.ErrNotSupported
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := *ack
+	c.BootInfoAck = &cp
+	return nil
+}
+
+// GetBootInfoAcknowledge returns the last stored acknowledge data,
+// or a default value when none have been stored.
+func (c *Chassis) GetBootInfoAcknowledge(_ context.Context) (*ipmi.BootOptionParam_BootInfoAcknowledge, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.BootInfoAck == nil {
+		return &ipmi.BootOptionParam_BootInfoAcknowledge{}, nil
+	}
+	cp := *c.BootInfoAck
+	return &cp, nil
 }
 
 // --- Sensors ---

--- a/pkg/handlers/chassis.go
+++ b/pkg/handlers/chassis.go
@@ -2,24 +2,21 @@ package handlers
 
 import (
 	"context"
+	"errors"
+
+	"github.com/bougou/go-ipmi/pkg/cmd/chassis"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
-// IPMI Chassis command IDs.
+// IPMI Chassis command IDs (spec §28).
 const (
 	CmdGetChassisCapabilities uint8 = 0x00
 	CmdGetChassisStatus       uint8 = 0x01
 	CmdChassisControl         uint8 = 0x02
 	CmdChassisIdentify        uint8 = 0x04
-)
-
-// ChassisControl actions (Table 28-3).
-const (
-	ChassisControlPowerDown     uint8 = 0x00
-	ChassisControlPowerUp       uint8 = 0x01
-	ChassisControlPowerCycle    uint8 = 0x02
-	ChassisControlHardReset     uint8 = 0x03
-	ChassisControlDiagInterrupt uint8 = 0x04
-	ChassisControlSoftShutdown  uint8 = 0x05
+	CmdSetSystemBootOptions   uint8 = 0x08
+	CmdGetSystemBootOptions   uint8 = 0x09
 )
 
 // RegisterChassisHandlers adds all Chassis command handlers to r.
@@ -28,6 +25,8 @@ func RegisterChassisHandlers(r *Registry) {
 	r.Register(NetFnChassisRequest, CmdGetChassisStatus, HandlerFunc(handleGetChassisStatus))
 	r.Register(NetFnChassisRequest, CmdChassisControl, HandlerFunc(handleChassisControl))
 	r.Register(NetFnChassisRequest, CmdChassisIdentify, HandlerFunc(handleChassisIdentify))
+	r.Register(NetFnChassisRequest, CmdSetSystemBootOptions, HandlerFunc(handleSetSystemBootOptions))
+	r.Register(NetFnChassisRequest, CmdGetSystemBootOptions, HandlerFunc(handleGetSystemBootOptions))
 }
 
 // handleGetChassisCapabilities returns a minimal static response.
@@ -39,48 +38,62 @@ func handleGetChassisCapabilities(_ context.Context, _ *HandlerContext, _ []byte
 	return []byte{0x00, 0x20, 0x20, 0x20, 0x20}, CodeOK, nil
 }
 
-// handleGetChassisStatus implements Get Chassis Status (Chassis 0x01).
+// handleGetChassisStatus implements Get Chassis Status (Chassis 0x01, spec §28.2).
+// It builds a typed [chassis.GetChassisStatusResponse] from the HAL and
+// serialises it with [chassis.GetChassisStatusResponse.Pack], eliminating
+// hand-written byte assembly.
 func handleGetChassisStatus(ctx context.Context, hctx *HandlerContext, _ []byte) ([]byte, CompletionCode, error) {
 	ch := hctx.BMC.HAL().Chassis()
 
-	var powerOn bool
+	resp := &chassis.GetChassisStatusResponse{}
 	if ch != nil {
-		var err error
-		powerOn, err = ch.PowerState(ctx)
+		on, err := ch.PowerState(ctx)
 		if err != nil {
-			return nil, CodeUnspecifiedError, err
+			return nil, codeFromHalErr(err), err
 		}
+		resp.PowerIsOn = on
+		// IntrusionState is optional; absence (ErrNotSupported) leaves the
+		// bit zero, matching the "no intrusion detected" wire value.
+		if intruded, err := ch.IntrusionState(ctx); err == nil {
+			resp.ChassisIntrusionActive = intruded
+		}
+		resp.ChassisIdentifySupported = true
 	}
-
-	byte0 := uint8(0x00)
-	if powerOn {
-		byte0 |= 0x01 // bit 0: power on
-	}
-	// Bytes 1-3: last power event, misc chassis state, FP button disables.
-	// Return zeros (no specific event, no buttons disabled) for the reference impl.
-	return []byte{byte0, 0x00, 0x00, 0x00}, CodeOK, nil
+	return resp.Pack(), CodeOK, nil
 }
 
-// handleChassisControl implements Chassis Control (Chassis 0x02).
+// handleChassisControl implements Chassis Control (Chassis 0x02, spec §28.3).
+// The request is decoded with [chassis.ChassisControlRequest.Unpack] and
+// dispatched to the typed HAL method matching the spec Table 28-3 action.
+// The action→HAL method mapping is a spec-fixed protocol dispatch; the
+// upper-layer HAL implementation defines what each method means for the
+// managed system.
 func handleChassisControl(ctx context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
-	if len(req) < 1 {
-		return nil, CodeRequestDataTruncated, nil
-	}
 	ch := hctx.BMC.HAL().Chassis()
 	if ch == nil {
 		return nil, CodeNotSupportedInState, nil
 	}
 
-	action := req[0] & 0x0F
-	switch action {
-	case ChassisControlPowerDown:
+	var typed chassis.ChassisControlRequest
+	if err := typed.Unpack(req); err != nil {
+		return nil, CodeRequestDataTruncated, nil
+	}
+
+	switch typed.ChassisControl {
+	case chassis.ChassisControlPowerDown:
 		return nil, codeFromErr(ch.SetPower(ctx, false)), nil
-	case ChassisControlPowerUp:
+	case chassis.ChassisControlPowerUp:
 		return nil, codeFromErr(ch.SetPower(ctx, true)), nil
-	case ChassisControlHardReset:
+	case chassis.ChassisControlPowerCycle:
+		return nil, codeFromErr(ch.PowerCycle(ctx)), nil
+	case chassis.ChassisControlHardReset:
 		return nil, codeFromErr(ch.ColdReset(ctx)), nil
-	case ChassisControlSoftShutdown:
+	case chassis.ChassisControlSoftShutdown:
 		return nil, codeFromErr(ch.WarmReset(ctx)), nil
+	case chassis.ChassisControlDiagnosticInterrupt:
+		// No corresponding typed HAL method in the reference interface;
+		// treat as an unsupported chassis control action per spec.
+		return nil, CodeParamOutOfRange, nil
 	default:
 		return nil, CodeParamOutOfRange, nil
 	}
@@ -105,10 +118,122 @@ func handleChassisIdentify(ctx context.Context, hctx *HandlerContext, req []byte
 	return nil, codeFromErr(ch.Identify(ctx, seconds)), nil
 }
 
+// handleSetSystemBootOptions implements Set System Boot Options (Chassis 0x08,
+// spec §28.12 Table 28-12).  Supported parameter selectors:
+//   - 0x04: Boot Info Acknowledge (§28.14 Table 28-14 param #4)
+//   - 0x05: Boot Flags (§28.14 Table 28-14 param #5)
+//
+// The request format is:
+//
+//	byte 1: [7] parameter valid/invalid, [6:0] boot option parameter selector
+//	byte 2:N: boot option parameter data (0 bytes allowed per spec)
+//
+// Per spec the BMC must return:
+//   - 80h – parameter not supported
+//   - 81h – attempt to set 'set in progress' when not in 'set complete' state
+//   - 82h – attempt to write read-only parameter
+func handleSetSystemBootOptions(ctx context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if len(req) < 1 {
+		return nil, CodeRequestDataTruncated, nil
+	}
+	// bit 7 = parameter valid flag (§28.12 byte 1).
+	_ = req[0] & 0x80 // accepted; HAL layer does not persist a lock state.
+	paramSelector := ipmi.BootOptionParamSelector(req[0] & 0x7f)
+	paramData := req[1:]
+
+	ch := hctx.BMC.HAL().Chassis()
+	if ch == nil {
+		return nil, CodeNotSupportedInState, nil
+	}
+
+	switch paramSelector {
+	case ipmi.BootOptionParamSelector_BootInfoAcknowledge:
+		// 0 bytes of data → toggling the valid/lock bit only.
+		if len(paramData) == 0 {
+			return nil, CodeOK, nil
+		}
+		var ack ipmi.BootOptionParam_BootInfoAcknowledge
+		if err := ack.Unpack(paramData); err != nil {
+			return nil, CodeRequestDataTruncated, nil
+		}
+		return nil, codeFromHalErr(ch.SetBootInfoAcknowledge(ctx, &ack)), nil
+
+	case ipmi.BootOptionParamSelector_BootFlags:
+		if len(paramData) == 0 {
+			return nil, CodeOK, nil
+		}
+		var flags ipmi.BootOptionParam_BootFlags
+		if err := flags.Unpack(paramData); err != nil {
+			return nil, CodeRequestDataTruncated, nil
+		}
+		return nil, codeFromHalErr(ch.SetBootFlags(ctx, &flags)), nil
+
+	default:
+		// Per spec Table 28-12: unimplemented parameter → 80h.
+		return nil, CodeBootParamNotSupported, nil
+	}
+}
+
+// handleGetSystemBootOptions implements Get System Boot Options (Chassis 0x09,
+// spec §28.13).  Supported parameter selectors:
+//   - 0x04: Boot Info Acknowledge
+//   - 0x05: Boot Flags
+func handleGetSystemBootOptions(ctx context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if len(req) < 1 {
+		return nil, CodeRequestDataTruncated, nil
+	}
+	paramSelector := ipmi.BootOptionParamSelector(req[0] & 0x7f)
+
+	ch := hctx.BMC.HAL().Chassis()
+	if ch == nil {
+		return nil, CodeNotSupportedInState, nil
+	}
+
+	switch paramSelector {
+	case ipmi.BootOptionParamSelector_BootInfoAcknowledge:
+		ack, err := ch.GetBootInfoAcknowledge(ctx)
+		if err != nil {
+			return nil, codeFromHalErr(err), nil
+		}
+		resp := make([]byte, 0, 2+2)
+		resp = append(resp, 0x01) // parameter version
+		resp = append(resp, byte(paramSelector&0x7f))
+		resp = append(resp, ack.Pack()...)
+		return resp, CodeOK, nil
+
+	case ipmi.BootOptionParamSelector_BootFlags:
+		flags, err := ch.GetBootFlags(ctx)
+		if err != nil {
+			return nil, codeFromHalErr(err), nil
+		}
+		resp := make([]byte, 0, 2+5)
+		resp = append(resp, 0x01) // parameter version
+		resp = append(resp, byte(paramSelector&0x7f))
+		resp = append(resp, flags.Pack()...)
+		return resp, CodeOK, nil
+
+	default:
+		return nil, CodeBootParamNotSupported, nil
+	}
+}
+
 // codeFromErr maps a HAL error to a completion code.
 func codeFromErr(err error) CompletionCode {
 	if err == nil {
 		return CodeOK
+	}
+	return CodeUnspecifiedError
+}
+
+// codeFromHalErr maps a HAL error to a completion code, translating
+// [hal.ErrNotSupported] to [CodeBootParamNotSupported] so callers can distinguish
+// "parameter not supported by this BMC" from a generic failure.
+func codeFromHalErr(err error) CompletionCode {
+	if err == nil {
+		return CodeOK
+	}
+	if errors.Is(err, hal.ErrNotSupported) {
+		return CodeBootParamNotSupported
 	}
 	return CodeUnspecifiedError
 }

--- a/pkg/handlers/chassis.go
+++ b/pkg/handlers/chassis.go
@@ -49,7 +49,11 @@ func handleGetChassisStatus(ctx context.Context, hctx *HandlerContext, _ []byte)
 	if ch != nil {
 		on, err := ch.PowerState(ctx)
 		if err != nil {
-			return nil, codeFromHalErr(err), err
+			// Use codeFromErr, not codeFromHalErr: GetChassisStatus (§28.2
+			// Table 28-3) does not define command-specific completion codes.
+			// 80h (CodeBootParamNotSupported) is only valid for
+			// Set/Get System Boot Options (§28.12/§28.13).
+			return nil, codeFromErr(err), err
 		}
 		resp.PowerIsOn = on
 		// IntrusionState is optional; absence (ErrNotSupported) leaves the

--- a/pkg/handlers/chassis_test.go
+++ b/pkg/handlers/chassis_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
-	"github.com/bougou/go-ipmi/pkg/cmd/chassis"
 	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/cmd/chassis"
 	"github.com/bougou/go-ipmi/pkg/hal"
 	"github.com/bougou/go-ipmi/pkg/hal/mock"
 	ipmi "github.com/bougou/go-ipmi/pkg/types"
@@ -79,9 +79,9 @@ func TestHandleChassisControl_PowerCycle(t *testing.T) {
 
 func TestHandleChassisControl_TypedDispatch(t *testing.T) {
 	cases := []struct {
-		name    string
-		action  chassis.ChassisControl
-		check   func(*mock.Chassis) bool
+		name   string
+		action chassis.ChassisControl
+		check  func(*mock.Chassis) bool
 	}{
 		{"PowerDown", chassis.ChassisControlPowerDown, func(c *mock.Chassis) bool { return !c.On }},
 		{"PowerUp", chassis.ChassisControlPowerUp, func(c *mock.Chassis) bool { return c.On }},
@@ -176,8 +176,8 @@ func TestHandleGetSystemBootOptions_NotSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cc != CodeParamNotSupported {
-		t.Fatalf("want CodeParamNotSupported for ErrNotSupported, got %d", cc)
+	if cc != CodeBootParamNotSupported {
+		t.Fatalf("want CodeBootParamNotSupported for ErrNotSupported, got %d", cc)
 	}
 }
 
@@ -187,12 +187,12 @@ func TestHandleSetSystemBootOptions_OtherParam(t *testing.T) {
 	ch := b.HAL().Chassis().(*mock.Chassis)
 	hctx := &HandlerContext{BMC: b}
 
-	// Set In Progress (0x00) is not implemented by the handler; it must be
-	// silently accepted without touching the HAL.
+	// Set In Progress (0x00) is not implemented; spec §28.12 requires 80h (CodeBootParamNotSupported)
+	// for unsupported parameters.
 	req := []byte{byte(ipmi.BootOptionParamSelector_SetInProgress), 0x01}
 	_, cc, err := handleSetSystemBootOptions(context.Background(), hctx, req)
-	if err != nil || cc != CodeOK {
-		t.Fatalf("want CodeOK for unimplemented param, got cc=%d err=%v", cc, err)
+	if err != nil || cc != CodeBootParamNotSupported {
+		t.Fatalf("want CodeBootParamNotSupported (80h) for unimplemented param, got cc=%d err=%v", cc, err)
 	}
 	if ch.BootFlags != nil {
 		t.Fatalf("HAL SetBootFlags must not be called for non-BootFlags params")
@@ -222,8 +222,8 @@ func TestCodeFromHalErr(t *testing.T) {
 	if got := codeFromHalErr(nil); got != CodeOK {
 		t.Fatalf("nil: want CodeOK, got %d", got)
 	}
-	if got := codeFromHalErr(hal.ErrNotSupported); got != CodeParamNotSupported {
-		t.Fatalf("ErrNotSupported: want CodeParamNotSupported, got %d", got)
+	if got := codeFromHalErr(hal.ErrNotSupported); got != CodeBootParamNotSupported {
+		t.Fatalf("ErrNotSupported: want CodeBootParamNotSupported, got %d", got)
 	}
 	if got := codeFromHalErr(errors.New("boom")); got != CodeUnspecifiedError {
 		t.Fatalf("generic error: want CodeUnspecifiedError, got %d", got)

--- a/pkg/handlers/chassis_test.go
+++ b/pkg/handlers/chassis_test.go
@@ -1,0 +1,231 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/cmd/chassis"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// newTestBMCWithMock builds a BMC backed by the supplied mock HAL so tests can
+// inspect and drive chassis state directly.
+func newTestBMCWithMock(m *mock.HAL) *bmc.BMC {
+	info := bmc.DeviceInfo{
+		DeviceID:       1,
+		IPMIVersion:    0x20,
+		ManufacturerID: 0x000157,
+		ProductID:      0x0001,
+	}
+	var guid [16]byte
+	return bmc.New(info, guid, m, bmc.WithClock(clock.Real))
+}
+
+func TestHandleGetChassisStatus_RoundTrip(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	ch.On = true
+	ch.Intruded = false
+	hctx := &HandlerContext{BMC: b}
+
+	resp, cc, err := handleGetChassisStatus(context.Background(), hctx, nil)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("unexpected cc=%d err=%v", cc, err)
+	}
+	// Re-encode through the typed codec and back to validate round-trip.
+	var decoded chassis.GetChassisStatusResponse
+	if err := decoded.Unpack(resp); err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if decoded.PowerIsOn != true {
+		t.Fatalf("PowerIsOn: want true, got %v", decoded.PowerIsOn)
+	}
+	if decoded.ChassisIdentifySupported != true {
+		t.Fatalf("ChassisIdentifySupported: want true, got %v", decoded.ChassisIdentifySupported)
+	}
+	if decoded.ChassisIntrusionActive != false {
+		t.Fatalf("ChassisIntrusionActive: want false, got %v", decoded.ChassisIntrusionActive)
+	}
+}
+
+func TestHandleChassisControl_PowerCycle(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	hctx := &HandlerContext{BMC: b}
+
+	req := (&chassis.ChassisControlRequest{ChassisControl: chassis.ChassisControlPowerCycle}).Pack()
+	_, cc, err := handleChassisControl(context.Background(), hctx, req)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("PowerCycle: want CodeOK, got cc=%d err=%v", cc, err)
+	}
+	if ch.PowerCycles != 1 {
+		t.Fatalf("PowerCycle dispatch: want 1 call, got %d", ch.PowerCycles)
+	}
+
+	// Unknown action still returns CodeParamOutOfRange (regression guard for
+	// the previous behaviour where PowerCycle fell through to the default).
+	_, cc, _ = handleChassisControl(context.Background(), hctx, []byte{0x0F})
+	if cc != CodeParamOutOfRange {
+		t.Fatalf("unknown action: want CodeParamOutOfRange, got %d", cc)
+	}
+}
+
+func TestHandleChassisControl_TypedDispatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		action  chassis.ChassisControl
+		check   func(*mock.Chassis) bool
+	}{
+		{"PowerDown", chassis.ChassisControlPowerDown, func(c *mock.Chassis) bool { return !c.On }},
+		{"PowerUp", chassis.ChassisControlPowerUp, func(c *mock.Chassis) bool { return c.On }},
+		{"HardReset", chassis.ChassisControlHardReset, func(c *mock.Chassis) bool { return c.ColdResets == 1 }},
+		{"SoftShutdown", chassis.ChassisControlSoftShutdown, func(c *mock.Chassis) bool { return c.WarmResets == 1 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mock.New()
+			b := newTestBMCWithMock(m)
+			ch := b.HAL().Chassis().(*mock.Chassis)
+			hctx := &HandlerContext{BMC: b}
+
+			req := (&chassis.ChassisControlRequest{ChassisControl: tc.action}).Pack()
+			_, cc, err := handleChassisControl(context.Background(), hctx, req)
+			if err != nil || cc != CodeOK {
+				t.Fatalf("%s: want CodeOK, got cc=%d err=%v", tc.name, cc, err)
+			}
+			if !tc.check(ch) {
+				t.Fatalf("%s: HAL state check failed (On=%v ColdResets=%d WarmResets=%d PowerCycles=%d)",
+					tc.name, ch.On, ch.ColdResets, ch.WarmResets, ch.PowerCycles)
+			}
+		})
+	}
+}
+
+func TestHandleSetSystemBootOptions_BootFlags(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	hctx := &HandlerContext{BMC: b}
+
+	flags := &ipmi.BootOptionParam_BootFlags{
+		BootFlagsValid:     true,
+		Persist:            true,
+		BootDeviceSelector: ipmi.BootDeviceSelectorForcePXE,
+	}
+	req := append([]byte{byte(ipmi.BootOptionParamSelector_BootFlags)}, flags.Pack()...)
+
+	_, cc, err := handleSetSystemBootOptions(context.Background(), hctx, req)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("want CodeOK, got cc=%d err=%v", cc, err)
+	}
+	if ch.BootFlags == nil {
+		t.Fatalf("SetBootFlags not invoked on HAL")
+	}
+	if !ch.BootFlags.Persist {
+		t.Fatalf("Persist bit lost: HAL received %+v", ch.BootFlags)
+	}
+	if ch.BootFlags.BootDeviceSelector != ipmi.BootDeviceSelectorForcePXE {
+		t.Fatalf("BootDeviceSelector: want PXE, got %v", ch.BootFlags.BootDeviceSelector)
+	}
+}
+
+func TestHandleGetSystemBootOptions_BootFlags(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	ch.BootFlags = &ipmi.BootOptionParam_BootFlags{
+		BootFlagsValid:     true,
+		BootDeviceSelector: ipmi.BootDeviceSelectorForcePXE,
+	}
+	hctx := &HandlerContext{BMC: b}
+
+	req := []byte{byte(ipmi.BootOptionParamSelector_BootFlags)}
+	resp, cc, err := handleGetSystemBootOptions(context.Background(), hctx, req)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("want CodeOK, got cc=%d err=%v", cc, err)
+	}
+	if len(resp) < 2 {
+		t.Fatalf("response too short: %d", len(resp))
+	}
+	// resp[0]=version, resp[1]=selector, resp[2:]=param data (5 bytes).
+	var decoded ipmi.BootOptionParam_BootFlags
+	if err := decoded.Unpack(resp[2:]); err != nil {
+		t.Fatalf("Unpack boot flags: %v", err)
+	}
+	if decoded.BootDeviceSelector != ipmi.BootDeviceSelectorForcePXE {
+		t.Fatalf("BootDeviceSelector round-trip: want PXE, got %v", decoded.BootDeviceSelector)
+	}
+}
+
+func TestHandleGetSystemBootOptions_NotSupported(t *testing.T) {
+	// Use a HAL whose GetBootFlags returns ErrNotSupported. The mock returns
+	// ErrNotSupported when no boot flags have been stored.
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	hctx := &HandlerContext{BMC: b}
+
+	req := []byte{byte(ipmi.BootOptionParamSelector_BootFlags)}
+	_, cc, err := handleGetSystemBootOptions(context.Background(), hctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CodeParamNotSupported {
+		t.Fatalf("want CodeParamNotSupported for ErrNotSupported, got %d", cc)
+	}
+}
+
+func TestHandleSetSystemBootOptions_OtherParam(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	hctx := &HandlerContext{BMC: b}
+
+	// Set In Progress (0x00) is not implemented by the handler; it must be
+	// silently accepted without touching the HAL.
+	req := []byte{byte(ipmi.BootOptionParamSelector_SetInProgress), 0x01}
+	_, cc, err := handleSetSystemBootOptions(context.Background(), hctx, req)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("want CodeOK for unimplemented param, got cc=%d err=%v", cc, err)
+	}
+	if ch.BootFlags != nil {
+		t.Fatalf("HAL SetBootFlags must not be called for non-BootFlags params")
+	}
+}
+
+func TestHandleSetSystemBootOptions_Truncated(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	hctx := &HandlerContext{BMC: b}
+
+	// BootFlags param selector but only 2 bytes of data (need 5).
+	req := []byte{byte(ipmi.BootOptionParamSelector_BootFlags), 0x01, 0x02}
+	_, cc, _ := handleSetSystemBootOptions(context.Background(), hctx, req)
+	if cc != CodeRequestDataTruncated {
+		t.Fatalf("want CodeRequestDataTruncated, got %d", cc)
+	}
+
+	// Empty request.
+	_, cc, _ = handleSetSystemBootOptions(context.Background(), hctx, nil)
+	if cc != CodeRequestDataTruncated {
+		t.Fatalf("empty request: want CodeRequestDataTruncated, got %d", cc)
+	}
+}
+
+func TestCodeFromHalErr(t *testing.T) {
+	if got := codeFromHalErr(nil); got != CodeOK {
+		t.Fatalf("nil: want CodeOK, got %d", got)
+	}
+	if got := codeFromHalErr(hal.ErrNotSupported); got != CodeParamNotSupported {
+		t.Fatalf("ErrNotSupported: want CodeParamNotSupported, got %d", got)
+	}
+	if got := codeFromHalErr(errors.New("boom")); got != CodeUnspecifiedError {
+		t.Fatalf("generic error: want CodeUnspecifiedError, got %d", got)
+	}
+}

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -9,19 +9,40 @@ import (
 // 0x00 means success; all other values indicate an error condition.
 // The constants below mirror the most commonly returned codes; handlers should
 // return the most specific code available.
+//
+// All value assignments are verified against:
+//
+//	IPMI v2.0 Rev 1.1, §5.2 Table 5-2, Completion Codes
+//	IPMI v2.0 Rev 1.1, §28.12 Table 28-12, Set System Boot Options
+//	IPMI v2.0 Rev 1.1, §28.13 Table 28-13, Get System Boot Options
 type CompletionCode uint8
 
+// Generic completion codes: 00h, C0h-FFh (§5.2 Table 5-2).
+// Command-specific completion codes: 80h-BEh (defined per-command).
 const (
-	CodeOK                    CompletionCode = 0x00
-	CodeInsufficientPrivilege CompletionCode = 0xD4
-	CodeNotSupportedInState   CompletionCode = 0xD5
-	CodeParamOutOfRange       CompletionCode = 0xC9
-	CodeRequestDataTruncated  CompletionCode = 0xC6
-	CodeRequestDataInvalid    CompletionCode = 0xCC
-	CodeCommandNotSupported   CompletionCode = 0xC1
-	CodeNodeBusy              CompletionCode = 0xC0
-	CodeParamNotSupported     CompletionCode = 0x80 // parameter not supported (e.g. Set/Get System Boot Options)
-	CodeUnspecifiedError      CompletionCode = 0xFF
+	CodeOK CompletionCode = 0x00 // 00h: Command Completed Normally.
+
+	// Generic error codes (§5.2 Table 5-2).
+	CodeNodeBusy            CompletionCode = 0xC0 // C0h: Node Busy.
+	CodeCommandNotSupported CompletionCode = 0xC1 // C1h: Invalid Command.
+
+	CodeParamOutOfRange      CompletionCode = 0xC9 // C9h: Parameter out of range. (§5.2 Table 5-2)
+	CodeRequestDataTruncated CompletionCode = 0xC6 // C6h: Request data truncated.
+	CodeRequestDataInvalid   CompletionCode = 0xCC // CCh: Invalid data field in Request.
+
+	CodeInsufficientPrivilege CompletionCode = 0xD4 // D4h: Insufficient privilege level or security restriction.
+	CodeNotSupportedInState   CompletionCode = 0xD5 // D5h: Command not supported in present state.
+
+	CodeUnspecifiedError CompletionCode = 0xFF // FFh: Unspecified error.
+
+	// Command-specific completion code (§28.12 Table 28-12, §28.13 Table 28-13):
+	// 80h = parameter not supported.  Defined for Set/Get System Boot Options
+	// when the requested boot option parameter selector is not implemented.
+	// Also defined for other config-parameter commands (e.g. §22.14a/b
+	// Set/Get System Info Parameters).  Separate from generic completion codes
+	// (00h, C0h-FFh); must only be returned by commands that explicitly define
+	// 80h in their command-specific completion code table.
+	CodeBootParamNotSupported CompletionCode = 0x80
 )
 
 // Handler processes a single IPMI command.

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -20,6 +20,7 @@ const (
 	CodeRequestDataInvalid    CompletionCode = 0xCC
 	CodeCommandNotSupported   CompletionCode = 0xC1
 	CodeNodeBusy              CompletionCode = 0xC0
+	CodeParamNotSupported     CompletionCode = 0x80 // parameter not supported (e.g. Set/Get System Boot Options)
 	CodeUnspecifiedError      CompletionCode = 0xFF
 )
 

--- a/pkg/server/crypto_test.go
+++ b/pkg/server/crypto_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestAesPadRoundTrip verifies the IPMI 2.0 AES-CBC-128 payload padding format
+// (spec §13.29): plain || pad bytes (1,2,3,...) || pad-length byte, total
+// length a multiple of 16.  decryptPayload must strip exactly the pad bytes
+// and the pad-length byte to recover the original payload.
+func TestAesPadRoundTrip(t *testing.T) {
+	k2 := bytes.Repeat([]byte{0x42}, 32)
+
+	cases := []int{
+		0, 1, 7, 13, 15, 16, 17, 31, 32, 33,
+	}
+	for _, n := range cases {
+		plain := make([]byte, n)
+		for i := range plain {
+			plain[i] = byte(i)
+		}
+
+		ct, err := encryptPayload(plain, k2)
+		if err != nil {
+			t.Fatalf("n=%d: encryptPayload failed: %v", n, err)
+		}
+
+		got, err := decryptPayload(ct, k2)
+		if err != nil {
+			t.Fatalf("n=%d: decryptPayload failed: %v", n, err)
+		}
+		if !bytes.Equal(got, plain) {
+			t.Fatalf("n=%d: round-trip mismatch\nwant % x\n got % x", n, plain, got)
+		}
+	}
+}
+
+// TestDecryptPayload_StripsPadding asserts that decryptPayload removes the
+// trailing pad bytes and pad-length byte rather than returning the full
+// decrypted block.  This is the regression guard for the boot-options handlers
+// that validate exact request lengths.
+func TestDecryptPayload_StripsPadding(t *testing.T) {
+	k2 := bytes.Repeat([]byte{0x07}, 32)
+
+	// A 13-byte IPMI message pads to 16 bytes (padLen=2 + pad-length byte).
+	plain := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c}
+	ct, err := encryptPayload(plain, k2)
+	if err != nil {
+		t.Fatalf("encryptPayload failed: %v", err)
+	}
+
+	got, err := decryptPayload(ct, k2)
+	if err != nil {
+		t.Fatalf("decryptPayload failed: %v", err)
+	}
+	if len(got) != len(plain) {
+		t.Fatalf("decryptPayload did not strip padding: got %d bytes, want %d", len(got), len(plain))
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -367,12 +367,33 @@ func (s *Server) sendRMCPPlusSession(addr net.Addr, payloadType, flags uint8, se
 // that already exist in helpers_hmac.go in the main package.
 // We reproduce small wrappers here to avoid importing ourselves.
 
+// decryptPayload decrypts an AES-CBC-128 confidential payload and strips the
+// IPMI 2.0 padding (spec §13.29).  The wire format is:
+//
+//	IV(16) || AES-CBC( payload || pad bytes || pad-length )
+//
+// where the final decrypted byte is the number of pad bytes (0..15).  The
+// returned slice is the original payload with pad bytes and the pad-length
+// byte removed.
 func decryptPayload(cipherText, k2 []byte) ([]byte, error) {
 	if len(cipherText) < 16 {
 		return nil, fmt.Errorf("ciphertext too short")
 	}
 	iv := cipherText[:16]
-	return decryptAES(cipherText[16:], k2[:16], iv)
+	padded, err := decryptAES(cipherText[16:], k2[:16], iv)
+	if err != nil {
+		return nil, err
+	}
+	if len(padded) == 0 {
+		return nil, fmt.Errorf("decrypted payload is empty")
+	}
+	padLen := int(padded[len(padded)-1])
+	// pad-length must fit within the trailing pad region; a value >= len-1
+	// would leave no payload and indicates a corrupted/invalid padding.
+	if padLen >= len(padded) {
+		return nil, fmt.Errorf("invalid AES pad length %d for %d-byte block", padLen, len(padded))
+	}
+	return padded[:len(padded)-1-padLen], nil
 }
 
 func encryptPayload(plain, k2 []byte) ([]byte, error) {

--- a/pkg/types/types_completion_code.go
+++ b/pkg/types/types_completion_code.go
@@ -2,38 +2,51 @@ package types
 
 type CompletionCode uint8
 
-// 5.2 Table 5 for generic completion codes
+// IPMI v2.0 Rev 1.1, section 5.2 Table 5-2, Completion Codes.
+//
+// IPMI v2.0 is backward-compatible with v1.5 for all completion codes.
+// The only differences from v1.5 Rev 1.2 Table 5-2 are:
+//   - D4h (modified): expanded from "Insufficient privilege level" to include
+//     "or other security-based restriction (e.g. disabled for firmware firewall)"
+//   - D6h (new): "Cannot execute command. Parameter is illegal because command
+//     sub-function has been disabled or is unavailable"
+//
+// Completion Code ranges:
+//   - 00h, C0h-FFh: Generic completion codes
+//   - 01h-7Eh:      Device-specific (OEM) codes
+//   - 80h-BEh:      Standard command-specific codes (per-command definitions)
+//   - All other:     Reserved
 const (
 	// GENERIC COMPLETION CODES 00h, C0h-FFh
-	CompletionCodeNormal                               CompletionCode = 0x00
-	CompletionCodeNodeBusy                             CompletionCode = 0xC0
-	CompletionCodeInvalidCommand                       CompletionCode = 0xC1
-	CompletionCodeInvalidCommandForLUN                 CompletionCode = 0xC2
-	CompletionCodeProcessTimeout                       CompletionCode = 0xC3
-	CompletionCodeOutOfSpace                           CompletionCode = 0xC4
-	CompletionCodeReservationCanceled                  CompletionCode = 0xC5
-	CompletionCodeRequestDataTruncated                 CompletionCode = 0xC6
-	CompletionCodeRequestDataLengthInvalid             CompletionCode = 0xC7
-	CompletionCodeRequestDataLengthLimitExceeded       CompletionCode = 0xC8
-	CompletionCodeParameterOutOfRange                  CompletionCode = 0xC9
-	CompletionCodeCannotReturnRequestedDataBytes       CompletionCode = 0xCA
-	CompletionCodeRequestedDataNotPresent              CompletionCode = 0xCB
-	CompletionCodeRequestDataFieldInvalid              CompletionCode = 0xCC
-	CompletionCodeIllegalCommand                       CompletionCode = 0xCD
-	CompletionCodeCannotProvideResponse                CompletionCode = 0xCE
-	CompletionCodeCannotExecuteDuplicatedRequest       CompletionCode = 0xCF
-	CompletionCodeCannotProvideResponseSDRRInUpdate    CompletionCode = 0xD0 // SDRR, SDR Repository
-	CompletionCodeCannotProvideResponseFirmwareUpdate  CompletionCode = 0xD1
-	CompletionCodeCannotProvideResponseBMCInitialize   CompletionCode = 0xD2
-	CompletionCodeDestinationUnavailable               CompletionCode = 0xD3
-	CompletionCodeCannotExecuteCommandSecurityRestrict CompletionCode = 0xD4
-	CompletionCodeCannotExecuteCommandNotSupported     CompletionCode = 0xD5
-	CompletionCodeCannotExecuteCommandSubFnDisabled    CompletionCode = 0xD6
-	CompletionCodeUnspecifiedError                     CompletionCode = 0xFF
+	CompletionCodeNormal                               CompletionCode = 0x00 // 00h: Command Completed Normally.
+	CompletionCodeNodeBusy                             CompletionCode = 0xC0 // C0h: Node Busy.
+	CompletionCodeInvalidCommand                       CompletionCode = 0xC1 // C1h: Invalid Command.
+	CompletionCodeInvalidCommandForLUN                 CompletionCode = 0xC2 // C2h: Command invalid for given LUN.
+	CompletionCodeProcessTimeout                       CompletionCode = 0xC3 // C3h: Timeout while processing command.
+	CompletionCodeOutOfSpace                           CompletionCode = 0xC4 // C4h: Out of space.
+	CompletionCodeReservationCanceled                  CompletionCode = 0xC5 // C5h: Reservation Canceled or Invalid Reservation ID.
+	CompletionCodeRequestDataTruncated                 CompletionCode = 0xC6 // C6h: Request data truncated.
+	CompletionCodeRequestDataLengthInvalid             CompletionCode = 0xC7 // C7h: Request data length invalid.
+	CompletionCodeRequestDataLengthLimitExceeded       CompletionCode = 0xC8 // C8h: Request data field length limit exceeded.
+	CompletionCodeParameterOutOfRange                  CompletionCode = 0xC9 // C9h: Parameter out of range.
+	CompletionCodeCannotReturnRequestedDataBytes       CompletionCode = 0xCA // CAh: Cannot return number of requested data bytes.
+	CompletionCodeRequestedDataNotPresent              CompletionCode = 0xCB // CBh: Requested Sensor, data, or record not present.
+	CompletionCodeRequestDataFieldInvalid              CompletionCode = 0xCC // CCh: Invalid data field in Request.
+	CompletionCodeIllegalCommand                       CompletionCode = 0xCD // CDh: Command illegal for specified sensor or record type.
+	CompletionCodeCannotProvideResponse                CompletionCode = 0xCE // CEh: Command response could not be provided.
+	CompletionCodeCannotExecuteDuplicatedRequest       CompletionCode = 0xCF // CFh: Cannot execute duplicated request.
+	CompletionCodeCannotProvideResponseSDRRInUpdate    CompletionCode = 0xD0 // D0h: SDR Repository in update mode.
+	CompletionCodeCannotProvideResponseFirmwareUpdate  CompletionCode = 0xD1 // D1h: Device in firmware update mode.
+	CompletionCodeCannotProvideResponseBMCInitialize   CompletionCode = 0xD2 // D2h: BMC initialization in progress.
+	CompletionCodeDestinationUnavailable               CompletionCode = 0xD3 // D3h: Destination unavailable.
+	CompletionCodeCannotExecuteCommandSecurityRestrict CompletionCode = 0xD4 // D4h: Cannot execute command due to insufficient privilege level or other security-based restriction.
+	CompletionCodeCannotExecuteCommandNotSupported     CompletionCode = 0xD5 // D5h: Cannot execute command. Command, or request parameter(s), not supported in present state.
+	CompletionCodeCannotExecuteCommandSubFnDisabled    CompletionCode = 0xD6 // D6h: Cannot execute command. Parameter is illegal because command sub-function has been disabled or is unavailable.
+	CompletionCodeUnspecifiedError                     CompletionCode = 0xFF // FFh: Unspecified error.
 
-	// DEVICE-SPECIFIC (OEM) CODES 01h-7Eh
+	// DEVICE-SPECIFIC (OEM) CODES 01h-7Eh — interpretation requires a-priori device knowledge.
 
-	// COMMAND-SPECIFIC CODES 80h-BEh
+	// COMMAND-SPECIFIC CODES 80h-BEh — defined per-command in the relevant command specification sections.
 )
 
 var CC = map[uint8]string{
@@ -64,7 +77,7 @@ var CC = map[uint8]string{
 	0xff: "Unspecified error",
 }
 
-// String return description of global completion code.
+// String return description of generic completion code.
 // Please use StrCC function to get description for any completion code
 // returned for specific command response.
 func (cc CompletionCode) String() string {

--- a/test/e2e/chassis_codec_test.sh
+++ b/test/e2e/chassis_codec_test.sh
@@ -166,16 +166,16 @@ test_set_boot_flags_zero_data() {
 	return 1
 }
 
-# Chassis Control with a reserved action (0x0F) — must return C8h (Parameter out
+# Chassis Control with a reserved action (0x0F) — must return C9h (Parameter out
 # of range) per §5.2 Table 5-2.  This validates the CodeParamOutOfRange fix
 # (was incorrectly 0xC9 before the spec alignment).
 test_chassis_control_unknown_action() {
 	local out
 	out=$(run_ipmitool raw 0x00 0x02 0x0F 2>&1) && { echo "${out}" >&2; return 1; }
-	if echo "${out}" | grep -q "rsp=0xc8"; then
+	if echo "${out}" | grep -q "rsp=0xc9"; then
 		return 0
 	fi
-	echo "  expected rsp=0xc8, got: ${out}" >&2
+	echo "  expected rsp=0xc9, got: ${out}" >&2
 	return 1
 }
 
@@ -198,10 +198,10 @@ failures=0
 e2e_run_test "chassis power cycle (PowerCycle dispatch)" test_power_cycle || ((failures++)) || true
 e2e_run_test "set/get boot flags PXE round-trip" test_bootdev_pxe_round_trip || ((failures++)) || true
 e2e_run_test "set/get boot flags CDROM round-trip" test_bootdev_cdrom_round_trip || ((failures++)) || true
- e2e_run_test "get unsupported boot param → 80h" test_get_unsupported_boot_param || ((failures++)) || true
- e2e_run_test "set unsupported boot param → 80h" test_set_unsupported_boot_param || ((failures++)) || true
- e2e_run_test "set boot flags with 0 data bytes → OK" test_set_boot_flags_zero_data || ((failures++)) || true
- e2e_run_test "chassis control unknown action → C8h" test_chassis_control_unknown_action || ((failures++)) || true
- e2e_run_test "chassis status always 4 bytes" test_chassis_status_always_4bytes || ((failures++)) || true
+e2e_run_test "get unsupported boot param → 80h" test_get_unsupported_boot_param || ((failures++)) || true
+e2e_run_test "set unsupported boot param → 80h" test_set_unsupported_boot_param || ((failures++)) || true
+e2e_run_test "set boot flags with 0 data bytes → OK" test_set_boot_flags_zero_data || ((failures++)) || true
+e2e_run_test "chassis control unknown action → C9h" test_chassis_control_unknown_action || ((failures++)) || true
+e2e_run_test "chassis status always 4 bytes" test_chassis_status_always_4bytes || ((failures++)) || true
 
 e2e_report "Chassis Codec E2E" "${failures}"

--- a/test/e2e/chassis_codec_test.sh
+++ b/test/e2e/chassis_codec_test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# chassis_codec_test.sh — E2E for the typed chassis codec + Set/Get System
+# Boot Options + PowerCycle dispatch (branch feat/typed-chassis-codec).
+#
+# Starts goipmi-server (mock HAL) and drives it with ipmitool, so the server is
+# validated by an external, spec-faithful client rather than our own client.
+#
+# Covers the acceptance criteria from docs/upstream-plan-2026-06.md §B.8:
+#   - `chassis power cycle` no longer returns CodeParamOutOfRange
+#   - Set/Get System Boot Options (Boot Flags) round-trips the typed structure
+#
+# Environment variables:
+#   GOIPMI_SERVER_PORT – server listen port (default: random high port)
+#   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
+#
+# Requires: make build  (or: make test-e2e-chassis-codec)
+#
+# Usage:
+#   ./test/e2e/chassis_codec_test.sh
+#   GOIPMI_SERVER_PORT=9623 ./test/e2e/chassis_codec_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-$((9800 + RANDOM % 1000))}"
+PORT="${GOIPMI_SERVER_PORT}"
+USER="${GOIPMI_USER:-ADMIN}"
+PASS="${GOIPMI_PASS:-ADMIN}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+
+# ---------------------------------------------------------------------------
+# Find or choose an ipmitool (local install, else Docker image).
+# ---------------------------------------------------------------------------
+IPMITOOL_BIN="${IPMITOOL_BIN:-}"
+if [ -z "${IPMITOOL_BIN}" ]; then
+	if command -v ipmitool &>/dev/null; then
+		IPMITOOL_BIN="ipmitool"
+	fi
+fi
+
+if [ -n "${IPMITOOL_BIN}" ]; then
+	echo "==> Using ipmitool: ${IPMITOOL_BIN}"
+	IPMITOOL_RUN="${IPMITOOL_BIN}"
+else
+	echo "==> ipmitool not found locally, will use Docker: ${IPMITOOL_IMAGE}"
+	IPMITOOL_RUN="docker run --rm --network host ${IPMITOOL_IMAGE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Start the server
+# ---------------------------------------------------------------------------
+cleanup() {
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo "==> Stopping goipmi-server (pid ${SERVER_PID}) ..."
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+}
+
+trap cleanup EXIT
+
+echo "==> Starting goipmi-server on :${PORT} ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	"${SERVER_BIN}" &
+SERVER_PID=$!
+sleep 1
+
+if ! ss -uln | grep -q ":${PORT} "; then
+	echo -e "${RED}ERROR: server failed to start${NC}" >&2
+	exit 1
+fi
+
+IPMI_ARGS=(-H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus)
+run_ipmitool() {
+	# shellcheck disable=SC2086
+	${IPMITOOL_RUN} "${IPMI_ARGS[@]}" "$@"
+}
+# ---------------------------------------------------------------------------
+# Run the tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Chassis Codec E2E: ipmitool → goipmi-server (:${PORT})"
+echo "========================================"
+
+# chassis power cycle: previously fell through to CodeParamOutOfRange on the
+# reference server. The mock HAL now exposes PowerCycle, so ipmitool must
+# report "Cycle" and exit 0.
+test_power_cycle() {
+	local out
+	out=$(run_ipmitool chassis power cycle 2>&1) || { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "Cycle"; then
+		return 0
+	fi
+	echo "  unexpected power cycle output: ${out}" >&2
+	return 1
+}
+# `chassis bootdev pxe` issues Set System Boot Options (param 5, Boot Flags)
+# with BootDeviceSelector=ForcePXE.  Read it back with `bootparam get 5` and
+# verify the typed structure round-trips to "Force PXE".
+test_bootdev_pxe_round_trip() {
+	local out
+	out=$(run_ipmitool chassis bootdev pxe 2>&1) || { echo "${out}" >&2; return 1; }
+	out=$(run_ipmitool chassis bootparam get 5 2>&1) || { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "Force PXE"; then
+		return 0
+	fi
+	echo "  PXE round-trip mismatch, got: ${out}" >&2
+	return 1
+}
+# Switch the boot device to CD/DVD and verify the selector round-trips to
+# "Force Boot from CD/DVD" on read-back.
+test_bootdev_cdrom_round_trip() {
+	local out
+	out=$(run_ipmitool chassis bootdev cdrom 2>&1) || { echo "${out}" >&2; return 1; }
+	out=$(run_ipmitool chassis bootparam get 5 2>&1) || { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "Force Boot from CD/DVD"; then
+		return 0
+	fi
+	echo "  CDROM round-trip mismatch, got: ${out}" >&2
+	return 1
+}
+
+# Get System Boot Options for param 0 (Set In Progress) – handler does not
+# implement this selector; must return completion code 80h per §28.13 Table 28-13.
+test_get_unsupported_boot_param() {
+	local out
+	out=$(run_ipmitool raw 0x00 0x09 0x00 0x00 0x00 2>&1) && { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "rsp=0x80"; then
+		return 0
+	fi
+	echo "  expected rsp=0x80, got: ${out}" >&2
+	return 1
+}
+# Set System Boot Options for param 0 (Set In Progress) – handler does not
+# implement this selector; must return completion code 80h per §28.12 Table 28-12.
+test_set_unsupported_boot_param() {
+	local out
+	out=$(run_ipmitool raw 0x00 0x08 0x00 0x01 2>&1) && { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "rsp=0x80"; then
+		return 0
+	fi
+	echo "  expected rsp=0x80, got: ${out}" >&2
+	return 1
+}
+# Set Boot Flags (param 5) with 0 bytes of parameter data – spec §28.12 allows
+# valid-bit toggling without affecting the current parameter value.
+test_set_boot_flags_zero_data() {
+	# First store real flags so a subsequent read-back succeeds.
+	run_ipmitool chassis bootdev pxe 2>&1 || { echo "  failed to set boot flags" >&2; return 1; }
+	# Now set param 5 with no data bytes.
+	run_ipmitool raw 0x00 0x08 0x05 2>&1 || { echo "  raw 0x00 0x08 0x05 failed" >&2; return 1; }
+	# Read-back must still show Force PXE.
+	local out
+	out=$(run_ipmitool chassis bootparam get 5 2>&1) || { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "Force PXE"; then
+		return 0
+	fi
+	echo "  PXE flags lost after 0-byte set: ${out}" >&2
+	return 1
+}
+
+# Chassis Control with a reserved action (0x0F) — must return C8h (Parameter out
+# of range) per §5.2 Table 5-2.  This validates the CodeParamOutOfRange fix
+# (was incorrectly 0xC9 before the spec alignment).
+test_chassis_control_unknown_action() {
+	local out
+	out=$(run_ipmitool raw 0x00 0x02 0x0F 2>&1) && { echo "${out}" >&2; return 1; }
+	if echo "${out}" | grep -q "rsp=0xc8"; then
+		return 0
+	fi
+	echo "  expected rsp=0xc8, got: ${out}" >&2
+	return 1
+}
+
+# Get Chassis Status response must always include byte 3 (front-panel button
+# disables) per §28.2 Table 28-3: "Return as 00h if the panel button disable
+# function is not supported."  This validates the Pack() always-4-bytes fix.
+test_chassis_status_always_4bytes() {
+	local out
+	out=$(run_ipmitool raw 0x00 0x01 2>&1)
+	# Raw response: " 00 00 40 00" (4 data bytes after completion code).
+	local bytes
+	bytes=$(echo "${out}" | tr ' ' '\n' | grep -cE '^[0-9a-fA-F]{2}$')
+	if [ "${bytes}" -ge 4 ]; then
+		return 0
+	fi
+	echo "  want >=4 data bytes, got ${bytes}: ${out}" >&2
+	return 1
+}
+failures=0
+e2e_run_test "chassis power cycle (PowerCycle dispatch)" test_power_cycle || ((failures++)) || true
+e2e_run_test "set/get boot flags PXE round-trip" test_bootdev_pxe_round_trip || ((failures++)) || true
+e2e_run_test "set/get boot flags CDROM round-trip" test_bootdev_cdrom_round_trip || ((failures++)) || true
+ e2e_run_test "get unsupported boot param → 80h" test_get_unsupported_boot_param || ((failures++)) || true
+ e2e_run_test "set unsupported boot param → 80h" test_set_unsupported_boot_param || ((failures++)) || true
+ e2e_run_test "set boot flags with 0 data bytes → OK" test_set_boot_flags_zero_data || ((failures++)) || true
+ e2e_run_test "chassis control unknown action → C8h" test_chassis_control_unknown_action || ((failures++)) || true
+ e2e_run_test "chassis status always 4 bytes" test_chassis_status_always_4bytes || ((failures++)) || true
+
+e2e_report "Chassis Codec E2E" "${failures}"


### PR DESCRIPTION
Replace hand-written byte assembly in the chassis handlers with typed codec
round-trips and complete the spec Table 28-3 action set. Fix decryptPayload to
strip exactly padLen+1 trailing bytes.