### PR TITLE
Implement windows client support

### DIFF
--- a/pkg/client/interface_system.go
+++ b/pkg/client/interface_system.go
@@ -3,14 +3,18 @@ package client
 import (
 	"context"
 	"fmt"
-
-	"github.com/bougou/go-ipmi/open"
-	ipmi "github.com/bougou/go-ipmi/pkg/types"
-	"math/rand"
 	"os"
-	"unsafe"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
+// openipmi holds the state for the "open" (local) interface.
+//
+// The local interface talks to the BMC directly through the host system
+// interface. The concrete transport is platform specific:
+//   - linux:   the OpenIPMI kernel driver (/dev/ipmiN) via ioctl.
+//   - windows: the Microsoft_IPMI WMI provider (ipmidrv.sys).
+//   - others:  not supported.
 type openipmi struct {
 	myAddr         uint8
 	msgID          int64
@@ -20,60 +24,12 @@ type openipmi struct {
 	transitAddr    uint8
 	transitLUN     uint8
 
-	file *os.File // /dev/ipmi0
+	file *os.File // /dev/ipmi0 (linux only)
 }
 
-// ConnectOpen try to initialize the client by open the device of linux ipmi driver.
-func (c *Client) ConnectOpen(ctx context.Context, devnum int32) error {
-	c.Debugf("Using ipmi device %d\n", devnum)
-
-	// try the following devices
-	var (
-		ipmiDev1 string = fmt.Sprintf("/dev/ipmi%d", devnum)
-		ipmiDev2 string = fmt.Sprintf("/dev/ipmi/%d", devnum)
-		ipmiDev3 string = fmt.Sprintf("/dev/ipmidev/%d", devnum)
-	)
-
-	var file *os.File
-	var tryOpenFile = func(ipmiDev string) {
-		if file != nil {
-			return
-		}
-		if f, err := os.OpenFile(ipmiDev, os.O_RDWR, 0); err != nil {
-			c.Debugf("can not open ipmi dev (%s), err: %w\n", ipmiDev, err)
-		} else {
-			file = f
-			c.Debugf("opened ipmi dev file: %v\n", ipmiDev)
-		}
-	}
-	tryOpenFile(ipmiDev1)
-	tryOpenFile(ipmiDev2)
-	tryOpenFile(ipmiDev3)
-
-	if file == nil {
-		return fmt.Errorf("ipmi dev file not opened")
-	}
-
-	c.Debugf("opened ipmi dev file: %v, descriptor is: %d\n", file, file.Fd())
-	// set opened ipmi dev file
-	c.openipmi.file = file
-
-	var receiveEvents uint32 = 1
-	if err := open.IOCTL(c.openipmi.file.Fd(), open.IPMICTL_SET_GETS_EVENTS_CMD, uintptr(unsafe.Pointer(&receiveEvents))); err != nil {
-		return fmt.Errorf("ioctl failed, cloud not enable event receiver, err: %w", err)
-	}
-
-	return nil
-}
-
-// closeOpen closes the ipmi dev file.
-func (c *Client) closeOpen(ctx context.Context) error {
-	if err := c.openipmi.file.Close(); err != nil {
-		return fmt.Errorf("close open file failed, err: %w", err)
-	}
-	return nil
-}
-
+// exchangeOpen sends a request through the local system interface and unpacks
+// the response. It is platform agnostic and relies on the platform specific
+// openSendRequest implementation to perform the actual transport.
 func (c *Client) exchangeOpen(ctx context.Context, request ipmi.Request, response ipmi.Response) error {
 	if c.openipmi.targetAddr != 0 && c.openipmi.targetAddr != c.openipmi.myAddr {
 
@@ -117,55 +73,4 @@ func (c *Client) exchangeOpen(ctx context.Context, request ipmi.Request, respons
 
 	c.Debug("<< Command Response", response)
 	return nil
-}
-
-func (c *Client) openSendRequest(ctx context.Context, request ipmi.Request) ([]byte, error) {
-
-	var dataPtr *byte
-
-	cmdData := request.Pack()
-	c.DebugBytes("cmdData", cmdData, 16)
-	if len(cmdData) > 0 {
-		dataPtr = &cmdData[0]
-	}
-
-	c.DebugBytes("cmd data", cmdData, 16)
-
-	msg := &open.IPMI_MSG{
-		NetFn:   uint8(request.Command().NetFn),
-		Cmd:     uint8(request.Command().ID),
-		Data:    dataPtr,
-		DataLen: uint16(len(cmdData)),
-	}
-
-	addr := &open.IPMI_SYSTEM_INTERFACE_ADDR{
-		AddrType: open.IPMI_SYSTEM_INTERFACE_ADDR_TYPE,
-		Channel:  open.IPMI_BMC_CHANNEL,
-		LUN:      0,
-	}
-
-	commandContext := GetCommandContext(ctx)
-	if commandContext != nil {
-		c.Debug("Got CommandContext:", commandContext)
-
-		if commandContext.responderAddr != nil {
-		}
-		if commandContext.responderLUN != nil {
-			addr.LUN = *commandContext.responderLUN
-		}
-		if commandContext.requesterAddr != nil {
-		}
-		if commandContext.requesterLUN != nil {
-		}
-	}
-
-	req := &open.IPMI_REQ{
-		Addr:    addr,
-		AddrLen: int(unsafe.Sizeof(addr)),
-		MsgID:   rand.Int63(),
-		Msg:     *msg,
-	}
-
-	c.Debug("IPMI_REQ", req)
-	return open.SendCommand(c.openipmi.file, req, c.timeout)
 }

--- a/pkg/client/interface_system_linux.go
+++ b/pkg/client/interface_system_linux.go
@@ -1,0 +1,117 @@
+//go:build linux
+// +build linux
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"unsafe"
+
+	"github.com/bougou/go-ipmi/open"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// ConnectOpen try to initialize the client by open the device of linux ipmi driver.
+func (c *Client) ConnectOpen(ctx context.Context, devnum int32) error {
+	c.Debugf("Using ipmi device %d\n", devnum)
+
+	// try the following devices
+	var (
+		ipmiDev1 string = fmt.Sprintf("/dev/ipmi%d", devnum)
+		ipmiDev2 string = fmt.Sprintf("/dev/ipmi/%d", devnum)
+		ipmiDev3 string = fmt.Sprintf("/dev/ipmidev/%d", devnum)
+	)
+
+	var file *os.File
+	var tryOpenFile = func(ipmiDev string) {
+		if file != nil {
+			return
+		}
+		if f, err := os.OpenFile(ipmiDev, os.O_RDWR, 0); err != nil {
+			c.Debugf("can not open ipmi dev (%s), err: %w\n", ipmiDev, err)
+		} else {
+			file = f
+			c.Debugf("opened ipmi dev file: %v\n", ipmiDev)
+		}
+	}
+	tryOpenFile(ipmiDev1)
+	tryOpenFile(ipmiDev2)
+	tryOpenFile(ipmiDev3)
+
+	if file == nil {
+		return fmt.Errorf("ipmi dev file not opened")
+	}
+
+	c.Debugf("opened ipmi dev file: %v, descriptor is: %d\n", file, file.Fd())
+	// set opened ipmi dev file
+	c.openipmi.file = file
+
+	var receiveEvents uint32 = 1
+	if err := open.IOCTL(c.openipmi.file.Fd(), open.IPMICTL_SET_GETS_EVENTS_CMD, uintptr(unsafe.Pointer(&receiveEvents))); err != nil {
+		return fmt.Errorf("ioctl failed, cloud not enable event receiver, err: %w", err)
+	}
+
+	return nil
+}
+
+// closeOpen closes the ipmi dev file.
+func (c *Client) closeOpen(ctx context.Context) error {
+	if err := c.openipmi.file.Close(); err != nil {
+		return fmt.Errorf("close open file failed, err: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) openSendRequest(ctx context.Context, request ipmi.Request) ([]byte, error) {
+
+	var dataPtr *byte
+
+	cmdData := request.Pack()
+	c.DebugBytes("cmdData", cmdData, 16)
+	if len(cmdData) > 0 {
+		dataPtr = &cmdData[0]
+	}
+
+	c.DebugBytes("cmd data", cmdData, 16)
+
+	msg := &open.IPMI_MSG{
+		NetFn:   uint8(request.Command().NetFn),
+		Cmd:     uint8(request.Command().ID),
+		Data:    dataPtr,
+		DataLen: uint16(len(cmdData)),
+	}
+
+	addr := &open.IPMI_SYSTEM_INTERFACE_ADDR{
+		AddrType: open.IPMI_SYSTEM_INTERFACE_ADDR_TYPE,
+		Channel:  open.IPMI_BMC_CHANNEL,
+		LUN:      0,
+	}
+
+	commandContext := GetCommandContext(ctx)
+	if commandContext != nil {
+		c.Debug("Got CommandContext:", commandContext)
+
+		if commandContext.responderAddr != nil {
+		}
+		if commandContext.responderLUN != nil {
+			addr.LUN = *commandContext.responderLUN
+		}
+		if commandContext.requesterAddr != nil {
+		}
+		if commandContext.requesterLUN != nil {
+		}
+	}
+
+	req := &open.IPMI_REQ{
+		Addr:    addr,
+		AddrLen: int(unsafe.Sizeof(addr)),
+		MsgID:   rand.Int63(),
+		Msg:     *msg,
+	}
+
+	c.Debug("IPMI_REQ", req)
+	return open.SendCommand(c.openipmi.file, req, c.timeout)
+}

--- a/pkg/client/interface_system_other.go
+++ b/pkg/client/interface_system_other.go
@@ -1,0 +1,28 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+var errOpenUnsupported = fmt.Errorf("open (local) interface is not supported on %s, only linux and windows are supported", runtime.GOOS)
+
+// ConnectOpen is not supported on this platform.
+func (c *Client) ConnectOpen(ctx context.Context, devnum int32) error {
+	return errOpenUnsupported
+}
+
+// closeOpen is not supported on this platform.
+func (c *Client) closeOpen(ctx context.Context) error {
+	return errOpenUnsupported
+}
+
+func (c *Client) openSendRequest(ctx context.Context, request ipmi.Request) ([]byte, error) {
+	return nil, errOpenUnsupported
+}

--- a/pkg/client/interface_system_windows.go
+++ b/pkg/client/interface_system_windows.go
@@ -1,0 +1,162 @@
+//go:build windows
+// +build windows
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// On Windows there is no OpenIPMI character device. Local (in-band) access to
+// the BMC is provided by the Microsoft IPMI driver (ipmidrv.sys), which is
+// surfaced through the Microsoft_IPMI WMI class in the root\wmi namespace.
+//
+// Rather than pulling in a COM/WMI dependency, the implementation drives the
+// provider through PowerShell (consistent with how the "tool" interface shells
+// out to ipmitool). Each request invokes the Microsoft_IPMI RequestResponse
+// method and the result is marshalled back as JSON.
+
+// winIPMIResponse mirrors the JSON emitted by the PowerShell helper script.
+type winIPMIResponse struct {
+	// CompletionCode is the driver/method level status of the WMI call
+	// (0 means the request was delivered). It is distinct from the IPMI
+	// completion code, which is the first byte of ResponseData.
+	CompletionCode uint32 `json:"CompletionCode"`
+	// ResponseData is the comma separated list of response bytes. The first
+	// byte is the IPMI completion code.
+	ResponseData     string `json:"ResponseData"`
+	ResponseDataSize uint32 `json:"ResponseDataSize"`
+}
+
+// ConnectOpen verifies that the Microsoft_IPMI WMI provider is available.
+func (c *Client) ConnectOpen(ctx context.Context, devnum int32) error {
+	c.Debugf("Using Microsoft_IPMI WMI provider (root\\wmi)\n")
+
+	script := `$ErrorActionPreference = 'Stop'
+$ipmi = Get-CimInstance -Namespace 'root/wmi' -ClassName 'Microsoft_IPMI' -ErrorAction Stop | Select-Object -First 1
+if ($null -eq $ipmi) { throw 'Microsoft_IPMI WMI instance not found' }
+'ok'`
+
+	if _, err := c.runPowerShell(ctx, script); err != nil {
+		return fmt.Errorf("Microsoft_IPMI WMI provider not available (is the IPMI driver installed and are you running as administrator?), err: %w", err)
+	}
+
+	return nil
+}
+
+// closeOpen is a no-op for the WMI backed local interface.
+func (c *Client) closeOpen(ctx context.Context) error {
+	return nil
+}
+
+func (c *Client) openSendRequest(ctx context.Context, request ipmi.Request) ([]byte, error) {
+	cmdData := request.Pack()
+	c.DebugBytes("cmd data", cmdData, 16)
+
+	parts := make([]string, len(cmdData))
+	for i, b := range cmdData {
+		parts[i] = strconv.Itoa(int(b))
+	}
+	dataCSV := strings.Join(parts, ",")
+
+	netFn := uint8(request.Command().NetFn)
+	cmd := uint8(request.Command().ID)
+	responderAddr := ipmi.BMC_SA
+	var lun uint8 = 0
+
+	commandContext := GetCommandContext(ctx)
+	if commandContext != nil {
+		c.Debug("Got CommandContext:", commandContext)
+		if commandContext.responderAddr != nil {
+			responderAddr = *commandContext.responderAddr
+		}
+		if commandContext.responderLUN != nil {
+			lun = *commandContext.responderLUN
+		}
+	}
+
+	script := fmt.Sprintf(`$ErrorActionPreference = 'Stop'
+$data = [byte[]]@(%s)
+$arguments = @{
+  NetworkFunction = [byte]%d
+  Command = [byte]%d
+  Lun = [byte]%d
+  ResponderAddress = [byte]%d
+  RequestData = $data
+  RequestDataSize = [uint32]$data.Length
+}
+$ipmi = Get-CimInstance -Namespace 'root/wmi' -ClassName 'Microsoft_IPMI' -ErrorAction Stop | Select-Object -First 1
+if ($null -eq $ipmi) { throw 'Microsoft_IPMI WMI instance not found' }
+$res = Invoke-CimMethod -InputObject $ipmi -MethodName 'RequestResponse' -Arguments $arguments -ErrorAction Stop
+$rd = $res.ResponseData
+if ($null -eq $rd) { $rdStr = '' } else { $rdStr = (($rd | ForEach-Object { [int]$_ }) -join ',') }
+[pscustomobject]@{
+  CompletionCode = [uint32]$res.CompletionCode
+  ResponseData = $rdStr
+  ResponseDataSize = [uint32]$res.ResponseDataSize
+} | ConvertTo-Json -Compress`, dataCSV, netFn, cmd, lun, responderAddr)
+
+	out, err := c.runPowerShell(ctx, script)
+	if err != nil {
+		return nil, fmt.Errorf("Microsoft_IPMI RequestResponse failed, err: %w", err)
+	}
+
+	var resp winIPMIResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out), &resp); err != nil {
+		return nil, fmt.Errorf("parse Microsoft_IPMI response failed, err: %w, output: %s", err, string(out))
+	}
+
+	if resp.CompletionCode != 0 {
+		return nil, fmt.Errorf("Microsoft_IPMI RequestResponse returned method completion code %#x", resp.CompletionCode)
+	}
+
+	recv, err := parseByteCSV(resp.ResponseData)
+	if err != nil {
+		return nil, fmt.Errorf("parse Microsoft_IPMI response data failed, err: %w", err)
+	}
+
+	// recv[0] is the IPMI completion code, recv[1:] is the response data.
+	return recv, nil
+}
+
+// runPowerShell executes the given PowerShell script and returns its stdout.
+func (c *Client) runPowerShell(ctx context.Context, script string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "powershell", "-NonInteractive", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// parseByteCSV parses a comma separated list of unsigned byte values.
+func parseByteCSV(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []byte{}, nil
+	}
+
+	fields := strings.Split(s, ",")
+	out := make([]byte, len(fields))
+	for i, f := range fields {
+		v, err := strconv.ParseUint(strings.TrimSpace(f), 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid byte value %q: %w", f, err)
+		}
+		out[i] = byte(v)
+	}
+	return out, nil
+}


### PR DESCRIPTION
This commit splits the client pkgs interface_system into a linux, windows and 'other' variant. This is purely untested other than compiling fine as I got no system to able to test this on. Resolves #23 