### PR TITLE
feat(server): support cipher suite 17 (SHA256) and configurable cipher advertisement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,7 @@ test-e2e-self: build
 test-e2e-chassis-codec: build
 	./test/e2e/chassis_codec_test.sh
 
-test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec
+test-e2e-cipher: build
+	./test/e2e/cipher_suite_test.sh
+
+test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec test-e2e-cipher

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
@@ -43,6 +45,17 @@ func run() error {
 	copy(guid[:], "go-ipmi-e2e\x00\x00\x00\x00")
 
 	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clock.Real))
+
+	// Optional cipher suite override. GOIPMI_SERVER_CIPHER_SUITES is a
+	// comma-separated list of RMCP+ cipher suite IDs (e.g. "3,17" or
+	// "1,2,15,16"). Empty/unset falls back to bmc.DefaultCipherSuites.
+	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_CIPHER_SUITES")); raw != "" {
+		ids, err := parseCipherSuites(raw)
+		if err != nil {
+			return err
+		}
+		b.SetCipherSuites(ids)
+	}
 
 	// User credentials for IPMI session authentication.
 	userName := os.Getenv("GOIPMI_SERVER_USER")
@@ -90,9 +103,40 @@ func run() error {
 	}()
 
 	fmt.Printf("goipmi-server: listening on %s (lanplus, user=%s, pass=%s)\n", addr, userName, userPass)
+	if len(b.ResolvedCipherSuites()) != 0 {
+		fmt.Printf("goipmi-server: cipher suites: %v\n", b.ResolvedCipherSuites())
+	}
 	if err := srv.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("serve: %w", err)
 	}
 	fmt.Println("goipmi-server: stopped")
 	return nil
