### PR TITLE
feat(handlers): implement error interface on CompletionCode

### DIFF
--- a/pkg/handlers/chassis.go
+++ b/pkg/handlers/chassis.go
@@ -222,19 +222,25 @@ func handleGetSystemBootOptions(ctx context.Context, hctx *HandlerContext, req [
 }
 
 // codeFromErr maps a HAL error to a completion code.
+// If err carries a [CompletionCode] (e.g. HAL returns [CodeNodeBusy] directly),
+// that code is extracted; otherwise the error is mapped to [CodeUnspecifiedError].
 func codeFromErr(err error) CompletionCode {
 	if err == nil {
 		return CodeOK
 	}
+	var cc CompletionCode
+	if errors.As(err, &cc) {
+		return cc
+	}
 	return CodeUnspecifiedError
 }
 
-// codeFromHalErr maps a HAL error to a completion code, translating
-// [hal.ErrNotSupported] to [CodeBootParamNotSupported] so callers can distinguish
-// "parameter not supported by this BMC" from a generic failure.
+// codeFromHalErr maps a HAL error to a completion code.
+// It delegates to [codeFromErr] and additionally maps [hal.ErrNotSupported]
+// to [CodeBootParamNotSupported].
 func codeFromHalErr(err error) CompletionCode {
-	if err == nil {
-		return CodeOK
+	if cc := codeFromErr(err); cc != CodeUnspecifiedError {
+		return cc
 	}
 	if errors.Is(err, hal.ErrNotSupported) {
 		return CodeBootParamNotSupported

--- a/pkg/handlers/chassis_test.go
+++ b/pkg/handlers/chassis_test.go
@@ -77,6 +77,26 @@ func TestHandleChassisControl_PowerCycle(t *testing.T) {
 	}
 }
 
+// TestHandleChassisControl_NodeBusy verifies that when a HAL method returns a
+// [CompletionCode] as an error (e.g. [CodeNodeBusy]), [codeFromErr] extracts
+// the specific code rather than falling back to [CodeUnspecifiedError].
+func TestHandleChassisControl_NodeBusy(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	// SetPowerHook allows the test to inject a CompletionCode as error.
+	ch.SetPowerHook = func(on bool) error {
+		return CodeNodeBusy
+	}
+	hctx := &HandlerContext{BMC: b}
+
+	req := (&chassis.ChassisControlRequest{ChassisControl: chassis.ChassisControlPowerDown}).Pack()
+	_, cc, _ := handleChassisControl(context.Background(), hctx, req)
+	if cc != CodeNodeBusy {
+		t.Fatalf("want CodeNodeBusy (0xC0), got cc=%d", cc)
+	}
+}
+
 func TestHandleChassisControl_TypedDispatch(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"context"
 	"fmt"
+
+	types "github.com/bougou/go-ipmi/pkg/types"
 )
 
 // CompletionCode is an IPMI completion code byte.
@@ -44,6 +46,20 @@ const (
 	// 80h in their command-specific completion code table.
 	CodeBootParamNotSupported CompletionCode = 0x80
 )
+
+// String returns the IPMI spec description for the completion code,
+// delegating to the canonical CC map in [types].
+func (cc CompletionCode) String() string {
+	if s := types.CC[uint8(cc)]; s != "" {
+		return s
+	}
+	return fmt.Sprintf("0x%02x", uint8(cc))
+}
+
+// Error makes CompletionCode implement the error interface.
+func (cc CompletionCode) Error() string {
+	return fmt.Sprintf("IPMI completion code %s", cc.String())
+}
 
 // Handler processes a single IPMI command.
 //


### PR DESCRIPTION
Make CompletionCode implement the error interface so HAL implementations can return specific completion codes (e.g. CodeNodeBusy) as Go errors.

Fixes #70.