+}
+
+// parseCipherSuites parses a comma-separated list of cipher suite IDs from the
+// GOIPMI_SERVER_CIPHER_SUITES env var and validates each against the reference
+// server's supported set. Returns a descriptive error for bad input rather than
+// letting bmc.SetCipherSuites panic.
+func parseCipherSuites(raw string) ([]bmc.CipherSuiteID, error) {
+	parts := strings.Split(raw, ",")
+	ids := make([]bmc.CipherSuiteID, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return nil, fmt.Errorf("invalid cipher suite id %q: expected an integer 0..255", p)
+		}
+		id := bmc.CipherSuiteID(n)
+		if !bmc.SupportedCipherSuite(id) {
+			return nil, fmt.Errorf("cipher suite %d is not implemented by the reference server", id)
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("GOIPMI_SERVER_CIPHER_SUITES contained no valid ids")
+	}
+	return ids, nil
 }

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bougou/go-ipmi/pkg/hal/mock"
 	"github.com/bougou/go-ipmi/pkg/server"
 	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 func main() {
@@ -117,9 +118,9 @@ func run() error {
 // GOIPMI_SERVER_CIPHER_SUITES env var and validates each against the reference
 // server's supported set. Returns a descriptive error for bad input rather than
 // letting bmc.SetCipherSuites panic.
-func parseCipherSuites(raw string) ([]bmc.CipherSuiteID, error) {
+func parseCipherSuites(raw string) ([]ipmi.CipherSuiteID, error) {
 	parts := strings.Split(raw, ",")
-	ids := make([]bmc.CipherSuiteID, 0, len(parts))
+	ids := make([]ipmi.CipherSuiteID, 0, len(parts))
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
 		if p == "" {
@@ -129,7 +130,7 @@ func parseCipherSuites(raw string) ([]bmc.CipherSuiteID, error) {
 		if err != nil || n < 0 || n > 255 {
 			return nil, fmt.Errorf("invalid cipher suite id %q: expected an integer 0..255", p)
 		}
-		id := bmc.CipherSuiteID(n)
+		id := ipmi.CipherSuiteID(n)
 		if !bmc.SupportedCipherSuite(id) {
 			return nil, fmt.Errorf("cipher suite %d is not implemented by the reference server", id)
 		}

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -6,6 +6,8 @@
 package bmc
 
 import (
+	"fmt"
+
 	"github.com/bougou/go-ipmi/pkg/clock"
 	"github.com/bougou/go-ipmi/pkg/hal"
 )
@@ -34,6 +36,13 @@ type BMC struct {
 	GUID [16]byte
 	KG   []byte // BMC key (Kg); nil means "one-key" mode using Kuid only
 
+	// CipherSuites is the set of RMCP+ cipher suites the server advertises and
+	// accepts during the Open Session handshake. Defaults to
+	// [DefaultCipherSuites] when nil. Each suite must be supported by the
+	// reference server (see [SupportedCipherSuite]); this is validated in
+	// [WithCipherSuites].
+	CipherSuites []CipherSuiteID
+
 	Users    *UserStore
 	Channels *ChannelStore
 	Sessions *SessionStore
@@ -60,6 +69,41 @@ func WithClock(c clock.Clock) Option {
 	return func(b *BMC) { b.clock = c }
 }
 
+// WithCipherSuites sets the RMCP+ cipher suites the server advertises and
+// accepts. Each ID must be a suite the reference server implements
+// ([SupportedCipherSuite]); otherwise an error is returned by New and the
+// default suite list is kept. Pass nil/empty to restore [DefaultCipherSuites].
+func WithCipherSuites(ids []CipherSuiteID) Option {
+	return func(b *BMC) {
+		b.setCipherSuites(ids)
+	}
+}
+
+// ResolvedCipherSuites returns the cipher suite list to use for advertisement,
+// falling back to [DefaultCipherSuites] when none was configured.
+func (b *BMC) ResolvedCipherSuites() []CipherSuiteID {
+	if len(b.CipherSuites) > 0 {
+		return b.CipherSuites
+	}
+	return DefaultCipherSuites
+}
+
+// SetCipherSuites replaces the configured cipher suite list. Each ID must be
+// supported by the reference server ([SupportedCipherSuite]); an unsupported
+// ID panics, failing at configuration time rather than at handshake time.
+func (b *BMC) SetCipherSuites(ids []CipherSuiteID) {
+	b.setCipherSuites(ids)
+}
+
+func (b *BMC) setCipherSuites(ids []CipherSuiteID) {
+	if len(ids) == 0 {
+		b.CipherSuites = nil
+		return
+	}
+	validateCipherSuites(ids)
+	b.CipherSuites = append(b.CipherSuites[:0:0], ids...)
+}
+
 // New creates a BMC with sane defaults.
 //
 // h is required; it provides hardware access.  opts are applied in order.
@@ -80,6 +124,17 @@ func New(info DeviceInfo, guid [16]byte, h hal.HAL, opts ...Option) *BMC {
 	// Re-apply clock to SessionStore after options in case WithClock was used.
 	b.Sessions.clock = b.clock
 	return b
+}
+
+// validateCipherSuites panics if any configured cipher suite is not implemented
+// by the reference server. Failing at construction avoids runtime handshake
+// failures from advertising suites we cannot negotiate.
+func validateCipherSuites(ids []CipherSuiteID) {
+	for _, id := range ids {
+		if !SupportedCipherSuite(id) {
+			panic(fmt.Sprintf("bmc: cipher suite %d is not implemented by the reference server", id))
+		}
+	}
 }
 
 // HAL returns the underlying hardware abstraction.

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bougou/go-ipmi/pkg/clock"
 	"github.com/bougou/go-ipmi/pkg/hal"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 // DeviceInfo contains the identification data returned by Get Device ID.
@@ -41,7 +42,7 @@ type BMC struct {
 	// [DefaultCipherSuites] when nil. Each suite must be supported by the
 	// reference server (see [SupportedCipherSuite]); this is validated in
 	// [WithCipherSuites].
-	CipherSuites []CipherSuiteID
+	CipherSuites []ipmi.CipherSuiteID
 
 	Users    *UserStore
 	Channels *ChannelStore
@@ -73,7 +74,7 @@ func WithClock(c clock.Clock) Option {
 // accepts. Each ID must be a suite the reference server implements
 // ([SupportedCipherSuite]); otherwise an error is returned by New and the
 // default suite list is kept. Pass nil/empty to restore [DefaultCipherSuites].
-func WithCipherSuites(ids []CipherSuiteID) Option {
+func WithCipherSuites(ids []ipmi.CipherSuiteID) Option {
 	return func(b *BMC) {
 		b.setCipherSuites(ids)
 	}
@@ -81,7 +82,7 @@ func WithCipherSuites(ids []CipherSuiteID) Option {
 
 // ResolvedCipherSuites returns the cipher suite list to use for advertisement,
 // falling back to [DefaultCipherSuites] when none was configured.
-func (b *BMC) ResolvedCipherSuites() []CipherSuiteID {
+func (b *BMC) ResolvedCipherSuites() []ipmi.CipherSuiteID {
 	if len(b.CipherSuites) > 0 {
 		return b.CipherSuites
 	}
@@ -91,11 +92,11 @@ func (b *BMC) ResolvedCipherSuites() []CipherSuiteID {
 // SetCipherSuites replaces the configured cipher suite list. Each ID must be
 // supported by the reference server ([SupportedCipherSuite]); an unsupported
 // ID panics, failing at configuration time rather than at handshake time.
-func (b *BMC) SetCipherSuites(ids []CipherSuiteID) {
+func (b *BMC) SetCipherSuites(ids []ipmi.CipherSuiteID) {
 	b.setCipherSuites(ids)
 }
 
-func (b *BMC) setCipherSuites(ids []CipherSuiteID) {
+func (b *BMC) setCipherSuites(ids []ipmi.CipherSuiteID) {
 	if len(ids) == 0 {
 		b.CipherSuites = nil
 		return
@@ -129,7 +130,7 @@ func New(info DeviceInfo, guid [16]byte, h hal.HAL, opts ...Option) *BMC {
 // validateCipherSuites panics if any configured cipher suite is not implemented
 // by the reference server. Failing at construction avoids runtime handshake
 // failures from advertising suites we cannot negotiate.
-func validateCipherSuites(ids []CipherSuiteID) {
+func validateCipherSuites(ids []ipmi.CipherSuiteID) {
 	for _, id := range ids {
 		if !SupportedCipherSuite(id) {
 			panic(fmt.Sprintf("bmc: cipher suite %d is not implemented by the reference server", id))

--- a/pkg/bmc/cipher_suite.go
+++ b/pkg/bmc/cipher_suite.go
@@ -8,7 +8,12 @@ package bmc
 type CipherSuiteID uint8
 
 const (
+	CipherSuiteID0  CipherSuiteID = 0  // RAKP-None + Integrity-None + Confidentiality-None (unauthenticated, unencrypted)
+	CipherSuiteID1  CipherSuiteID = 1  // RAKP-HMAC-SHA1 + Integrity-None + Confidentiality-None
+	CipherSuiteID2  CipherSuiteID = 2  // RAKP-HMAC-SHA1 + HMAC-SHA1-96 + Confidentiality-None
 	CipherSuiteID3  CipherSuiteID = 3  // RAKP-HMAC-SHA1 + HMAC-SHA1-96 + AES-CBC-128 (spec-mandatory)
+	CipherSuiteID15 CipherSuiteID = 15 // RAKP-HMAC-SHA256 + Integrity-None + Confidentiality-None
+	CipherSuiteID16 CipherSuiteID = 16 // RAKP-HMAC-SHA256 + HMAC-SHA256-128 + Confidentiality-None
 	CipherSuiteID17 CipherSuiteID = 17 // RAKP-HMAC-SHA256 + HMAC-SHA256-128 + AES-CBC-128
 )
 
@@ -20,22 +25,27 @@ var DefaultCipherSuites = []CipherSuiteID{CipherSuiteID3, CipherSuiteID17}
 // CipherSuiteAlgorithms expands a cipher suite ID into its auth / integrity /
 // confidentiality algorithm codes (spec §22.15.2). ok is false for IDs whose
 // algorithm triple is not known to this build.
+//
+// Suite 0 (AuthAlgNone) is intentionally NOT in DefaultCipherSuites: selecting
+// it disables RAKP authentication entirely, so the session is established
+// without any password verification. Operators who want this must add it
+// explicitly via [WithCipherSuites] / [BMC.SetCipherSuites].
 func CipherSuiteAlgorithms(id CipherSuiteID) (auth AuthAlg, integ IntegrityAlg, crypt CryptAlg, ok bool) {
 	switch id {
+	case CipherSuiteID0:
+		return AuthAlgNone, IntegrityAlgNone, CryptAlgNone, true
+	case CipherSuiteID1:
+		return AuthAlgHMACSHA1, IntegrityAlgNone, CryptAlgNone, true
+	case CipherSuiteID2:
+		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgNone, true
 	case CipherSuiteID3:
 		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgAESCBC128, true
+	case CipherSuiteID15:
+		return AuthAlgHMACSHA256, IntegrityAlgNone, CryptAlgNone, true
+	case CipherSuiteID16:
+		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgNone, true
 	case CipherSuiteID17:
 		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgAESCBC128, true
-	case 0:
-		return AuthAlgNone, IntegrityAlgNone, CryptAlgNone, true
-	case 1:
-		return AuthAlgHMACSHA1, IntegrityAlgNone, CryptAlgNone, true
-	case 2:
-		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgNone, true
-	case 15:
-		return AuthAlgHMACSHA256, IntegrityAlgNone, CryptAlgNone, true
-	case 16:
-		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgNone, true
 	default:
 		return 0, 0, 0, false
 	}

--- a/pkg/bmc/cipher_suite.go
+++ b/pkg/bmc/cipher_suite.go
@@ -1,0 +1,75 @@
+package bmc
+
+// CipherSuiteID identifies an IPMI 2.0 RMCP+ cipher suite (spec §22.15.2).
+//
+// The bmc package mirrors this type (rather than importing pkg/types) to keep
+// its dependency surface minimal, consistent with the existing AuthAlg /
+// IntegrityAlg / CryptAlg mirrors in session.go.
+type CipherSuiteID uint8
+
+const (
+	CipherSuiteID3  CipherSuiteID = 3  // RAKP-HMAC-SHA1 + HMAC-SHA1-96 + AES-CBC-128 (spec-mandatory)
+	CipherSuiteID17 CipherSuiteID = 17 // RAKP-HMAC-SHA256 + HMAC-SHA256-128 + AES-CBC-128
+)
+
+// DefaultCipherSuites is the cipher suite set advertised when no explicit
+// configuration is provided. It contains the spec-mandatory suite 3 plus the
+// recommended SHA256 suite 17.
+var DefaultCipherSuites = []CipherSuiteID{CipherSuiteID3, CipherSuiteID17}
+
+// CipherSuiteAlgorithms expands a cipher suite ID into its auth / integrity /
+// confidentiality algorithm codes (spec §22.15.2). ok is false for IDs whose
+// algorithm triple is not known to this build.
+func CipherSuiteAlgorithms(id CipherSuiteID) (auth AuthAlg, integ IntegrityAlg, crypt CryptAlg, ok bool) {
+	switch id {
+	case CipherSuiteID3:
+		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgAESCBC128, true
+	case CipherSuiteID17:
+		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgAESCBC128, true
+	case 0:
+		return AuthAlgNone, IntegrityAlgNone, CryptAlgNone, true
+	case 1:
+		return AuthAlgHMACSHA1, IntegrityAlgNone, CryptAlgNone, true
+	case 2:
+		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgNone, true
+	case 15:
+		return AuthAlgHMACSHA256, IntegrityAlgNone, CryptAlgNone, true
+	case 16:
+		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgNone, true
+	default:
+		return 0, 0, 0, false
+	}
+}
+
+// serverImplementedAlgorithms reports whether the reference server can perform
+// the given algorithm triple end-to-end (advertise, negotiate, compute).
+func serverImplementedAlgorithms(auth AuthAlg, integ IntegrityAlg, crypt CryptAlg) bool {
+	switch auth {
+	case AuthAlgNone, AuthAlgHMACSHA1, AuthAlgHMACSHA256:
+	default:
+		return false
+	}
+	switch integ {
+	case IntegrityAlgNone, IntegrityAlgHMACSHA1_96, IntegrityAlgHMACSHA256_128:
+	default:
+		return false
+	}
+	switch crypt {
+	case CryptAlgNone, CryptAlgAESCBC128:
+	default:
+		return false
+	}
+	return true
+}
+
+// SupportedCipherSuite reports whether the reference server implements every
+// algorithm in the named cipher suite. Configuring an unsupported suite would
+// cause a runtime handshake failure, so callers validate with this before
+// installing a cipher suite list.
+func SupportedCipherSuite(id CipherSuiteID) bool {
+	auth, integ, crypt, ok := CipherSuiteAlgorithms(id)
+	if !ok {
+		return false
+	}
+	return serverImplementedAlgorithms(auth, integ, crypt)
+}

--- a/pkg/bmc/cipher_suite.go
+++ b/pkg/bmc/cipher_suite.go
@@ -1,26 +1,13 @@
 package bmc
 
-// CipherSuiteID identifies an IPMI 2.0 RMCP+ cipher suite (spec §22.15.2).
-//
-// The bmc package mirrors this type (rather than importing pkg/types) to keep
-// its dependency surface minimal, consistent with the existing AuthAlg /
-// IntegrityAlg / CryptAlg mirrors in session.go.
-type CipherSuiteID uint8
-
-const (
-	CipherSuiteID0  CipherSuiteID = 0  // RAKP-None + Integrity-None + Confidentiality-None (unauthenticated, unencrypted)
-	CipherSuiteID1  CipherSuiteID = 1  // RAKP-HMAC-SHA1 + Integrity-None + Confidentiality-None
-	CipherSuiteID2  CipherSuiteID = 2  // RAKP-HMAC-SHA1 + HMAC-SHA1-96 + Confidentiality-None
-	CipherSuiteID3  CipherSuiteID = 3  // RAKP-HMAC-SHA1 + HMAC-SHA1-96 + AES-CBC-128 (spec-mandatory)
-	CipherSuiteID15 CipherSuiteID = 15 // RAKP-HMAC-SHA256 + Integrity-None + Confidentiality-None
-	CipherSuiteID16 CipherSuiteID = 16 // RAKP-HMAC-SHA256 + HMAC-SHA256-128 + Confidentiality-None
-	CipherSuiteID17 CipherSuiteID = 17 // RAKP-HMAC-SHA256 + HMAC-SHA256-128 + AES-CBC-128
+import (
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 // DefaultCipherSuites is the cipher suite set advertised when no explicit
 // configuration is provided. It contains the spec-mandatory suite 3 plus the
 // recommended SHA256 suite 17.
-var DefaultCipherSuites = []CipherSuiteID{CipherSuiteID3, CipherSuiteID17}
+var DefaultCipherSuites = []ipmi.CipherSuiteID{ipmi.CipherSuiteID3, ipmi.CipherSuiteID17}
 
 // CipherSuiteAlgorithms expands a cipher suite ID into its auth / integrity /
 // confidentiality algorithm codes (spec §22.15.2). ok is false for IDs whose
@@ -30,21 +17,21 @@ var DefaultCipherSuites = []CipherSuiteID{CipherSuiteID3, CipherSuiteID17}
 // it disables RAKP authentication entirely, so the session is established
 // without any password verification. Operators who want this must add it
 // explicitly via [WithCipherSuites] / [BMC.SetCipherSuites].
-func CipherSuiteAlgorithms(id CipherSuiteID) (auth AuthAlg, integ IntegrityAlg, crypt CryptAlg, ok bool) {
+func CipherSuiteAlgorithms(id ipmi.CipherSuiteID) (auth AuthAlg, integ IntegrityAlg, crypt CryptAlg, ok bool) {
 	switch id {
-	case CipherSuiteID0:
+	case ipmi.CipherSuiteID0:
 		return AuthAlgNone, IntegrityAlgNone, CryptAlgNone, true
-	case CipherSuiteID1:
+	case ipmi.CipherSuiteID1:
 		return AuthAlgHMACSHA1, IntegrityAlgNone, CryptAlgNone, true
-	case CipherSuiteID2:
+	case ipmi.CipherSuiteID2:
 		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgNone, true
-	case CipherSuiteID3:
+	case ipmi.CipherSuiteID3:
 		return AuthAlgHMACSHA1, IntegrityAlgHMACSHA1_96, CryptAlgAESCBC128, true
-	case CipherSuiteID15:
+	case ipmi.CipherSuiteID15:
 		return AuthAlgHMACSHA256, IntegrityAlgNone, CryptAlgNone, true
-	case CipherSuiteID16:
+	case ipmi.CipherSuiteID16:
 		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgNone, true
-	case CipherSuiteID17:
+	case ipmi.CipherSuiteID17:
 		return AuthAlgHMACSHA256, IntegrityAlgHMACSHA256_128, CryptAlgAESCBC128, true
 	default:
 		return 0, 0, 0, false
@@ -76,7 +63,7 @@ func serverImplementedAlgorithms(auth AuthAlg, integ IntegrityAlg, crypt CryptAl
 // algorithm in the named cipher suite. Configuring an unsupported suite would
 // cause a runtime handshake failure, so callers validate with this before
 // installing a cipher suite list.
-func SupportedCipherSuite(id CipherSuiteID) bool {
+func SupportedCipherSuite(id ipmi.CipherSuiteID) bool {
 	auth, integ, crypt, ok := CipherSuiteAlgorithms(id)
 	if !ok {
 		return false

--- a/pkg/client/client_auth_code.go
+++ b/pkg/client/client_auth_code.go
@@ -338,9 +338,31 @@ func (c *Client) generate_rakp3_authcode() ([]byte, error) {
 }
 
 // 13.31 RMCP+ Authenticated Key-Exchange Protocol (RAKP)
-// 13.28
-// the client use this method to verify the authcode returned in rakp4
+// 13.28 Authentication, Integrity, and Confidentiality Algorithm Numbers
+//
+// generate_rakp4_authcode computes the Integrity Check Value the remote
+// console uses to verify RAKP Message 4 from the BMC.
+//
+// Per spec §13.28.1 / §13.28.1b / §13.28.3 / §13.31 the RAKP4 Integrity Check
+// Value is selected by the *authentication* algorithm (not the session
+// integrity algorithm), using SIK as the HMAC key:
+//   - RAKP-HMAC-SHA1   → HMAC-SHA1-96    (RFC2404, 12 bytes)
+//   - RAKP-HMAC-SHA256 → HMAC-SHA256-128 (RFC4868, 16 bytes)
+//   - RAKP-HMAC-MD5    → HMAC-MD5-128    (16 bytes)
+//   - RAKP-none        → absent (spec §13.28.2)
+//
+// Spec §13.31 states the RAKP steps run even when the cipher suite has no
+// integrity/encryption, so suites that pair a non-None auth algorithm with
+// Integrity=None (suites 1 and 15) still produce a non-empty RAKP4 ICV.
+// Selecting the HMAC variant by the integrity algorithm was a spec deviation
+// that only worked for suites where the integrity truncation coincided with
+// the auth algorithm's RAKP4 truncation (suites 2/3/16/17).
 func (c *Client) generate_rakp4_authcode() ([]byte, error) {
+	// RAKP-none: the Integrity Check Value is absent (spec §13.28.2).
+	if c.session.v20.authAlg == ipmi.AuthAlgRAKP_None {
+		return []byte{}, nil
+	}
+
 	var input []byte = []byte{}
 	input = append(input, c.session.v20.consoleRand[:]...) // 16 bytes, Console random number
 
@@ -355,44 +377,38 @@ func (c *Client) generate_rakp4_authcode() ([]byte, error) {
 	hmacKey := c.session.v20.sik
 	c.DebugBytes("rakp4 auth code key", hmacKey, 16)
 
-	b, err := generate_auth_hmac(c.session.v20.integrityAlg, input, hmacKey)
+	b, err := generate_auth_hmac(c.session.v20.authAlg, input, hmacKey)
 	if err != nil {
 		return nil, fmt.Errorf("generate hmac failed, err: %w", err)
 	}
 
 	c.DebugBytes("rakp4 generated authcode", b, 16)
 
-	var errHmacLen = func(length int, integrityAlg ipmi.IntegrityAlg) error {
-		return fmt.Errorf("the length of generated mac is not long enough, should be at least (%d) for integrity algorithm (%0x)", len(b), integrityAlg)
-	}
-
-	var out = b
-
-	integrityAlg := c.session.v20.integrityAlg
-	switch integrityAlg {
-	case ipmi.IntegrityAlg_None:
-		// nothing need to do
-	case ipmi.IntegrityAlg_HMAC_MD5_128:
-		// need to copy 16 bytes
-		if len(b) < 16 {
-			err = errHmacLen(len(b), integrityAlg)
-		}
-		out = b[0:16]
-	case ipmi.IntegrityAlg_HMAC_SHA1_96:
-		// need to copy 12 bytes
+	authAlg := c.session.v20.authAlg
+	var out []byte
+	switch authAlg {
+	case ipmi.AuthAlgRAKP_HMAC_SHA1:
+		// HMAC-SHA1-96: truncate to 12 bytes.
 		if len(b) < 12 {
-			err = errHmacLen(len(b), integrityAlg)
+			return nil, fmt.Errorf("rakp4: hmac sha1 length %d too short for SHA1-96 (auth alg 0x%x)", len(b), authAlg)
 		}
 		out = b[0:12]
-	case ipmi.IntegrityAlg_HMAC_SHA256_128:
+	case ipmi.AuthAlgRAKP_HMAC_SHA256:
+		// HMAC-SHA256-128: truncate to 16 bytes.
 		if len(b) < 16 {
-			err = errHmacLen(len(b), integrityAlg)
+			return nil, fmt.Errorf("rakp4: hmac sha256 length %d too short for SHA256-128 (auth alg 0x%x)", len(b), authAlg)
+		}
+		out = b[0:16]
+	case ipmi.AuthAlgRAKP_HMAC_MD5:
+		// HMAC-MD5-128: 16 bytes.
+		if len(b) < 16 {
+			return nil, fmt.Errorf("rakp4: hmac md5 length %d too short for MD5-128 (auth alg 0x%x)", len(b), authAlg)
 		}
 		out = b[0:16]
 	default:
-		err = fmt.Errorf("rakp4 message: no support for integrity algorithm %x", c.session.v20.integrityAlg)
+		return nil, fmt.Errorf("rakp4 message: no support for authentication algorithm 0x%x", authAlg)
 	}
 	c.DebugBytes("rakp4 used authcode", out, 16)
 
-	return out, err
+	return out, nil
 }

--- a/pkg/client/server_rakp_sha256_test.go
+++ b/pkg/client/server_rakp_sha256_test.go
@@ -1,0 +1,194 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestRAKP_SHA256_CrossValidation drives the reference server's RAKP1/RAKP3
+// handlers with cipher suite 17 (RAKP-HMAC-SHA256 + HMAC-SHA256-128) and
+// verifies every auth code / derived key against the client-side generators.
+// This is the cross-package equivalent of an ipmitool -C 17 handshake.
+func TestRAKP_SHA256_CrossValidation(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+	consoleID := uint32(0x11223344)
+	role := uint8(bmc.PrivilegeLevelAdministrator)
+
+	b := newSHA256TestBMC(t, username, password)
+
+	sess, err := b.Sessions.Allocate(consoleID,
+		bmc.AuthAlgHMACSHA256, bmc.IntegrityAlgHMACSHA256_128, bmc.CryptAlgAESCBC128)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	sess.Channel = 1
+	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
+
+	// Build RAKP1 with a fixed console random for reproducibility.
+	var consoleRand [16]byte
+	for i := range consoleRand {
+		consoleRand[i] = byte(0xA0 + i)
+	}
+	rakp1 := buildRAKP1(sess.BMCID, role, consoleRand, username)
+
+	rakp2, err := handlers.HandleRAKP1(context.Background(), b, rakp1)
+	if err != nil {
+		t.Fatalf("HandleRAKP1: %v", err)
+	}
+	if len(rakp2) < 40 || rakp2[1] != 0x00 {
+		t.Fatalf("RAKP2 not successful: len=%d status=0x%02x", len(rakp2), rakp2Status(rakp2))
+	}
+
+	// Parse RAKP2: tag(1) status(1) reserved(2) consoleID(4) bmcRand(16) bmcGUID(16) authCode(N).
+	var bmcRand [16]byte
+	copy(bmcRand[:], rakp2[8:24])
+	var bmcGUID [16]byte
+	copy(bmcGUID[:], rakp2[24:40])
+	serverRAKP2Code := rakp2[40:] // SHA256 → 32 bytes
+
+	// Configure the client session to mirror the exchange and let the client
+	// recompute the RAKP2 auth code.
+	c := newTestClient(t, username, password)
+	c.session.v20.authAlg = ipmi.AuthAlgRAKP_HMAC_SHA256
+	c.session.v20.integrityAlg = ipmi.IntegrityAlg_HMAC_SHA256_128
+	c.session.v20.consoleSessionID = consoleID
+	c.session.v20.bmcSessionID = sess.BMCID
+	c.session.v20.consoleRand = consoleRand
+	c.session.v20.bmcRand = bmcRand
+	c.session.v20.bmcGUID = bmcGUID
+	c.session.v20.role = role
+
+	clientRAKP2Code, err := c.generate_rakp2_authcode()
+	if err != nil {
+		t.Fatalf("client generate_rakp2_authcode: %v", err)
+	}
+	if !bytes.Equal(clientRAKP2Code, serverRAKP2Code) {
+		t.Fatalf("RAKP2 auth code mismatch:\n client=%x\n server=%x", clientRAKP2Code, serverRAKP2Code)
+	}
+
+	// Build RAKP3 with the client's RAKP3 auth code and feed it to the server.
+	clientRAKP3Code, err := c.generate_rakp3_authcode()
+	if err != nil {
+		t.Fatalf("client generate_rakp3_authcode: %v", err)
+	}
+	rakp3 := buildRAKP3(sess.BMCID, clientRAKP3Code)
+
+	rakp4, err := handlers.HandleRAKP3(context.Background(), b, rakp3)
+	if err != nil {
+		t.Fatalf("HandleRAKP3: %v", err)
+	}
+	if len(rakp4) < 8 || rakp4[1] != 0x00 {
+		t.Fatalf("RAKP4 not successful: len=%d status=0x%02x", len(rakp4), rakp2Status(rakp4))
+	}
+
+	// SIK / K1 / K2 must match between client and server. The client stores SIK
+	// on the session before deriving K1/K2.
+	clientSIK, err := c.generate_sik()
+	if err != nil {
+		t.Fatalf("client generate_sik: %v", err)
+	}
+	c.session.v20.sik = clientSIK
+	if !bytes.Equal(clientSIK, sess.SIK) {
+		t.Fatalf("SIK mismatch:\n client=%x\n server=%x", clientSIK, sess.SIK)
+	}
+	clientK1, err := c.generate_k1()
+	if err != nil {
+		t.Fatalf("client generate_k1: %v", err)
+	}
+	if !bytes.Equal(clientK1, sess.K1) {
+		t.Fatalf("K1 mismatch:\n client=%x\n server=%x", clientK1, sess.K1)
+	}
+	clientK2, err := c.generate_k2()
+	if err != nil {
+		t.Fatalf("client generate_k2: %v", err)
+	}
+	if !bytes.Equal(clientK2, sess.K2) {
+		t.Fatalf("K2 mismatch:\n client=%x\n server=%x", clientK2, sess.K2)
+	}
+
+	// RAKP4 auth code (HMAC-SHA256-128, 16 bytes) must match.
+	clientRAKP4Code, err := c.generate_rakp4_authcode()
+	if err != nil {
+		t.Fatalf("client generate_rakp4_authcode: %v", err)
+	}
+	serverRAKP4Code := rakp4[8:]
+	if !bytes.Equal(clientRAKP4Code, serverRAKP4Code) {
+		t.Fatalf("RAKP4 auth code mismatch:\n client=%x\n server=%x", clientRAKP4Code, serverRAKP4Code)
+	}
+	if len(serverRAKP4Code) != 16 {
+		t.Fatalf("RAKP4 auth code length: want 16 (SHA256-128), got %d", len(serverRAKP4Code))
+	}
+}
+
+func newSHA256TestBMC(t *testing.T, username, password string) *bmc.BMC {
+	t.Helper()
+	info := bmc.DeviceInfo{DeviceID: 1, IPMIVersion: 0x20, ManufacturerID: 0x000157, ProductID: 0x0001}
+	var guid [16]byte
+	for i := range guid {
+		guid[i] = byte(0x10 + i)
+	}
+	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clock.Real))
+	user, err := b.Users.Add(2, username)
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte(password))
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+	return b
+}
+
+func newTestClient(t *testing.T, username, password string) *Client {
+	t.Helper()
+	c, err := NewClient("127.0.0.1", 623, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// buildRAKP1 constructs a RAKP Message 1 payload (spec §13.21):
+//
+//	tag(1) status(1) reserved(2) bmcSessionID(4) consoleRand(16) role(1) reserved(2) userLen(1) username(N)
+func buildRAKP1(bmcSessionID uint32, role uint8, consoleRand [16]byte, username string) []byte {
+	p := make([]byte, 28+len(username))
+	p[0] = 0x01 // tag
+	binary.LittleEndian.PutUint32(p[4:8], bmcSessionID)
+	copy(p[8:24], consoleRand[:])
+	p[24] = role
+	p[27] = uint8(len(username))
+	copy(p[28:], username)
+	return p
+}
+
+// buildRAKP3 constructs a RAKP Message 3 payload (spec §13.23):
+//
+//	tag(1) status(1) reserved(2) bmcSessionID(4) authCode(N)
+func buildRAKP3(bmcSessionID uint32, authCode []byte) []byte {
+	p := make([]byte, 8+len(authCode))
+	p[0] = 0x03 // tag
+	binary.LittleEndian.PutUint32(p[4:8], bmcSessionID)
+	copy(p[8:], authCode)
+	return p
+}
+
+func rakp2Status(resp []byte) uint8 {
+	if len(resp) < 2 {
+		return 0xff
+	}
+	return resp[1]
+}

--- a/pkg/client/server_rakp_sha256_test.go
+++ b/pkg/client/server_rakp_sha256_test.go
@@ -131,6 +131,153 @@ func TestRAKP_SHA256_CrossValidation(t *testing.T) {
 	}
 }
 
+// TestRAKP4_CrossValidation_AuthAlgorithm drives the reference server's
+// RAKP1/RAKP3 handlers for several (auth, integrity) combinations and verifies
+// the client-side generate_rakp4_authcode matches the server's RAKP4 Integrity
+// Check Value. This guards the spec fix that selects the RAKP4 ICV by the
+// *authentication* algorithm (spec §13.28.1/§13.28.1b/§13.31) rather than the
+// session integrity algorithm.
+//
+// The critical cases are suites that pair a non-None auth algorithm with
+// Integrity=None (suite 1: SHA1+None, suite 15: SHA256+None), which previously
+// produced an empty ICV on both sides and would have failed against a
+// spec-faithful BMC.
+func TestRAKP4_CrossValidation_AuthAlgorithm(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+	consoleID := uint32(0x11223344)
+	role := uint8(bmc.PrivilegeLevelAdministrator)
+
+	cases := []struct {
+		name         string
+		authAlg      bmc.AuthAlg
+		integrityAlg bmc.IntegrityAlg
+		clientAuth   ipmi.AuthAlg
+		clientInt    ipmi.IntegrityAlg
+		wantICVLen   int
+	}{
+		{
+			name:    "suite 1 (RAKP-HMAC-SHA1 + Integrity-None)",
+			authAlg: bmc.AuthAlgHMACSHA1, integrityAlg: bmc.IntegrityAlgNone,
+			clientAuth: ipmi.AuthAlgRAKP_HMAC_SHA1, clientInt: ipmi.IntegrityAlg_None,
+			wantICVLen: 12, // HMAC-SHA1-96
+		},
+		{
+			name:    "suite 15 (RAKP-HMAC-SHA256 + Integrity-None)",
+			authAlg: bmc.AuthAlgHMACSHA256, integrityAlg: bmc.IntegrityAlgNone,
+			clientAuth: ipmi.AuthAlgRAKP_HMAC_SHA256, clientInt: ipmi.IntegrityAlg_None,
+			wantICVLen: 16, // HMAC-SHA256-128
+		},
+		{
+			name:    "suite 3 (RAKP-HMAC-SHA1 + HMAC-SHA1-96)",
+			authAlg: bmc.AuthAlgHMACSHA1, integrityAlg: bmc.IntegrityAlgHMACSHA1_96,
+			clientAuth: ipmi.AuthAlgRAKP_HMAC_SHA1, clientInt: ipmi.IntegrityAlg_HMAC_SHA1_96,
+			wantICVLen: 12,
+		},
+		{
+			name:    "suite 17 (RAKP-HMAC-SHA256 + HMAC-SHA256-128)",
+			authAlg: bmc.AuthAlgHMACSHA256, integrityAlg: bmc.IntegrityAlgHMACSHA256_128,
+			clientAuth: ipmi.AuthAlgRAKP_HMAC_SHA256, clientInt: ipmi.IntegrityAlg_HMAC_SHA256_128,
+			wantICVLen: 16,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newSHA256TestBMC(t, username, password)
+
+			sess, err := b.Sessions.Allocate(consoleID, tc.authAlg, tc.integrityAlg, bmc.CryptAlgNone)
+			if err != nil {
+				t.Fatalf("allocate session: %v", err)
+			}
+			sess.Channel = 1
+			sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
+
+			var consoleRand [16]byte
+			for i := range consoleRand {
+				consoleRand[i] = byte(0xA0 + i)
+			}
+			rakp1 := buildRAKP1(sess.BMCID, role, consoleRand, username)
+
+			rakp2, err := handlers.HandleRAKP1(context.Background(), b, rakp1)
+			if err != nil {
+				t.Fatalf("HandleRAKP1: %v", err)
+			}
+			if len(rakp2) < 40 || rakp2[1] != 0x00 {
+				t.Fatalf("RAKP2 not successful: len=%d status=0x%02x", len(rakp2), rakp2Status(rakp2))
+			}
+
+			var bmcRand [16]byte
+			copy(bmcRand[:], rakp2[8:24])
+			var bmcGUID [16]byte
+			copy(bmcGUID[:], rakp2[24:40])
+			serverRAKP2Code := rakp2[40:]
+
+			c := newTestClient(t, username, password)
+			c.session.v20.authAlg = tc.clientAuth
+			c.session.v20.integrityAlg = tc.clientInt
+			c.session.v20.consoleSessionID = consoleID
+			c.session.v20.bmcSessionID = sess.BMCID
+			c.session.v20.consoleRand = consoleRand
+			c.session.v20.bmcRand = bmcRand
+			c.session.v20.bmcGUID = bmcGUID
+			c.session.v20.role = role
+
+			// RAKP2 auth code must match (full auth-algorithm digest length).
+			clientRAKP2Code, err := c.generate_rakp2_authcode()
+			if err != nil {
+				t.Fatalf("client generate_rakp2_authcode: %v", err)
+			}
+			if !bytes.Equal(clientRAKP2Code, serverRAKP2Code) {
+				t.Fatalf("RAKP2 auth code mismatch:\n client=%x\n server=%x", clientRAKP2Code, serverRAKP2Code)
+			}
+
+			// Build RAKP3 with the client's auth code and drive the server.
+			clientRAKP3Code, err := c.generate_rakp3_authcode()
+			if err != nil {
+				t.Fatalf("client generate_rakp3_authcode: %v", err)
+			}
+			rakp3 := buildRAKP3(sess.BMCID, clientRAKP3Code)
+
+			rakp4, err := handlers.HandleRAKP3(context.Background(), b, rakp3)
+			if err != nil {
+				t.Fatalf("HandleRAKP3: %v", err)
+			}
+			if len(rakp4) < 8 || rakp4[1] != 0x00 {
+				t.Fatalf("RAKP4 not successful: len=%d status=0x%02x", len(rakp4), rakp2Status(rakp4))
+			}
+
+			// SIK must match; the client stores SIK before deriving RAKP4 ICV.
+			clientSIK, err := c.generate_sik()
+			if err != nil {
+				t.Fatalf("client generate_sik: %v", err)
+			}
+			c.session.v20.sik = clientSIK
+			if !bytes.Equal(clientSIK, sess.SIK) {
+				t.Fatalf("SIK mismatch:\n client=%x\n server=%x", clientSIK, sess.SIK)
+			}
+
+			// RAKP4 ICV must match and have the auth-algorithm-defined length.
+			clientRAKP4Code, err := c.generate_rakp4_authcode()
+			if err != nil {
+				t.Fatalf("client generate_rakp4_authcode: %v", err)
+			}
+			serverRAKP4Code := rakp4[8:]
+			if !bytes.Equal(clientRAKP4Code, serverRAKP4Code) {
+				t.Fatalf("RAKP4 ICV mismatch:\n client=%x\n server=%x", clientRAKP4Code, serverRAKP4Code)
+			}
+			if len(serverRAKP4Code) != tc.wantICVLen {
+				t.Fatalf("RAKP4 ICV length: want %d, got %d (code=%x)", tc.wantICVLen, len(serverRAKP4Code), serverRAKP4Code)
+			}
+			if len(clientRAKP4Code) != tc.wantICVLen {
+				t.Fatalf("client RAKP4 ICV length: want %d, got %d", tc.wantICVLen, len(clientRAKP4Code))
+			}
+		})
+	}
+}
+
 func newSHA256TestBMC(t *testing.T, username, password string) *bmc.BMC {
 	t.Helper()
 	info := bmc.DeviceInfo{DeviceID: 1, IPMIVersion: 0x20, ManufacturerID: 0x000157, ProductID: 0x0001}

--- a/pkg/cmd/app/cmd_get_channel_cipher_suites.go
+++ b/pkg/cmd/app/cmd_get_channel_cipher_suites.go
@@ -72,8 +72,13 @@ func ParseCipherSuitesData(cipherSuitesData []byte) ([]ipmi.CipherSuiteRecord, e
 
 		switch startOfRecord {
 		case ipmi.StandardCipherSuite:
-			// id + 3 algs (4 bytes)
-			if offset+4 > len(cipherSuitesData)-1 {
+			// Per §22.15.1 the record is tag-delimited, not fixed-length: the
+			// start byte is followed by the cipher suite id and then 1..3
+			// algorithm bytes (auth is always present; integrity/confidentiality
+			// are omitted when the suite does not use them, e.g. suites 0/1/15).
+			// Only require the id byte here; the tag loop below handles the rest
+			// and its own end-of-data bounds check.
+			if offset+1 > len(cipherSuitesData)-1 {
 				return records, fmt.Errorf("incomplete cipher suite data")
 			}
 			offset++

--- a/pkg/cmd/app/cmd_get_channel_cipher_suites_test.go
+++ b/pkg/cmd/app/cmd_get_channel_cipher_suites_test.go
@@ -1,0 +1,135 @@
+package app
+
+import (
+	"testing"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestParseCipherSuitesData_VariableLengthRecords exercises tag-delimited
+// cipher suite records per IPMI 2.0 §22.15.1, where integrity/confidentiality
+// entries are omitted when the suite does not use them. This previously broke
+// ParseCipherSuitesData, which assumed a fixed id+3-algs (4-byte) payload after
+// each 0xC0 start byte and rejected short records.
+func TestParseCipherSuitesData_VariableLengthRecords(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want []ipmi.CipherSuiteRecord
+	}{
+		{
+			// Suite 1 alone: auth only (RAKP-HMAC-SHA1), no integ, no crypt.
+			name: "suite1_only",
+			data: []byte{0xC0, 0x01, 0x01},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID1, AuthAlg: 0x01},
+			},
+		},
+		{
+			// Suite 15 alone: auth only (RAKP-HMAC-SHA256), no integ, no crypt.
+			name: "suite15_only",
+			data: []byte{0xC0, 0x0F, 0x03},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID15, AuthAlg: 0x03},
+			},
+		},
+		{
+			// Full 5-byte record (suite 3): auth + integ + crypt.
+			name: "suite3_only",
+			data: []byte{0xC0, 0x03, 0x01, 0x41, 0x81},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID3, AuthAlg: 0x01, IntegrityAlgs: []uint8{0x01}, CryptAlgs: []uint8{0x01}},
+			},
+		},
+		{
+			// Short record LAST: previously rejected by the fixed 4-byte
+			// bounds check ("incomplete cipher suite data").
+			name: "suite3_then_suite1_short_last",
+			data: []byte{
+				0xC0, 0x03, 0x01, 0x41, 0x81, // suite 3
+				0xC0, 0x01, 0x01, // suite 1 (short, last)
+			},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID3, AuthAlg: 0x01, IntegrityAlgs: []uint8{0x01}, CryptAlgs: []uint8{0x01}},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID1, AuthAlg: 0x01},
+			},
+		},
+		{
+			// Short record FIRST, then full record.
+			name: "suite1_short_first_then_suite3",
+			data: []byte{
+				0xC0, 0x01, 0x01, // suite 1 (short, first)
+				0xC0, 0x03, 0x01, 0x41, 0x81, // suite 3
+			},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID1, AuthAlg: 0x01},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID3, AuthAlg: 0x01, IntegrityAlgs: []uint8{0x01}, CryptAlgs: []uint8{0x01}},
+			},
+		},
+		{
+			// Mixed omit-None set as advertised by the extended e2e server.
+			name: "mixed_1_2_15_16_3_17",
+			data: []byte{
+				0xC0, 0x01, 0x01, // 1
+				0xC0, 0x02, 0x01, 0x41, // 2
+				0xC0, 0x0F, 0x03, // 15
+				0xC0, 0x10, 0x03, 0x44, // 16
+				0xC0, 0x03, 0x01, 0x41, 0x81, // 3
+				0xC0, 0x11, 0x03, 0x44, 0x81, // 17
+			},
+			want: []ipmi.CipherSuiteRecord{
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID1, AuthAlg: 0x01},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID2, AuthAlg: 0x01, IntegrityAlgs: []uint8{0x01}},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID15, AuthAlg: 0x03},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID16, AuthAlg: 0x03, IntegrityAlgs: []uint8{0x04}},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID3, AuthAlg: 0x01, IntegrityAlgs: []uint8{0x01}, CryptAlgs: []uint8{0x01}},
+				{StartOfRecord: 0xC0, CipherSuitID: ipmi.CipherSuiteID17, AuthAlg: 0x03, IntegrityAlgs: []uint8{0x04}, CryptAlgs: []uint8{0x01}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCipherSuitesData(tc.data)
+			if err != nil {
+				t.Fatalf("ParseCipherSuitesData returned unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("record count: got %d, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if !cipherSuiteRecordEqual(got[i], tc.want[i]) {
+					t.Errorf("record %d: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func cipherSuiteRecordEqual(a, b ipmi.CipherSuiteRecord) bool {
+	if a.StartOfRecord != b.StartOfRecord || a.CipherSuitID != b.CipherSuitID {
+		return false
+	}
+	if a.AuthAlg != b.AuthAlg {
+		return false
+	}
+	if !uint8SliceEqual(a.IntegrityAlgs, b.IntegrityAlgs) {
+		return false
+	}
+	if !uint8SliceEqual(a.CryptAlgs, b.CryptAlgs) {
+		return false
+	}
+	return true
+}
+
+func uint8SliceEqual(a, b []uint8) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -203,10 +203,10 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	cryptAlg := bmc.CryptAlg(data[28])   // byte 4 of crypt payload
 
 	// Validate algorithm support against the cipher suites this BMC is
-	// configured to accept. An algorithm is accepted if at least one
-	// configured suite uses it (or None, always accepted). Error codes per
-	// spec Table 13-17: 0x04 invalid auth, 0x05 invalid integrity, 0x10
-	// invalid confidentiality.
+	// configured to accept. An algorithm is accepted if and only if at least
+	// one configured suite uses it (None is not implicitly accepted). Error
+	// codes per spec Table 13-17: 0x04 invalid auth, 0x05 invalid integrity,
+	// 0x10 invalid confidentiality.
 	allowedAuth, allowedInt, allowedCrypt := allowedAlgorithms(b)
 	if !allowedAuth[authAlg] {
 		return buildOpenSessionError(tag, consoleID, 0x04), nil // Invalid auth alg

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -202,20 +202,14 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	intAlg := bmc.IntegrityAlg(data[20]) // byte 4 of integrity payload
 	cryptAlg := bmc.CryptAlg(data[28])   // byte 4 of crypt payload
 
-	// Validate algorithm support against the cipher suites this BMC is
-	// configured to accept. An algorithm is accepted if and only if at least
-	// one configured suite uses it (None is not implicitly accepted). Error
-	// codes per spec Table 13-17: 0x04 invalid auth, 0x05 invalid integrity,
-	// 0x10 invalid confidentiality.
-	allowedAuth, allowedInt, allowedCrypt := allowedAlgorithms(b)
-	if !allowedAuth[authAlg] {
-		return buildOpenSessionError(tag, consoleID, 0x04), nil // Invalid auth alg
-	}
-	if !allowedInt[intAlg] {
-		return buildOpenSessionError(tag, consoleID, 0x05), nil // Invalid integrity alg
-	}
-	if !allowedCrypt[cryptAlg] {
-		return buildOpenSessionError(tag, consoleID, 0x10), nil // Invalid confidentiality alg
+	// Validate that the requested algorithm triple matches a configured
+	// cipher suite (spec §22.15.2, §13.17). The triple must appear as a
+	// unit — cross-suite recombinations are rejected even when each
+	// individual algorithm exists in some configured suite. Error codes per
+	// spec Table 13-17: 0x04 invalid auth, 0x05 invalid integrity, 0x10
+	// invalid confidentiality.
+	if ok, code := isCipherSuiteAllowed(b, authAlg, intAlg, cryptAlg); !ok {
+		return buildOpenSessionError(tag, consoleID, code), nil
 	}
 
 	sess, err := b.Sessions.Allocate(consoleID, authAlg, intAlg, cryptAlg)

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -83,26 +83,25 @@ func resolveChannelNumber(reqByte uint8) uint8 {
 }
 
 // handleGetChannelCipherSuites implements Get Channel Cipher Suites (App 0x54).
-// Returns a single record for cipher suite 3 (RAKP-HMAC-SHA1 + HMAC-SHA1-96 +
-// AES-CBC-128) — the suite the server actually supports in its RMCP+ handshake.
+// Returns one record per cipher suite configured on the BMC (default
+// {3, 17}), encoded per spec §22.15.1. Each standard record is:
+//
+//	0xC0 <id> 0x00|authAlg [0x40|integAlg] [0x80|cryptAlg]
+//
+// Records are returned in 16-byte windows addressed by the list index; the
+// remote console keeps incrementing the index until fewer than 16 record bytes
+// are returned.
 func handleGetChannelCipherSuites(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
 	if len(req) < 2 {
 		return nil, CodeRequestDataTruncated, nil
 	}
+	if hctx == nil || hctx.BMC == nil {
+		return []byte{resolveChannelNumber(req[0])}, CodeOK, nil
+	}
 	// Byte 0: channel number (bits 3:0; 0x0E = current channel)
 	// Byte 1: payload type (0x00 = IPMI)
 	// Byte 2: bits 5:0 = list index; bit 6 = list mode flag (echoed unused here)
-	//
-	// The cipher suite records are returned in chunks of at most 16 bytes per
-	// request.  The list index addresses the next 16-byte window; the remote
-	// console keeps incrementing it until fewer than 16 record bytes are
-	// returned.  We expose a single standard record for cipher suite 3:
-	//   0xC0           start-of-record (standard)
-	//   0x03           cipher suite ID 3
-	//   0x01           auth alg  RAKP-HMAC-SHA1   (tag 00b)
-	//   0x41           integ alg HMAC-SHA1-96     (tag 01b)
-	//   0x81           crypt alg AES-CBC-128      (tag 10b)
-	record := []byte{0xC0, 0x03, 0x01, 0x41, 0x81}
+	record := cipherSuiteRecords(hctx.BMC)
 
 	var listIndex int
 	if len(req) >= 3 {
@@ -203,15 +202,19 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 	intAlg := bmc.IntegrityAlg(data[20]) // byte 4 of integrity payload
 	cryptAlg := bmc.CryptAlg(data[28])   // byte 4 of crypt payload
 
-	// Validate algorithm support.  We support RAKP-HMAC-SHA1 (0x01),
-	// HMAC-SHA1-96 (0x01), AES-CBC-128 (0x01) as the reference cipher suite.
-	if authAlg != bmc.AuthAlgNone && authAlg != bmc.AuthAlgHMACSHA1 {
+	// Validate algorithm support against the cipher suites this BMC is
+	// configured to accept. An algorithm is accepted if at least one
+	// configured suite uses it (or None, always accepted). Error codes per
+	// spec Table 13-17: 0x04 invalid auth, 0x05 invalid integrity, 0x10
+	// invalid confidentiality.
+	allowedAuth, allowedInt, allowedCrypt := allowedAlgorithms(b)
+	if !allowedAuth[authAlg] {
 		return buildOpenSessionError(tag, consoleID, 0x04), nil // Invalid auth alg
 	}
-	if intAlg != bmc.IntegrityAlgNone && intAlg != bmc.IntegrityAlgHMACSHA1_96 {
+	if !allowedInt[intAlg] {
 		return buildOpenSessionError(tag, consoleID, 0x05), nil // Invalid integrity alg
 	}
-	if cryptAlg != bmc.CryptAlgNone && cryptAlg != bmc.CryptAlgAESCBC128 {
+	if !allowedCrypt[cryptAlg] {
 		return buildOpenSessionError(tag, consoleID, 0x10), nil // Invalid confidentiality alg
 	}
 

--- a/pkg/handlers/session_cipher.go
+++ b/pkg/handlers/session_cipher.go
@@ -33,31 +33,49 @@ func cipherSuiteRecords(b *bmc.BMC) []byte {
 	return out
 }
 
-// allowedAlgorithms returns the sets of auth / integrity / confidentiality
-// algorithm codes the server will accept in an RMCP+ Open Session Request,
-// derived strictly from the configured cipher suites (spec §22.15.2,
-// §13.17). An algorithm is accepted if and only if at least one configured
-// cipher suite uses it.
+// isCipherSuiteAllowed checks whether the (auth, integ, crypt) triple from an
+// Open Session Request matches at least one configured cipher suite (spec
+// §22.15.2, §13.17). It validates the triple as a whole — each algorithm must
+// come from the same suite. Cross-suite recombinations (where each algorithm
+// appears in some configured suite but the triple as a unit was never
+// advertised via Get Channel Cipher Suites) are rejected.
 //
-// None is NOT implicitly accepted. The default cipher suite set
-// ([bmc.DefaultCipherSuites], suites 3 and 17) does not contain any
-// unauthenticated or unencrypted suite, so AuthAlgNone / IntegrityAlgNone /
-// CryptAlgNone are rejected unless an operator explicitly configures a suite
-// that uses them (e.g. suite 0 for fully unauthenticated, suite 1/15 for
-// authenticated-but-unencrypted). This keeps Open Session negotiation
-// consistent with the suites advertised via Get Channel Cipher Suites.
-func allowedAlgorithms(b *bmc.BMC) (auth map[bmc.AuthAlg]bool, integ map[bmc.IntegrityAlg]bool, crypt map[bmc.CryptAlg]bool) {
-	auth = make(map[bmc.AuthAlg]bool)
-	integ = make(map[bmc.IntegrityAlg]bool)
-	crypt = make(map[bmc.CryptAlg]bool)
+// When the triple is rejected, the error code attributes the failure to the
+// first algorithm that does not appear in any configured suite. If all three
+// algorithms exist individually but the triple is not a recognised suite
+// combination, 0x04 (invalid authentication algorithm) is returned.
+func isCipherSuiteAllowed(b *bmc.BMC, auth bmc.AuthAlg, integ bmc.IntegrityAlg, crypt bmc.CryptAlg) (ok bool, errCode uint8) {
+	authKnown := false
+	integKnown := false
+	cryptKnown := false
 	for _, id := range b.ResolvedCipherSuites() {
 		a, i, c, ok := bmc.CipherSuiteAlgorithms(id)
 		if !ok {
 			continue
 		}
-		auth[a] = true
-		integ[i] = true
-		crypt[c] = true
+		if !authKnown {
+			authKnown = a == auth
+		}
+		if !integKnown {
+			integKnown = i == integ
+		}
+		if !cryptKnown {
+			cryptKnown = c == crypt
+		}
+		if a == auth && i == integ && c == crypt {
+			return true, 0
+		}
 	}
-	return
+	if !authKnown {
+		return false, 0x04 // Invalid authentication algorithm
+	}
+	if !integKnown {
+		return false, 0x05 // Invalid integrity algorithm
+	}
+	if !cryptKnown {
+		return false, 0x10 // Invalid confidentiality algorithm
+	}
+	// All three algorithms appear individually in some configured suite, but
+	// no single suite contains this triple — a cross-suite recombination.
+	return false, 0x04
 }

--- a/pkg/handlers/session_cipher.go
+++ b/pkg/handlers/session_cipher.go
@@ -33,16 +33,23 @@ func cipherSuiteRecords(b *bmc.BMC) []byte {
 	return out
 }
 
-// allowedAuthAlgorithms / allowedIntegrityAlgorithms / allowedCryptAlgorithms
-// return the sets of algorithm codes the server will accept in an Open Session
-// Request, derived from the configured cipher suites. An algorithm is accepted
-// if at least one configured suite uses it (or None, which is always accepted
-// for auth/integrity/crypt since the spec allows negotiating "no integrity" /
-// "no confidentiality" within a suite that supports them).
+// allowedAlgorithms returns the sets of auth / integrity / confidentiality
+// algorithm codes the server will accept in an RMCP+ Open Session Request,
+// derived strictly from the configured cipher suites (spec §22.15.2,
+// §13.17). An algorithm is accepted if and only if at least one configured
+// cipher suite uses it.
+//
+// None is NOT implicitly accepted. The default cipher suite set
+// ([bmc.DefaultCipherSuites], suites 3 and 17) does not contain any
+// unauthenticated or unencrypted suite, so AuthAlgNone / IntegrityAlgNone /
+// CryptAlgNone are rejected unless an operator explicitly configures a suite
+// that uses them (e.g. suite 0 for fully unauthenticated, suite 1/15 for
+// authenticated-but-unencrypted). This keeps Open Session negotiation
+// consistent with the suites advertised via Get Channel Cipher Suites.
 func allowedAlgorithms(b *bmc.BMC) (auth map[bmc.AuthAlg]bool, integ map[bmc.IntegrityAlg]bool, crypt map[bmc.CryptAlg]bool) {
-	auth = map[bmc.AuthAlg]bool{bmc.AuthAlgNone: true}
-	integ = map[bmc.IntegrityAlg]bool{bmc.IntegrityAlgNone: true}
-	crypt = map[bmc.CryptAlg]bool{bmc.CryptAlgNone: true}
+	auth = make(map[bmc.AuthAlg]bool)
+	integ = make(map[bmc.IntegrityAlg]bool)
+	crypt = make(map[bmc.CryptAlg]bool)
 	for _, id := range b.ResolvedCipherSuites() {
 		a, i, c, ok := bmc.CipherSuiteAlgorithms(id)
 		if !ok {

--- a/pkg/handlers/session_cipher.go
+++ b/pkg/handlers/session_cipher.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+// cipherSuiteRecords builds the wire bytes for the Get Channel Cipher Suites
+// response (spec §22.15.1) from the BMC's configured cipher suite list.
+//
+// Each standard record is:
+//
+//	0xC0 <cipherSuiteID> 0x00|authAlg [0x40|integAlg] [0x80|cryptAlg]
+//
+// where the integrity and confidentiality entries are omitted when their
+// algorithm is None. Auth is always present per spec.
+func cipherSuiteRecords(b *bmc.BMC) []byte {
+	ids := b.ResolvedCipherSuites()
+	out := make([]byte, 0, len(ids)*5)
+	for _, id := range ids {
+		auth, integ, crypt, ok := bmc.CipherSuiteAlgorithms(id)
+		if !ok {
+			continue
+		}
+		out = append(out, 0xC0, byte(id))
+		out = append(out, 0x00|byte(auth))
+		if integ != bmc.IntegrityAlgNone {
+			out = append(out, 0x40|byte(integ))
+		}
+		if crypt != bmc.CryptAlgNone {
+			out = append(out, 0x80|byte(crypt))
+		}
+	}
+	return out
+}
+
+// allowedAuthAlgorithms / allowedIntegrityAlgorithms / allowedCryptAlgorithms
+// return the sets of algorithm codes the server will accept in an Open Session
+// Request, derived from the configured cipher suites. An algorithm is accepted
+// if at least one configured suite uses it (or None, which is always accepted
+// for auth/integrity/crypt since the spec allows negotiating "no integrity" /
+// "no confidentiality" within a suite that supports them).
+func allowedAlgorithms(b *bmc.BMC) (auth map[bmc.AuthAlg]bool, integ map[bmc.IntegrityAlg]bool, crypt map[bmc.CryptAlg]bool) {
+	auth = map[bmc.AuthAlg]bool{bmc.AuthAlgNone: true}
+	integ = map[bmc.IntegrityAlg]bool{bmc.IntegrityAlgNone: true}
+	crypt = map[bmc.CryptAlg]bool{bmc.CryptAlgNone: true}
+	for _, id := range b.ResolvedCipherSuites() {
+		a, i, c, ok := bmc.CipherSuiteAlgorithms(id)
+		if !ok {
+			continue
+		}
+		auth[a] = true
+		integ[i] = true
+		crypt[c] = true
+	}
+	return
+}

--- a/pkg/handlers/session_crypto.go
+++ b/pkg/handlers/session_crypto.go
@@ -72,21 +72,51 @@ func computeRAKP3AuthCode(sess *bmc.Session, b *bmc.BMC) ([]byte, error) {
 	return computeHMAC(sess.AuthAlg, buf, key)
 }
 
-// computeRAKP4AuthCode generates the confirmation code the BMC sends in RAKP4.
+// computeRAKP4AuthCode generates the Integrity Check Value the BMC sends in
+// RAKP Message 4.
 //
-// HMAC input:
+// HMAC input (spec §13.31):
 //
 //	ConsoleRand(16) || BMCID(4) || BMCGUID(16)
 //
-// The HMAC key for RAKP4 is the Session Integrity Key (SIK), not Kuid/KG.
-// The integrity algorithm (not auth algorithm) selects the HMAC variant.
+// The HMAC key is the Session Integrity Key (SIK). Per spec §13.28.1 / §13.28.1b
+// the RAKP4 Integrity Check Value is selected by the *authentication* algorithm,
+// not the session integrity algorithm:
+//   - RAKP-HMAC-SHA1   → HMAC-SHA1-96   (RFC2404, 12 bytes)
+//   - RAKP-HMAC-SHA256 → HMAC-SHA256-128 (RFC4868, 16 bytes)
+//   - RAKP-none        → absent (spec §13.28.2)
+//
+// Spec §13.31 additionally states that the RAKP steps are followed even when
+// the cipher suite has no integrity/encryption, so suites that pair a non-None
+// auth algorithm with Integrity=None (e.g. suite 1 / 15) still produce a
+// non-empty RAKP4 ICV. Using the integrity algorithm here was a spec deviation
+// that only worked for suites where the integrity truncation coincidentally
+// matched the auth algorithm's RAKP4 truncation (suites 2/3/16/17).
 func computeRAKP4AuthCode(sess *bmc.Session, b *bmc.BMC) ([]byte, error) {
+	// RAKP-none: the Integrity Check Value is absent (spec §13.28.2).
+	if sess.AuthAlg == bmc.AuthAlgNone {
+		return nil, nil
+	}
 	buf := make([]byte, 16+4+16)
 	copy(buf[0:16], sess.ConsoleRand[:])
 	binary.LittleEndian.PutUint32(buf[16:20], sess.BMCID)
 	copy(buf[20:36], b.GUID[:])
 
-	return computeHMACIntegrity(sess.IntegrityAlg, buf, sess.SIK)
+	return computeRAKP4ICV(sess.AuthAlg, buf, sess.SIK)
+}
+
+// computeRAKP4ICV computes the RAKP Message 4 Integrity Check Value for the
+// given authentication algorithm, using SIK as the HMAC key and truncating to
+// the length defined by the auth algorithm's RAKP4 ICV (12 / 16 bytes).
+func computeRAKP4ICV(authAlg bmc.AuthAlg, data, key []byte) ([]byte, error) {
+	switch authAlg {
+	case bmc.AuthAlgHMACSHA1:
+		return doHMACSHA1(data, key)[:12], nil // HMAC-SHA1-96
+	case bmc.AuthAlgHMACSHA256:
+		return doHMACSHA256(data, key)[:16], nil // HMAC-SHA256-128
+	default:
+		return nil, fmt.Errorf("unsupported auth algorithm for RAKP4 ICV: %d", authAlg)
+	}
 }
 
 // deriveSessKeys computes SIK, K1, and K2 from the session parameters per spec §13.31-13.32.
@@ -174,25 +204,6 @@ func computeHMAC(alg bmc.AuthAlg, data, key []byte) ([]byte, error) {
 		return doHMACSHA256(data, key), nil
 	default:
 		return nil, fmt.Errorf("unsupported auth algorithm: %d", alg)
-	}
-}
-
-// computeHMACIntegrity selects the HMAC variant based on the integrity algorithm
-// for RAKP4 and session trailer AuthCode. The digest is truncated to the
-// algorithm's integrity length: HMAC-SHA1-96 → 12 bytes, HMAC-SHA256-128 → 16
-// bytes (spec §13.28).
-func computeHMACIntegrity(alg bmc.IntegrityAlg, data, key []byte) ([]byte, error) {
-	switch alg {
-	case bmc.IntegrityAlgNone:
-		return nil, nil
-	case bmc.IntegrityAlgHMACSHA1_96:
-		full := doHMACSHA1(data, key)
-		return full[:12], nil // truncated to 96 bits
-	case bmc.IntegrityAlgHMACSHA256_128:
-		full := doHMACSHA256(data, key)
-		return full[:16], nil // truncated to 128 bits
-	default:
-		return nil, fmt.Errorf("unsupported integrity algorithm: %d", alg)
 	}
 }
 

--- a/pkg/handlers/session_crypto.go
+++ b/pkg/handlers/session_crypto.go
@@ -11,6 +11,7 @@ package handlers
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 
@@ -160,20 +161,26 @@ func paddedPassword(sess *bmc.Session) []byte {
 }
 
 // computeHMAC selects the HMAC variant based on the auth algorithm.
-// Currently only RAKP-HMAC-SHA1 is implemented in the reference server.
+// Returns the full-length auth code (RAKP2/RAKP3 use the full digest; SIK/K1/K2
+// derivation also uses the full digest). Supported: RAKP-HMAC-SHA1 (20B) and
+// RAKP-HMAC-SHA256 (32B).
 func computeHMAC(alg bmc.AuthAlg, data, key []byte) ([]byte, error) {
 	switch alg {
 	case bmc.AuthAlgNone:
 		return nil, nil
 	case bmc.AuthAlgHMACSHA1:
 		return doHMACSHA1(data, key), nil
+	case bmc.AuthAlgHMACSHA256:
+		return doHMACSHA256(data, key), nil
 	default:
 		return nil, fmt.Errorf("unsupported auth algorithm: %d", alg)
 	}
 }
 
 // computeHMACIntegrity selects the HMAC variant based on the integrity algorithm
-// for RAKP4 and session trailer AuthCode.
+// for RAKP4 and session trailer AuthCode. The digest is truncated to the
+// algorithm's integrity length: HMAC-SHA1-96 → 12 bytes, HMAC-SHA256-128 → 16
+// bytes (spec §13.28).
 func computeHMACIntegrity(alg bmc.IntegrityAlg, data, key []byte) ([]byte, error) {
 	switch alg {
 	case bmc.IntegrityAlgNone:
@@ -181,6 +188,9 @@ func computeHMACIntegrity(alg bmc.IntegrityAlg, data, key []byte) ([]byte, error
 	case bmc.IntegrityAlgHMACSHA1_96:
 		full := doHMACSHA1(data, key)
 		return full[:12], nil // truncated to 96 bits
+	case bmc.IntegrityAlgHMACSHA256_128:
+		full := doHMACSHA256(data, key)
+		return full[:16], nil // truncated to 128 bits
 	default:
 		return nil, fmt.Errorf("unsupported integrity algorithm: %d", alg)
 	}
@@ -188,6 +198,12 @@ func computeHMACIntegrity(alg bmc.IntegrityAlg, data, key []byte) ([]byte, error
 
 func doHMACSHA1(data, key []byte) []byte {
 	h := hmac.New(sha1.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func doHMACSHA256(data, key []byte) []byte {
+	h := hmac.New(sha256.New, key)
 	h.Write(data)
 	return h.Sum(nil)
 }

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -207,6 +207,79 @@ func TestHandleOpenSession_RejectsUnsupported(t *testing.T) {
 	}
 }
 
+// TestHandleOpenSession_RejectsNoneByDefault verifies that the default cipher
+// suite set ({3, 17}) does NOT allow negotiating AuthAlgNone / IntegrityAlgNone
+// / CryptAlgNone. None is only reachable by explicitly configuring a suite that
+// uses it (e.g. suite 0). This guards against an authentication bypass where
+// AuthAlgNone skips RAKP password verification.
+func TestHandleOpenSession_RejectsNoneByDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		auth    bmc.AuthAlg
+		integ   bmc.IntegrityAlg
+		crypt   bmc.CryptAlg
+		wantErr uint8
+	}{
+		{"auth none", bmc.AuthAlgNone, bmc.IntegrityAlgHMACSHA1_96, bmc.CryptAlgAESCBC128, 0x04},
+		{"integrity none", bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgNone, bmc.CryptAlgAESCBC128, 0x05},
+		{"crypt none", bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgHMACSHA1_96, bmc.CryptAlgNone, 0x10},
+		{"all none", bmc.AuthAlgNone, bmc.IntegrityAlgNone, bmc.CryptAlgNone, 0x04},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBMC()
+			payload := openSessionPayload(0x01, 0x04, 0x01020304,
+				uint8(tc.auth), uint8(tc.integ), uint8(tc.crypt))
+			resp, err := HandleOpenSession(context.Background(), b, payload)
+			if err != nil {
+				t.Fatalf("HandleOpenSession: %v", err)
+			}
+			if len(resp) != 8 || resp[1] != tc.wantErr {
+				t.Fatalf("want status 0x%02x, got len=%d status=0x%02x", tc.wantErr, len(resp), safeStatus(resp))
+			}
+		})
+	}
+}
+
+// TestHandleOpenSession_AcceptsNoneWhenSuite0Configured verifies that an
+// operator who explicitly configures suite 0 (unauthenticated) can still
+// negotiate AuthAlgNone. This is the spec-defined way to opt in to
+// unauthenticated sessions; the security choice is the operator's.
+func TestHandleOpenSession_AcceptsNoneWhenSuite0Configured(t *testing.T) {
+	b := newTestBMC()
+	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID0})
+
+	payload := openSessionPayload(0x01, 0x04, 0x01020304,
+		uint8(bmc.AuthAlgNone), uint8(bmc.IntegrityAlgNone), uint8(bmc.CryptAlgNone))
+	resp, err := HandleOpenSession(context.Background(), b, payload)
+	if err != nil {
+		t.Fatalf("HandleOpenSession: %v", err)
+	}
+	if len(resp) != 36 || resp[1] != 0x00 {
+		t.Fatalf("want success 36-byte response, got len=%d status=0x%02x", len(resp), safeStatus(resp))
+	}
+}
+
+// TestHandleOpenSession_AcceptsMixedSuites verifies that configuring a mix of
+// authenticated and unencrypted suites (e.g. 3 + 15) allows each suite's
+// algorithm triple to be negotiated individually, including IntegrityAlgNone
+// and CryptAlgNone from suite 15.
+func TestHandleOpenSession_AcceptsMixedSuites(t *testing.T) {
+	b := newTestBMC()
+	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID3, bmc.CipherSuiteID15})
+
+	// Suite 15 triple: HMAC-SHA256 auth + None integ + None crypt.
+	payload := openSessionPayload(0x01, 0x04, 0x01020304,
+		uint8(bmc.AuthAlgHMACSHA256), uint8(bmc.IntegrityAlgNone), uint8(bmc.CryptAlgNone))
+	resp, err := HandleOpenSession(context.Background(), b, payload)
+	if err != nil {
+		t.Fatalf("HandleOpenSession: %v", err)
+	}
+	if len(resp) != 36 || resp[1] != 0x00 {
+		t.Fatalf("want success 36-byte response, got len=%d status=0x%02x", len(resp), safeStatus(resp))
+	}
+}
+
 func safeStatus(resp []byte) uint8 {
 	if len(resp) < 2 {
 		return 0xff

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+func TestHandleGetChannelAuthCapsAdvertisesRMCPPlusOnly(t *testing.T) {
+	resp, cc, err := handleGetChannelAuthCaps(context.Background(), &HandlerContext{}, []byte{0x8e, 0x04})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CodeOK {
+		t.Fatalf("want CodeOK, got %d", cc)
+	}
+	if len(resp) != 8 {
+		t.Fatalf("want 8 response bytes, got %d", len(resp))
+	}
+	if resp[1]&0x80 == 0 {
+		t.Fatalf("expected IPMI v2.0 extended capabilities to be available, byte=0x%02x", resp[1])
+	}
+	if resp[3]&0x02 == 0 {
+		t.Fatalf("expected IPMI v2.0 connection support, byte=0x%02x", resp[3])
+	}
+	if resp[3]&0x01 != 0 {
+		t.Fatalf("must not advertise IPMI v1.5 session support, byte=0x%02x", resp[3])
+	}
+}
+
+func TestHandleRAKP1RejectsUnauthorizedPrivilege(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "operator")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("secret"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelUser,
+		Enabled:      true,
+	}
+	sess, err := b.Sessions.Allocate(0x01020304, bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgHMACSHA1_96, bmc.CryptAlgAESCBC128)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	sess.Channel = lanChannelNumber
+	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
+
+	resp, err := HandleRAKP1(context.Background(), b, rakp1Payload(sess.BMCID, bmc.PrivilegeLevelAdministrator, "operator"))
+	if err != nil {
+		t.Fatalf("HandleRAKP1: %v", err)
+	}
+	if len(resp) < 2 || resp[1] != 0x0A {
+		t.Fatalf("want unauthorized privilege status 0x0a, got %x", resp)
+	}
+	if _, err := b.Sessions.Get(sess.BMCID); err == nil {
+		t.Fatalf("unauthorized session should be closed")
+	}
+}
+
+func TestHandleRAKP1AcceptsAuthorizedPrivilege(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+	sess, err := b.Sessions.Allocate(0x01020304, bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgHMACSHA1_96, bmc.CryptAlgAESCBC128)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	sess.Channel = lanChannelNumber
+	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
+
+	resp, err := HandleRAKP1(context.Background(), b, rakp1Payload(sess.BMCID, bmc.PrivilegeLevelAdministrator, "ADMIN"))
+	if err != nil {
+		t.Fatalf("HandleRAKP1: %v", err)
+	}
+	if len(resp) < 40 || resp[1] != 0x00 {
+		t.Fatalf("want successful RAKP2 response, got %x", resp)
+	}
+	if sess.User != user {
+		t.Fatalf("session user was not recorded")
+	}
+}
+
+func rakp1Payload(bmcSessionID uint32, role bmc.PrivilegeLevel, username string) []byte {
+	payload := make([]byte, 28+len(username))
+	payload[0] = 0x01
+	binary.LittleEndian.PutUint32(payload[4:8], bmcSessionID)
+	for i := range payload[8:24] {
+		payload[8+i] = byte(i + 1)
+	}
+	payload[24] = uint8(role)
+	payload[27] = uint8(len(username))
+	copy(payload[28:], username)
+	return payload
+}
+
+// openSessionPayload builds a 32-byte RMCP+ Open Session Request payload with
+// the given algorithm codes. Record layout per spec §13.17:
+//
+//	tag(1) maxPriv(1) reserved(2) consoleID(4)
+//	[auth: type=0 reserved(2) 0x08 alg(1) reserved(3)]
+//	[integ: type=1 reserved(2) 0x08 alg(1) reserved(3)]
+//	[crypt: type=2 reserved(2) 0x08 alg(1) reserved(3)]
+func openSessionPayload(tag, maxPriv uint8, consoleID uint32, authAlg, intAlg, cryptAlg uint8) []byte {
+	p := make([]byte, 32)
+	p[0] = tag
+	p[1] = maxPriv
+	binary.LittleEndian.PutUint32(p[4:8], consoleID)
+	p[11], p[12], p[15] = 0x08, authAlg, 0x08
+	p[19], p[20], p[23] = 0x08, intAlg, 0x08
+	p[27], p[28], p[31] = 0x08, cryptAlg, 0x08
+	p[8] = 0x00  // auth payload type
+	p[16] = 0x01 // integrity payload type
+	p[24] = 0x02 // confidentiality payload type
+	return p
+}
+
+func TestHandleGetChannelCipherSuites_Default(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+
+	// listIndex 0: channel byte + 10 record bytes (suite 3 + suite 17).
+	resp, cc, err := handleGetChannelCipherSuites(context.Background(), hctx, []byte{0x8e, 0x00, 0x00})
+	if err != nil || cc != CodeOK {
+		t.Fatalf("unexpected cc=%d err=%v", cc, err)
+	}
+	if len(resp) != 11 {
+		t.Fatalf("want 11 bytes (1 channel + 10 record), got %d", len(resp))
+	}
+	wantRecords := []byte{0xC0, 0x03, 0x01, 0x41, 0x81, 0xC0, 0x11, 0x03, 0x44, 0x81}
+	if !bytes.Equal(resp[1:], wantRecords) {
+		t.Fatalf("records: want %x, got %x", wantRecords, resp[1:])
+	}
+
+	// listIndex 1: beyond the 10-byte record window, only channel byte remains.
+	resp2, _, _ := handleGetChannelCipherSuites(context.Background(), hctx, []byte{0x8e, 0x00, 0x01})
+	if len(resp2) != 1 {
+		t.Fatalf("listIndex 1: want 1 byte (channel only), got %d", len(resp2))
+	}
+}
+
+func TestHandleGetChannelCipherSuites_Custom(t *testing.T) {
+	b := newTestBMC()
+	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID17})
+	hctx := &HandlerContext{BMC: b}
+
+	resp, cc, err := handleGetChannelCipherSuites(context.Background(), hctx, []byte{0x8e, 0x00, 0x00})
+	if err != nil || cc != CodeOK {
+		t.Fatalf("unexpected cc=%d err=%v", cc, err)
+	}
+	if len(resp) != 6 {
+		t.Fatalf("want 6 bytes (1 channel + 5 record), got %d", len(resp))
+	}
+	wantRecords := []byte{0xC0, 0x11, 0x03, 0x44, 0x81}
+	if !bytes.Equal(resp[1:], wantRecords) {
+		t.Fatalf("records: want %x, got %x", wantRecords, resp[1:])
+	}
+}
+
+func TestHandleOpenSession_AcceptsSHA256(t *testing.T) {
+	b := newTestBMC()
+	payload := openSessionPayload(0x01, 0x04, 0x01020304,
+		uint8(bmc.AuthAlgHMACSHA256), uint8(bmc.IntegrityAlgHMACSHA256_128), uint8(bmc.CryptAlgAESCBC128))
+
+	resp, err := HandleOpenSession(context.Background(), b, payload)
+	if err != nil {
+		t.Fatalf("HandleOpenSession: %v", err)
+	}
+	if len(resp) != 36 || resp[1] != 0x00 {
+		t.Fatalf("want success 36-byte response, got len=%d status=0x%02x", len(resp), safeStatus(resp))
+	}
+	if resp[16] != uint8(bmc.AuthAlgHMACSHA256) {
+		t.Fatalf("auth alg not echoed: 0x%02x", resp[16])
+	}
+	if resp[24] != uint8(bmc.IntegrityAlgHMACSHA256_128) {
+		t.Fatalf("integrity alg not echoed: 0x%02x", resp[24])
+	}
+	if resp[32] != uint8(bmc.CryptAlgAESCBC128) {
+		t.Fatalf("crypt alg not echoed: 0x%02x", resp[32])
+	}
+}
+
+func TestHandleOpenSession_RejectsUnsupported(t *testing.T) {
+	b := newTestBMC()
+	// MD5 auth (0x02) is not part of any configured suite (default {3,17}).
+	payload := openSessionPayload(0x01, 0x04, 0x01020304,
+		uint8(bmc.AuthAlgHMACMD5), uint8(bmc.IntegrityAlgHMACSHA1_96), uint8(bmc.CryptAlgAESCBC128))
+
+	resp, err := HandleOpenSession(context.Background(), b, payload)
+	if err != nil {
+		t.Fatalf("HandleOpenSession: %v", err)
+	}
+	if len(resp) != 8 || resp[1] != 0x04 {
+		t.Fatalf("want status 0x04 (invalid auth alg), got len=%d status=0x%02x", len(resp), safeStatus(resp))
+	}
+}
+
+func safeStatus(resp []byte) uint8 {
+	if len(resp) < 2 {
+		return 0xff
+	}
+	return resp[1]
+}

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 func TestHandleGetChannelAuthCapsAdvertisesRMCPPlusOnly(t *testing.T) {
@@ -153,7 +154,7 @@ func TestHandleGetChannelCipherSuites_Default(t *testing.T) {
 
 func TestHandleGetChannelCipherSuites_Custom(t *testing.T) {
 	b := newTestBMC()
-	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID17})
+	b.SetCipherSuites([]ipmi.CipherSuiteID{ipmi.CipherSuiteID17})
 	hctx := &HandlerContext{BMC: b}
 
 	resp, cc, err := handleGetChannelCipherSuites(context.Background(), hctx, []byte{0x8e, 0x00, 0x00})
@@ -247,7 +248,7 @@ func TestHandleOpenSession_RejectsNoneByDefault(t *testing.T) {
 // unauthenticated sessions; the security choice is the operator's.
 func TestHandleOpenSession_AcceptsNoneWhenSuite0Configured(t *testing.T) {
 	b := newTestBMC()
-	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID0})
+	b.SetCipherSuites([]ipmi.CipherSuiteID{ipmi.CipherSuiteID0})
 
 	payload := openSessionPayload(0x01, 0x04, 0x01020304,
 		uint8(bmc.AuthAlgNone), uint8(bmc.IntegrityAlgNone), uint8(bmc.CryptAlgNone))
@@ -266,7 +267,7 @@ func TestHandleOpenSession_AcceptsNoneWhenSuite0Configured(t *testing.T) {
 // and CryptAlgNone from suite 15.
 func TestHandleOpenSession_AcceptsMixedSuites(t *testing.T) {
 	b := newTestBMC()
-	b.SetCipherSuites([]bmc.CipherSuiteID{bmc.CipherSuiteID3, bmc.CipherSuiteID15})
+	b.SetCipherSuites([]ipmi.CipherSuiteID{ipmi.CipherSuiteID3, ipmi.CipherSuiteID15})
 
 	// Suite 15 triple: HMAC-SHA256 auth + None integ + None crypt.
 	payload := openSessionPayload(0x01, 0x04, 0x01020304,
@@ -289,7 +290,7 @@ func TestHandleOpenSession_AcceptsMixedSuites(t *testing.T) {
 func TestHandleOpenSession_RejectsCrossSuiteRecombination(t *testing.T) {
 	type testCase struct {
 		name       string
-		suites     []bmc.CipherSuiteID
+		suites     []ipmi.CipherSuiteID
 		auth       bmc.AuthAlg
 		integ      bmc.IntegrityAlg
 		crypt      bmc.CryptAlg
@@ -302,7 +303,7 @@ func TestHandleOpenSession_RejectsCrossSuiteRecombination(t *testing.T) {
 			// (SHA1/SHA1-96 from suite 2, AES from suite 17), but no single
 			// configured suite contains the triple.
 			name:       "{2,17} should reject suite 3 (cross-suite SHA1+SHA1-96+AES)",
-			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID2, bmc.CipherSuiteID17},
+			suites:     []ipmi.CipherSuiteID{ipmi.CipherSuiteID2, ipmi.CipherSuiteID17},
 			auth:       bmc.AuthAlgHMACSHA1,
 			integ:      bmc.IntegrityAlgHMACSHA1_96,
 			crypt:      bmc.CryptAlgAESCBC128,
@@ -313,7 +314,7 @@ func TestHandleOpenSession_RejectsCrossSuiteRecombination(t *testing.T) {
 			// is not configured; SHA256/SHA256-128 are from suite 17, None
 			// is from suite 2's crypt.
 			name:       "{2,17} should reject suite 16 (cross-suite SHA256+SHA256-128+None)",
-			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID2, bmc.CipherSuiteID17},
+			suites:     []ipmi.CipherSuiteID{ipmi.CipherSuiteID2, ipmi.CipherSuiteID17},
 			auth:       bmc.AuthAlgHMACSHA256,
 			integ:      bmc.IntegrityAlgHMACSHA256_128,
 			crypt:      bmc.CryptAlgNone,
@@ -326,7 +327,7 @@ func TestHandleOpenSession_RejectsCrossSuiteRecombination(t *testing.T) {
 			// integrity check) would be accepted even though it was never
 			// configured. This is the most dangerous recombination.
 			name:       "{3,15} should reject suite 1 (auth bypass SHA1+None+None)",
-			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID3, bmc.CipherSuiteID15},
+			suites:     []ipmi.CipherSuiteID{ipmi.CipherSuiteID3, ipmi.CipherSuiteID15},
 			auth:       bmc.AuthAlgHMACSHA1,
 			integ:      bmc.IntegrityAlgNone,
 			crypt:      bmc.CryptAlgNone,

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -280,6 +280,47 @@ func TestHandleOpenSession_AcceptsMixedSuites(t *testing.T) {
 	}
 }
 
+// TestComputeRAKP4AuthCode_UsesAuthAlgorithm verifies that the RAKP4 Integrity
+// Check Value is selected by the *authentication* algorithm (spec §13.28.1 /
+// §13.28.1b / §13.31), not the session integrity algorithm. This matters for
+// suites that pair a non-None auth algorithm with Integrity=None (suites 1 and
+// 15): the ICV must still be 12 / 16 bytes, not absent.
+func TestComputeRAKP4AuthCode_UsesAuthAlgorithm(t *testing.T) {
+	b := newTestBMC()
+	cases := []struct {
+		name    string
+		auth    bmc.AuthAlg
+		integ   bmc.IntegrityAlg
+		wantLen int
+	}{
+		{"SHA1 auth + None integ (suite 1)", bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgNone, 12},
+		{"SHA256 auth + None integ (suite 15)", bmc.AuthAlgHMACSHA256, bmc.IntegrityAlgNone, 16},
+		{"SHA1 auth + SHA1-96 integ (suite 3)", bmc.AuthAlgHMACSHA1, bmc.IntegrityAlgHMACSHA1_96, 12},
+		{"SHA256 auth + SHA256-128 integ (suite 17)", bmc.AuthAlgHMACSHA256, bmc.IntegrityAlgHMACSHA256_128, 16},
+		{"None auth + None integ (suite 0)", bmc.AuthAlgNone, bmc.IntegrityAlgNone, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sess, err := b.Sessions.Allocate(0x11223344, tc.auth, tc.integ, bmc.CryptAlgNone)
+			if err != nil {
+				t.Fatalf("allocate session: %v", err)
+			}
+			for i := range sess.ConsoleRand {
+				sess.ConsoleRand[i] = byte(0xA0 + i)
+			}
+			sess.SIK = bytes.Repeat([]byte{0x5a}, 32) // any key longer than block size is fine
+
+			code, err := computeRAKP4AuthCode(sess, b)
+			if err != nil {
+				t.Fatalf("computeRAKP4AuthCode: %v", err)
+			}
+			if len(code) != tc.wantLen {
+				t.Fatalf("ICV length: want %d, got %d (code=%x)", tc.wantLen, len(code), code)
+			}
+		})
+	}
+}
+
 func safeStatus(resp []byte) uint8 {
 	if len(resp) < 2 {
 		return 0xff

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -280,6 +280,78 @@ func TestHandleOpenSession_AcceptsMixedSuites(t *testing.T) {
 	}
 }
 
+// TestHandleOpenSession_RejectsCrossSuiteRecombination verifies that the
+// server rejects algorithm triples formed by recombining algorithms from
+// different configured suites. Configuring suites {2, 17} must NOT accept
+// suite 3 (SHA1 auth + SHA1-96 integ + AES crypt), even though each
+// component exists individually (SHA1 and SHA1-96 from suite 2, AES from
+// suite 17). The triple must come from a single configured suite.
+func TestHandleOpenSession_RejectsCrossSuiteRecombination(t *testing.T) {
+	type testCase struct {
+		name       string
+		suites     []bmc.CipherSuiteID
+		auth       bmc.AuthAlg
+		integ      bmc.IntegrityAlg
+		crypt      bmc.CryptAlg
+		wantStatus uint8
+	}
+
+	cases := []testCase{
+		{
+			// Suites {2, 17}: each component of suite 3 exists individually
+			// (SHA1/SHA1-96 from suite 2, AES from suite 17), but no single
+			// configured suite contains the triple.
+			name:       "{2,17} should reject suite 3 (cross-suite SHA1+SHA1-96+AES)",
+			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID2, bmc.CipherSuiteID17},
+			auth:       bmc.AuthAlgHMACSHA1,
+			integ:      bmc.IntegrityAlgHMACSHA1_96,
+			crypt:      bmc.CryptAlgAESCBC128,
+			wantStatus: 0x04,
+		},
+		{
+			// Suites {2, 17}: SHA256+SHA256-128+None = suite 16. Suite 16
+			// is not configured; SHA256/SHA256-128 are from suite 17, None
+			// is from suite 2's crypt.
+			name:       "{2,17} should reject suite 16 (cross-suite SHA256+SHA256-128+None)",
+			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID2, bmc.CipherSuiteID17},
+			auth:       bmc.AuthAlgHMACSHA256,
+			integ:      bmc.IntegrityAlgHMACSHA256_128,
+			crypt:      bmc.CryptAlgNone,
+			wantStatus: 0x04,
+		},
+		{
+			// Auth bypass: suites {3, 15} create auth={SHA1,SHA256},
+			// integ={SHA1-96,None}, crypt={AES,None}. Without triple
+			// validation, suite 1 (SHA1+None+None — authenticated but no
+			// integrity check) would be accepted even though it was never
+			// configured. This is the most dangerous recombination.
+			name:       "{3,15} should reject suite 1 (auth bypass SHA1+None+None)",
+			suites:     []bmc.CipherSuiteID{bmc.CipherSuiteID3, bmc.CipherSuiteID15},
+			auth:       bmc.AuthAlgHMACSHA1,
+			integ:      bmc.IntegrityAlgNone,
+			crypt:      bmc.CryptAlgNone,
+			wantStatus: 0x04,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBMC()
+			b.SetCipherSuites(tc.suites)
+
+			payload := openSessionPayload(0x01, 0x04, 0x01020304,
+				uint8(tc.auth), uint8(tc.integ), uint8(tc.crypt))
+			resp, err := HandleOpenSession(context.Background(), b, payload)
+			if err != nil {
+				t.Fatalf("HandleOpenSession: %v", err)
+			}
+			if len(resp) != 8 || resp[1] != tc.wantStatus {
+				t.Fatalf("want status 0x%02x, got len=%d status=0x%02x", tc.wantStatus, len(resp), safeStatus(resp))
+			}
+		})
+	}
+}
+
 // TestComputeRAKP4AuthCode_UsesAuthAlgorithm verifies that the RAKP4 Integrity
 // Check Value is selected by the *authentication* algorithm (spec §13.28.1 /
 // §13.28.1b / §13.31), not the session integrity algorithm. This matters for

--- a/pkg/server/integrity.go
+++ b/pkg/server/integrity.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
@@ -91,6 +92,8 @@ func rmcpPlusIntegrityAuthCodeLen(alg bmc.IntegrityAlg) (int, bool) {
 		return 0, true
 	case bmc.IntegrityAlgHMACSHA1_96:
 		return 12, true
+	case bmc.IntegrityAlgHMACSHA256_128:
+		return 16, true
 	default:
 		return 0, false
 	}
@@ -102,6 +105,10 @@ func rmcpPlusIntegrityAuthCode(alg bmc.IntegrityAlg, data, key []byte) []byte {
 		h := hmac.New(sha1.New, key)
 		h.Write(data)
 		return h.Sum(nil)[:12]
+	case bmc.IntegrityAlgHMACSHA256_128:
+		h := hmac.New(sha256.New, key)
+		h.Write(data)
+		return h.Sum(nil)[:16]
 	default:
 		return nil
 	}

--- a/pkg/server/integrity_test.go
+++ b/pkg/server/integrity_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+)
+
+type capturePacketConn struct {
+	writes [][]byte
+}
+
+func (c *capturePacketConn) ReadFrom(_ []byte) (int, net.Addr, error) {
+	return 0, nil, errors.New("not implemented")
+}
+
+func (c *capturePacketConn) WriteTo(data []byte, _ net.Addr) (int, error) {
+	c.writes = append(c.writes, append([]byte(nil), data...))
+	return len(data), nil
+}
+
+func (c *capturePacketConn) Close() error {
+	return nil
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return string(a) }
+
+func TestSendRMCPPlusSessionAddsIntegrityTrailer(t *testing.T) {
+	conn := &capturePacketConn{}
+	srv := &Server{conn: conn}
+	sess := &bmc.Session{
+		ConsoleID:    0x11223344,
+		OutboundSeq:  7,
+		IntegrityAlg: bmc.IntegrityAlgHMACSHA1_96,
+		K1:           []byte("0123456789abcdefghij"),
+	}
+	payload := []byte{0x20, 0x18, 0xc8, 0x81, 0x00}
+
+	srv.sendRMCPPlusSession(testAddr("console"), srvPayloadIPMI, 0, sess, payload)
+
+	if len(conn.writes) != 1 {
+		t.Fatalf("want one packet, got %d", len(conn.writes))
+	}
+	pkt := conn.writes[0]
+	if pkt[5]&protocol.PayloadAuthenticatedFlag == 0 {
+		t.Fatalf("authenticated bit was not set: payload type byte=0x%02x", pkt[5])
+	}
+	if !verifyRMCPPlusIntegrity(pkt, sess, true) {
+		t.Fatalf("generated integrity trailer did not verify")
+	}
+
+	tampered := append([]byte(nil), pkt...)
+	tampered[rmcpPlusPayloadOffset] ^= 0xff
+	if verifyRMCPPlusIntegrity(tampered, sess, true) {
+		t.Fatalf("tampered packet passed integrity verification")
+	}
+}
+
+func TestVerifyRMCPPlusIntegrityRequiresAuthenticatedFlag(t *testing.T) {
+	sess := &bmc.Session{
+		IntegrityAlg: bmc.IntegrityAlgHMACSHA1_96,
+		K1:           []byte("0123456789abcdefghij"),
+	}
+	pkt := protocol.BuildRMCPPlusPacket(srvPayloadIPMI, protocol.PayloadAuthenticatedFlag, 1, 1, []byte{0x01, 0x02})
+	pkt, ok := appendRMCPPlusIntegrity(pkt, sess)
+	if !ok {
+		t.Fatalf("appendRMCPPlusIntegrity failed")
+	}
+
+	if verifyRMCPPlusIntegrity(pkt, sess, false) {
+		t.Fatalf("packet without authenticated flag should not verify")
+	}
+}
+
+func TestRMCPPlusIntegrity_SHA256_128(t *testing.T) {
+	sess := &bmc.Session{
+		ConsoleID:    0x11223344,
+		OutboundSeq:  3,
+		IntegrityAlg: bmc.IntegrityAlgHMACSHA256_128,
+		// SHA256-128 uses a 128-bit (16-byte) K1; any 16+ byte key works.
+		K1: []byte("0123456789abcdef"),
+	}
+	payload := []byte{0x20, 0x18, 0xc8, 0x81, 0x00}
+
+	pkt, ok := appendRMCPPlusIntegrity(protocol.BuildRMCPPlusPacket(
+		srvPayloadIPMI, protocol.PayloadAuthenticatedFlag, sess.ConsoleID, sess.OutboundSeq, payload), sess)
+	if !ok {
+		t.Fatalf("appendRMCPPlusIntegrity failed for SHA256-128")
+	}
+
+	if !verifyRMCPPlusIntegrity(pkt, sess, true) {
+		t.Fatalf("SHA256-128 integrity trailer did not verify")
+	}
+
+	// The auth code length must be 16 bytes (128 bits), not 12 (SHA1-96).
+	authCodeLen, ok := rmcpPlusIntegrityAuthCodeLen(sess.IntegrityAlg)
+	if !ok || authCodeLen != 16 {
+		t.Fatalf("want authCodeLen 16, got %d (ok=%v)", authCodeLen, ok)
+	}
+	padLen := rmcpPlusIntegrityPadLen(rmcpPlusHeaderSize, len(payload))
+	authCodeStart := rmcpPlusPayloadOffset + len(payload) + padLen + 2
+	if got := len(pkt) - authCodeStart; got != 16 {
+		t.Fatalf("trailer auth code length: want 16, got %d", got)
+	}
+
+	tampered := append([]byte(nil), pkt...)
+	tampered[rmcpPlusPayloadOffset] ^= 0xff
+	if verifyRMCPPlusIntegrity(tampered, sess, true) {
+		t.Fatalf("tampered SHA256-128 packet passed integrity verification")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,6 +72,18 @@ func WithServerBufferSize(n int) ServerOption {
 	return func(s *Server) { s.bufSize = n }
 }
 
+// WithCipherSuites configures the RMCP+ cipher suites the server advertises
+// and accepts. Each ID must be a suite the reference server implements
+// (validated by [bmc.BMC.SetCipherSuites]); passing an unsupported suite
+// panics. Use this to advertise only a subset, e.g. only suite 17.
+func WithCipherSuites(ids []bmc.CipherSuiteID) ServerOption {
+	return func(s *Server) {
+		if s.bmc != nil {
+			s.bmc.SetCipherSuites(ids)
+		}
+	}
+}
+
 // NewServer creates a Server.
 //
 // b is the BMC state (create with [bmc.New]).

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,7 +76,7 @@ func WithServerBufferSize(n int) ServerOption {
 // and accepts. Each ID must be a suite the reference server implements
 // (validated by [bmc.BMC.SetCipherSuites]); passing an unsupported suite
 // panics. Use this to advertise only a subset, e.g. only suite 17.
-func WithCipherSuites(ids []bmc.CipherSuiteID) ServerOption {
+func WithCipherSuites(ids []ipmi.CipherSuiteID) ServerOption {
 	return func(s *Server) {
 		if s.bmc != nil {
 			s.bmc.SetCipherSuites(ids)

--- a/test/e2e/cipher_suite_test.sh
+++ b/test/e2e/cipher_suite_test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# cipher_suite_test.sh — E2E for RMCP+ cipher suite 17 (SHA256) support
+# (branch feat/server-cipher-suite-17).
+#
+# Starts goipmi-server (which advertises {3, 17} by default) and connects with
+# ipmitool using explicit cipher-suite selectors, so the server's RAKP/HMAC and
+# integrity handling for SHA256 is validated by an external, spec-faithful
+# client rather than our own client.
+#
+# Covers the acceptance criteria from docs/upstream-plan-2026-06.md §A.8:
+#   - ipmitool -C 17 (RAKP-HMAC-SHA256, HMAC-SHA256-128, AES-CBC-128) succeeds
+#   - ipmitool -C 3  (RAKP-HMAC-SHA1,  HMAC-SHA1-96,   AES-CBC-128) still works
+#
+# Environment variables:
+#   GOIPMI_SERVER_PORT – server listen port (default: random high port)
+#   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
+#
+# Requires: make build  (or: make test-e2e-cipher)
+#
+# Usage:
+#   ./test/e2e/cipher_suite_test.sh
+#   GOIPMI_SERVER_PORT=9623 ./test/e2e/cipher_suite_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+PORT="${GOIPMI_SERVER_PORT:-$((9900 + RANDOM % 1000))}"
+USER="${GOIPMI_USER:-ADMIN}"
+PASS="${GOIPMI_PASS:-ADMIN}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+
+# ---------------------------------------------------------------------------
+# Find or choose an ipmitool (local install, else Docker image).
+# ---------------------------------------------------------------------------
+IPMITOOL_BIN="${IPMITOOL_BIN:-}"
+if [ -z "${IPMITOOL_BIN}" ]; then
+	if command -v ipmitool &>/dev/null; then
+		IPMITOOL_BIN="ipmitool"
+	fi
+fi
+
+if [ -n "${IPMITOOL_BIN}" ]; then
+	echo "==> Using ipmitool: ${IPMITOOL_BIN}"
+	IPMITOOL_RUN="${IPMITOOL_BIN}"
+else
+	echo "==> ipmitool not found locally, will use Docker: ${IPMITOOL_IMAGE}"
+	IPMITOOL_RUN="docker run --rm --network host ${IPMITOOL_IMAGE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Start the server
+# ---------------------------------------------------------------------------
+cleanup() {
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo "==> Stopping goipmi-server (pid ${SERVER_PID}) ..."
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+echo "==> Starting goipmi-server on :${PORT} ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	"${SERVER_BIN}" &
+SERVER_PID=$!
+sleep 1
+
+if ! ss -uln | grep -q ":${PORT} "; then
+	echo -e "${RED}ERROR: server failed to start${NC}" >&2
+	exit 1
+fi
+
+IPMI_ARGS=(-H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus)
+
+# run_cipher <suite> <ipmitool-args...>
+run_cipher() {
+	local suite="$1"
+	shift
+	# shellcheck disable=SC2086
+	${IPMITOOL_RUN} "${IPMI_ARGS[@]}" -C "${suite}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Run the tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Cipher Suite E2E: ipmitool → goipmi-server (:${PORT})"
+echo "========================================"
+
+# Suite 17 = RAKP-HMAC-SHA256 / HMAC-SHA256-128 / AES-CBC-128.  The Get Channel
+# Cipher Suites / Open Session / RAKP handshake and the first authenticated,
+# encrypted command must all succeed.
+test_suite17_chassis_status() {
+	local out
+	out=$(run_cipher 17 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 17 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 17 over a different NetFn (App Get Device ID) to exercise SHA256-128
+# integrity on more than one payload type.
+test_suite17_mc_info() {
+	local out
+	out=$(run_cipher 17 mc info 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "Device ID" && return 0
+	echo "  suite 17 mc info mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 3 = RAKP-HMAC-SHA1 / HMAC-SHA1-96 / AES-CBC-128.  Regression guard: the
+# SHA256 additions must not break the existing SHA1 path.
+test_suite3_chassis_status() {
+	local out
+	out=$(run_cipher 3 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 3 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+failures=0
+e2e_run_test "suite 17 (SHA256) chassis status" test_suite17_chassis_status || ((failures++)) || true
+e2e_run_test "suite 17 (SHA256) mc info"        test_suite17_mc_info        || ((failures++)) || true
+e2e_run_test "suite 3 (SHA1) chassis status"    test_suite3_chassis_status  || ((failures++)) || true
+
+e2e_report "Cipher Suite E2E" "${failures}"

--- a/test/e2e/cipher_suite_test.sh
+++ b/test/e2e/cipher_suite_test.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-# cipher_suite_test.sh — E2E for RMCP+ cipher suite 17 (SHA256) support
-# (branch feat/server-cipher-suite-17).
+# cipher_suite_test.sh — E2E for RMCP+ cipher suite coverage.
 #
-# Starts goipmi-server (which advertises {3, 17} by default) and connects with
-# ipmitool using explicit cipher-suite selectors, so the server's RAKP/HMAC and
-# integrity handling for SHA256 is validated by an external, spec-faithful
-# client rather than our own client.
+# Starts two goipmi-server instances:
+#   1) default config ({3, 17})        — verifies suites 3/17 succeed and that
+#      suite 0 (AuthAlgNone) is rejected, guarding against the auth bypass.
+#   2) extended config ({1,2,15,16,3,17}) — verifies the remaining spec-defined
+#      suites (1, 2, 15, 16) succeed end-to-end with an external, spec-faithful
+#      ipmitool client. This exercises RAKP4 ICV derivation by the *auth*
+#      algorithm (spec §13.28.1/§13.28.1b) for suites that pair a non-None auth
+#      algorithm with Integrity=None (suites 1 and 15).
 #
 # Covers the acceptance criteria from docs/upstream-plan-2026-06.md §A.8:
 #   - ipmitool -C 17 (RAKP-HMAC-SHA256, HMAC-SHA256-128, AES-CBC-128) succeeds
 #   - ipmitool -C 3  (RAKP-HMAC-SHA1,  HMAC-SHA1-96,   AES-CBC-128) still works
 #
 # Environment variables:
-#   GOIPMI_SERVER_PORT – server listen port (default: random high port)
+#   GOIPMI_SERVER_PORT – default server listen port (default: random high port)
+#   GOIPMI_SERVER_PORT_EXTENDED – extended-config server port (default: random)
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #
 # Requires: make build  (or: make test-e2e-cipher)
@@ -28,6 +32,7 @@ source "$(dirname "$0")/common.sh"
 e2e_init
 
 PORT="${GOIPMI_SERVER_PORT:-$((9900 + RANDOM % 1000))}"
+PORT_EXTENDED="${GOIPMI_SERVER_PORT_EXTENDED:-$((11100 + RANDOM % 1000))}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
 IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
@@ -59,10 +64,15 @@ cleanup() {
 		kill "${SERVER_PID}" 2>/dev/null || true
 		wait "${SERVER_PID}" 2>/dev/null || true
 	fi
+	if [ -n "${EXTENDED_PID:-}" ] && kill -0 "${EXTENDED_PID}" 2>/dev/null; then
+		echo "==> Stopping extended-config goipmi-server (pid ${EXTENDED_PID}) ..."
+		kill "${EXTENDED_PID}" 2>/dev/null || true
+		wait "${EXTENDED_PID}" 2>/dev/null || true
+	fi
 }
 trap cleanup EXIT
 
-echo "==> Starting goipmi-server on :${PORT} ..."
+echo "==> Starting goipmi-server on :${PORT} (default cipher suites) ..."
 env \
 	GOIPMI_SERVER_PORT="${PORT}" \
 	GOIPMI_SERVER_USER="${USER}" \
@@ -76,14 +86,37 @@ if ! ss -uln | grep -q ":${PORT} "; then
 	exit 1
 fi
 
-IPMI_ARGS=(-H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus)
+echo "==> Starting goipmi-server on :${PORT_EXTENDED} (extended cipher suites 1,2,15,16,3,17) ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT_EXTENDED}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	GOIPMI_SERVER_CIPHER_SUITES="1,2,15,16,3,17" \
+	"${SERVER_BIN}" &
+EXTENDED_PID=$!
+sleep 1
 
-# run_cipher <suite> <ipmitool-args...>
+if ! ss -uln | grep -q ":${PORT_EXTENDED} "; then
+	echo -e "${RED}ERROR: extended-config server failed to start${NC}" >&2
+	exit 1
+fi
+
+IPMI_ARGS=(-H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus)
+IPMI_ARGS_EXTENDED=(-H 127.0.0.1 -p "${PORT_EXTENDED}" -U "${USER}" -P "${PASS}" -I lanplus)
+
+# run_cipher <suite> <ipmitool-args...>          — against the default server.
+# run_cipher_extended <suite> <ipmitool-args...> — against the extended server.
 run_cipher() {
 	local suite="$1"
 	shift
 	# shellcheck disable=SC2086
 	${IPMITOOL_RUN} "${IPMI_ARGS[@]}" -C "${suite}" "$@"
+}
+run_cipher_extended() {
+	local suite="$1"
+	shift
+	# shellcheck disable=SC2086
+	${IPMITOOL_RUN} "${IPMI_ARGS_EXTENDED[@]}" -C "${suite}" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -91,7 +124,9 @@ run_cipher() {
 # ---------------------------------------------------------------------------
 echo ""
 echo "========================================"
-echo " Cipher Suite E2E: ipmitool → goipmi-server (:${PORT})"
+echo " Cipher Suite E2E: ipmitool → goipmi-server"
+echo "   default   :${PORT}  (suites 3, 17)"
+echo "   extended  :${PORT_EXTENDED}  (suites 1, 2, 15, 16, 3, 17)"
 echo "========================================"
 
 # Suite 17 = RAKP-HMAC-SHA256 / HMAC-SHA256-128 / AES-CBC-128.  The Get Channel
@@ -144,10 +179,60 @@ test_suite0_rejected_by_default() {
 	return 0
 }
 
+# The following suites are negotiated against the extended-config server
+# (GOIPMI_SERVER_CIPHER_SUITES="1,2,15,16,3,17"). Each must complete the full
+# RAKP handshake and an authenticated (optionally encrypted) command.
+
+# Suite 1 = RAKP-HMAC-SHA1 / Integrity-None / Confidentiality-None.
+# Exercises the spec-correct RAKP4 ICV: selected by the *auth* algorithm
+# (HMAC-SHA1-96, 12 bytes) even though Integrity=None (spec §13.28.1, §13.31).
+test_suite1_chassis_status() {
+	local out
+	out=$(run_cipher_extended 1 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 1 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 2 = RAKP-HMAC-SHA1 / HMAC-SHA1-96 / Confidentiality-None.
+# Authenticated + integrity-protected, unencrypted.
+test_suite2_chassis_status() {
+	local out
+	out=$(run_cipher_extended 2 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 2 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 15 = RAKP-HMAC-SHA256 / Integrity-None / Confidentiality-None.
+# Like suite 1 but with SHA256 auth: RAKP4 ICV = HMAC-SHA256-128 (16 bytes)
+# even though Integrity=None (spec §13.28.1b, §13.31).
+test_suite15_chassis_status() {
+	local out
+	out=$(run_cipher_extended 15 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 15 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 16 = RAKP-HMAC-SHA256 / HMAC-SHA256-128 / Confidentiality-None.
+# Authenticated + integrity-protected, unencrypted.
+test_suite16_chassis_status() {
+	local out
+	out=$(run_cipher_extended 16 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 16 chassis status mismatch: ${out}" >&2
+	return 1
+}
+
 failures=0
 e2e_run_test "suite 17 (SHA256) chassis status" test_suite17_chassis_status || ((failures++)) || true
 e2e_run_test "suite 17 (SHA256) mc info"        test_suite17_mc_info        || ((failures++)) || true
 e2e_run_test "suite 3 (SHA1) chassis status"    test_suite3_chassis_status  || ((failures++)) || true
 e2e_run_test "suite 0 (AuthAlgNone) rejected by default" test_suite0_rejected_by_default || ((failures++)) || true
+e2e_run_test "suite 1 (SHA1, no integ/crypt)"   test_suite1_chassis_status  || ((failures++)) || true
+e2e_run_test "suite 2 (SHA1, no crypt)"         test_suite2_chassis_status  || ((failures++)) || true
+e2e_run_test "suite 15 (SHA256, no integ/crypt)" test_suite15_chassis_status || ((failures++)) || true
+e2e_run_test "suite 16 (SHA256, no crypt)"       test_suite16_chassis_status || ((failures++)) || true
 
 e2e_report "Cipher Suite E2E" "${failures}"

--- a/test/e2e/cipher_suite_test.sh
+++ b/test/e2e/cipher_suite_test.sh
@@ -125,9 +125,29 @@ test_suite3_chassis_status() {
 	return 1
 }
 
+# Suite 0 = RAKP-None / Integrity-None / Confidentiality-None.  The default
+# cipher suite set ({3, 17}) does not advertise suite 0, so the server must
+# reject the Open Session Request (error 0x04 invalid auth alg) and no
+# authenticated session may be established.  This guards against the
+# authentication bypass where AuthAlgNone skips RAKP password verification.
+test_suite0_rejected_by_default() {
+	local out rc
+	out=$(run_cipher 0 chassis status 2>&1) && rc=0 || rc=$?
+	if [ "${rc}" -eq 0 ]; then
+		echo "  suite 0 (AuthAlgNone) unexpectedly established a session: ${out}" >&2
+		return 1
+	fi
+	if echo "${out}" | grep -q "System Power"; then
+		echo "  suite 0 (AuthAlgNone) executed a command despite default config: ${out}" >&2
+		return 1
+	fi
+	return 0
+}
+
 failures=0
 e2e_run_test "suite 17 (SHA256) chassis status" test_suite17_chassis_status || ((failures++)) || true
 e2e_run_test "suite 17 (SHA256) mc info"        test_suite17_mc_info        || ((failures++)) || true
 e2e_run_test "suite 3 (SHA1) chassis status"    test_suite3_chassis_status  || ((failures++)) || true
+e2e_run_test "suite 0 (AuthAlgNone) rejected by default" test_suite0_rejected_by_default || ((failures++)) || true
 
 e2e_report "Cipher Suite E2E" "${failures}"

--- a/test/e2e/cipher_suite_test.sh
+++ b/test/e2e/cipher_suite_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cipher_suite_test.sh — E2E for RMCP+ cipher suite coverage.
 #
-# Starts two goipmi-server instances:
+# Starts three goipmi-server instances:
 #   1) default config ({3, 17})        — verifies suites 3/17 succeed and that
 #      suite 0 (AuthAlgNone) is rejected, guarding against the auth bypass.
 #   2) extended config ({1,2,15,16,3,17}) — verifies the remaining spec-defined
@@ -9,6 +9,10 @@
 #      ipmitool client. This exercises RAKP4 ICV derivation by the *auth*
 #      algorithm (spec §13.28.1/§13.28.1b) for suites that pair a non-None auth
 #      algorithm with Integrity=None (suites 1 and 15).
+#   3) cross-suite config ({2, 17})    — verifies that suite 3 (SHA1+SHA1-96+AES)
+#      is rejected even though each algorithm appears individually (SHA1/SHA1-96
+#      from suite 2, AES from suite 17). This guards against cross-suite
+#      algorithm recombination in Open Session negotiation.
 #
 # Covers the acceptance criteria from docs/upstream-plan-2026-06.md §A.8:
 #   - ipmitool -C 17 (RAKP-HMAC-SHA256, HMAC-SHA256-128, AES-CBC-128) succeeds
@@ -17,6 +21,7 @@
 # Environment variables:
 #   GOIPMI_SERVER_PORT – default server listen port (default: random high port)
 #   GOIPMI_SERVER_PORT_EXTENDED – extended-config server port (default: random)
+#   GOIPMI_SERVER_PORT_CROSS – cross-suite-test server port (default: random)
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #
 # Requires: make build  (or: make test-e2e-cipher)
@@ -33,6 +38,7 @@ e2e_init
 
 PORT="${GOIPMI_SERVER_PORT:-$((9900 + RANDOM % 1000))}"
 PORT_EXTENDED="${GOIPMI_SERVER_PORT_EXTENDED:-$((11100 + RANDOM % 1000))}"
+PORT_CROSS="${GOIPMI_SERVER_PORT_CROSS:-$((11300 + RANDOM % 1000))}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
 IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
@@ -69,6 +75,11 @@ cleanup() {
 		kill "${EXTENDED_PID}" 2>/dev/null || true
 		wait "${EXTENDED_PID}" 2>/dev/null || true
 	fi
+	if [ -n "${CROSS_PID:-}" ] && kill -0 "${CROSS_PID}" 2>/dev/null; then
+		echo "==> Stopping cross-suite-test goipmi-server (pid ${CROSS_PID}) ..."
+		kill "${CROSS_PID}" 2>/dev/null || true
+		wait "${CROSS_PID}" 2>/dev/null || true
+	fi
 }
 trap cleanup EXIT
 
@@ -101,11 +112,28 @@ if ! ss -uln | grep -q ":${PORT_EXTENDED} "; then
 	exit 1
 fi
 
+echo "==> Starting goipmi-server on :${PORT_CROSS} (cross-suite-test cipher suites 2,17) ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT_CROSS}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	GOIPMI_SERVER_CIPHER_SUITES="2,17" \
+	"${SERVER_BIN}" &
+CROSS_PID=$!
+sleep 1
+
+if ! ss -uln | grep -q ":${PORT_CROSS} "; then
+	echo -e "${RED}ERROR: cross-suite-test server failed to start${NC}" >&2
+	exit 1
+fi
+
 IPMI_ARGS=(-H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus)
 IPMI_ARGS_EXTENDED=(-H 127.0.0.1 -p "${PORT_EXTENDED}" -U "${USER}" -P "${PASS}" -I lanplus)
+IPMI_ARGS_CROSS=(-H 127.0.0.1 -p "${PORT_CROSS}" -U "${USER}" -P "${PASS}" -I lanplus)
 
 # run_cipher <suite> <ipmitool-args...>          — against the default server.
 # run_cipher_extended <suite> <ipmitool-args...> — against the extended server.
+# run_cipher_cross <suite> <ipmitool-args...>    — against the cross-suite-test server.
 run_cipher() {
 	local suite="$1"
 	shift
@@ -118,6 +146,12 @@ run_cipher_extended() {
 	# shellcheck disable=SC2086
 	${IPMITOOL_RUN} "${IPMI_ARGS_EXTENDED[@]}" -C "${suite}" "$@"
 }
+run_cipher_cross() {
+	local suite="$1"
+	shift
+	# shellcheck disable=SC2086
+	${IPMITOOL_RUN} "${IPMI_ARGS_CROSS[@]}" -C "${suite}" "$@"
+}
 
 # ---------------------------------------------------------------------------
 # Run the tests
@@ -127,6 +161,7 @@ echo "========================================"
 echo " Cipher Suite E2E: ipmitool → goipmi-server"
 echo "   default   :${PORT}  (suites 3, 17)"
 echo "   extended  :${PORT_EXTENDED}  (suites 1, 2, 15, 16, 3, 17)"
+echo "   cross     :${PORT_CROSS}  (suites 2, 17)"
 echo "========================================"
 
 # Suite 17 = RAKP-HMAC-SHA256 / HMAC-SHA256-128 / AES-CBC-128.  The Get Channel
@@ -177,6 +212,46 @@ test_suite0_rejected_by_default() {
 		return 1
 	fi
 	return 0
+}
+
+# Cross-suite recombination guard: server configured with {2, 17} must reject
+# suite 3 (SHA1+SHA1-96+AES).  Each algorithm appears in some configured suite
+# (SHA1/SHA1-96 from suite 2, AES from suite 17), but the triple as a unit was
+# never advertised.  Accepting it would violate the cipher suite model and,
+# with certain configs (e.g. {3, 15}), could silently enable suite 1
+# (authenticated but no integrity check).
+test_suite3_rejected_by_cross_suite_server() {
+	local out rc
+	out=$(run_cipher_cross 3 chassis status 2>&1) && rc=0 || rc=$?
+	if [ "${rc}" -eq 0 ]; then
+		echo "  suite 3 (cross-suite recombination) unexpectedly established a session: ${out}" >&2
+		return 1
+	fi
+	if echo "${out}" | grep -q "System Power"; then
+		echo "  suite 3 (cross-suite recombination) executed a command despite not being configured: ${out}" >&2
+		return 1
+	fi
+	return 0
+}
+
+# Suite 2 against the cross-suite server ({2, 17}) must succeed — it is a
+# legitimately configured suite.
+test_suite2_cross_suite_server() {
+	local out
+	out=$(run_cipher_cross 2 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 2 (cross-suite server) chassis status mismatch: ${out}" >&2
+	return 1
+}
+
+# Suite 17 against the cross-suite server ({2, 17}) must succeed — it is a
+# legitimately configured suite.
+test_suite17_cross_suite_server() {
+	local out
+	out=$(run_cipher_cross 17 chassis status 2>&1) || { echo "${out}" >&2; return 1; }
+	echo "${out}" | grep -q "System Power" && return 0
+	echo "  suite 17 (cross-suite server) chassis status mismatch: ${out}" >&2
+	return 1
 }
 
 # The following suites are negotiated against the extended-config server
@@ -230,6 +305,9 @@ e2e_run_test "suite 17 (SHA256) chassis status" test_suite17_chassis_status || (
 e2e_run_test "suite 17 (SHA256) mc info"        test_suite17_mc_info        || ((failures++)) || true
 e2e_run_test "suite 3 (SHA1) chassis status"    test_suite3_chassis_status  || ((failures++)) || true
 e2e_run_test "suite 0 (AuthAlgNone) rejected by default" test_suite0_rejected_by_default || ((failures++)) || true
+e2e_run_test "suite 3 rejected by {2,17} cross-suite server" test_suite3_rejected_by_cross_suite_server || ((failures++)) || true
+e2e_run_test "suite 2 (SHA1, no crypt) on cross-suite server" test_suite2_cross_suite_server || ((failures++)) || true
+e2e_run_test "suite 17 (SHA256) on cross-suite server" test_suite17_cross_suite_server || ((failures++)) || true
 e2e_run_test "suite 1 (SHA1, no integ/crypt)"   test_suite1_chassis_status  || ((failures++)) || true
 e2e_run_test "suite 2 (SHA1, no crypt)"         test_suite2_chassis_status  || ((failures++)) || true
 e2e_run_test "suite 15 (SHA256, no integ/crypt)" test_suite15_chassis_status || ((failures++)) || true


### PR DESCRIPTION
Add RAKP-HMAC-SHA256 auth (0x03) and HMAC-SHA256-128 integrity (0x04) to the reference RMCP+ server so ipmitool -C 17 completes the handshake. Cipher suite advertisement and Open Session algorithm acceptance are now driven by a configurable cipher suite list on the BMC (default {3, 17}) instead of a hardcoded SHA1-only record.