### PR TITLE
feat(server): add IPMI v1.5 LAN sessions and dual-stack reference server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,10 @@ _output
 
 .DS_Store
 
-goipmitest
-cmd/goipmi/goipmi
-goipmi-server
+# e2e binaries produced by `make build` (see test/e2e/common.sh)
+/_output/goipmi
+/_output/goipmi-server
 
 # asdf
 .tool-versions
-goipmi
 .claude

--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// runtimeConfig holds goipmi-server settings from the environment.
+type runtimeConfig struct {
+	Port     string
+	User     string
+	Password string
+
+	CipherSuites []ipmi.CipherSuiteID
+	V15AuthTypes []bmc.V15AuthType // nil = default (md5)
+	V15Disabled  bool
+}
+
+func loadRuntimeConfig() (runtimeConfig, error) {
+	cfg := runtimeConfig{
+		Port:     envOr("GOIPMI_SERVER_PORT", "623"),
+		User:     envOr("GOIPMI_SERVER_USER", "ADMIN"),
+		Password: envOr("GOIPMI_SERVER_PASS", "ADMIN"),
+	}
+
+	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_CIPHER_SUITES")); raw != "" {
+		ids, err := parseCipherSuites(raw)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.CipherSuites = ids
+	}
+
+	if v := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_V15")); v != "" {
+		enabled, err := parseBoolEnv(v)
+		if err != nil {
+			return cfg, fmt.Errorf("GOIPMI_SERVER_V15: %w", err)
+		}
+		cfg.V15Disabled = !enabled
+	}
+
+	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_V15_AUTH_TYPES")); raw != "" {
+		types, err := bmc.ParseV15AuthTypes(raw)
+		if err != nil {
+			return cfg, fmt.Errorf("GOIPMI_SERVER_V15_AUTH_TYPES: %w", err)
+		}
+		cfg.V15AuthTypes = types
+		cfg.V15Disabled = false
+	}
+
+	return cfg, nil
+}
+
+func applyRuntimeConfig(b *bmc.BMC, cfg runtimeConfig) {
+	if len(cfg.CipherSuites) > 0 {
+		b.SetCipherSuites(cfg.CipherSuites)
+	}
+	if cfg.V15Disabled {
+		bmc.WithV15Disabled()(b)
+	} else if len(cfg.V15AuthTypes) > 0 {
+		bmc.WithV15AuthTypes(cfg.V15AuthTypes)(b)
+	}
+}
+
+func printRuntimeBanner(cfg runtimeConfig, b *bmc.BMC) {
+	fmt.Printf("goipmi-server: listening on :%s (user=%s)\n", cfg.Port, cfg.User)
+	fmt.Printf("goipmi-server: IPMI v2.0 (lanplus) cipher suites: %v\n", b.ResolvedCipherSuites())
+	if b.V15LANEnabled() {
+		fmt.Printf("goipmi-server: IPMI v1.5 (lan) auth types: %s\n", bmc.FormatV15AuthTypes(b.ResolvedV15AuthTypes()))
+	} else {
+		fmt.Println("goipmi-server: IPMI v1.5 (lan) disabled")
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseBoolEnv(v string) (bool, error) {
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("expected 0/1, true/false, yes/no, or on/off, got %q", v)
+	}
+}
+
+// parseCipherSuites parses a comma-separated list of cipher suite IDs from the
+// GOIPMI_SERVER_CIPHER_SUITES env var and validates each against the reference
+// server's supported set. Returns a descriptive error for bad input rather than
+// letting bmc.SetCipherSuites panic.
+func parseCipherSuites(raw string) ([]ipmi.CipherSuiteID, error) {
+	parts := strings.Split(raw, ",")
+	ids := make([]ipmi.CipherSuiteID, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return nil, fmt.Errorf("invalid cipher suite id %q: expected an integer 0..255", p)
+		}
+		id := ipmi.CipherSuiteID(n)
+		if !bmc.SupportedCipherSuite(id) {
+			return nil, fmt.Errorf("cipher suite %d is not implemented by the reference server", id)
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("GOIPMI_SERVER_CIPHER_SUITES contained no valid ids")
+	}
+	return ids, nil
+}

--- a/cmd/goipmi-server/config_test.go
+++ b/cmd/goipmi-server/config_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestParseCipherSuites(t *testing.T) {
+	ids, err := parseCipherSuites("3,17")
+	if err != nil {
+		t.Fatalf("parseCipherSuites: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != ipmi.CipherSuiteID3 || ids[1] != ipmi.CipherSuiteID17 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestParseBoolEnv(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"0", false},
+		{"1", true},
+		{"off", false},
+		{"yes", true},
+	} {
+		got, err := parseBoolEnv(tc.in)
+		if err != nil {
+			t.Fatalf("parseBoolEnv(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseBoolEnv(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLoadRuntimeConfigDefaultsDualStack(t *testing.T) {
+	t.Setenv("GOIPMI_SERVER_PORT", "")
+	t.Setenv("GOIPMI_SERVER_CIPHER_SUITES", "")
+	t.Setenv("GOIPMI_SERVER_V15", "")
+	t.Setenv("GOIPMI_SERVER_V15_AUTH_TYPES", "")
+
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig: %v", err)
+	}
+	if cfg.V15Disabled {
+		t.Fatal("v1.5 should be enabled by default")
+	}
+	if len(cfg.V15AuthTypes) != 0 {
+		t.Fatalf("expected nil v15 auth types (use BMC default), got %v", cfg.V15AuthTypes)
+	}
+
+	b := bmc.New(bmc.DeviceInfo{}, [16]byte{}, mock.New())
+	applyRuntimeConfig(b, cfg)
+	if !b.V15LANEnabled() {
+		t.Fatal("expected v1.5 enabled after apply")
+	}
+	if b.ResolvedV15AuthTypes()[0] != bmc.V15AuthTypeMD5 {
+		t.Fatalf("default v1.5 auth: %v", b.ResolvedV15AuthTypes())
+	}
+}
+
+func TestLoadRuntimeConfigCustomV15Auth(t *testing.T) {
+	t.Setenv("GOIPMI_SERVER_V15_AUTH_TYPES", "md5,md2")
+
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig: %v", err)
+	}
+	if len(cfg.V15AuthTypes) != 2 {
+		t.Fatalf("want 2 auth types, got %v", cfg.V15AuthTypes)
+	}
+}
+
+func TestLoadRuntimeConfigDisableV15(t *testing.T) {
+	t.Setenv("GOIPMI_SERVER_V15", "0")
+	t.Setenv("GOIPMI_SERVER_V15_AUTH_TYPES", "")
+
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig: %v", err)
+	}
+	if !cfg.V15Disabled {
+		t.Fatal("expected v1.5 disabled")
+	}
+
+	b := bmc.New(bmc.DeviceInfo{}, [16]byte{}, mock.New())
+	applyRuntimeConfig(b, cfg)
+	if b.V15LANEnabled() {
+		t.Fatal("expected v1.5 disabled after apply")
+	}
+}

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -1,8 +1,17 @@
-// goipmi-server is a minimal IPMI BMC server for e2e testing.
+// goipmi-server is a reference IPMI BMC server for development and E2E testing.
 //
-// It uses the in-memory mock HAL and serves on UDP port 623.  By default it
-// creates a single user "ADMIN" with password "ADMIN" so that external tools
-// such as ipmitool can connect via lanplus.
+// By default it serves both IPMI protocol generations on the same UDP port:
+//   - IPMI v2.0 / RMCP+ (ipmitool -I lanplus, goipmi -I lanplus)
+//   - IPMI v1.5       (ipmitool -I lan -A MD5, goipmi -I lan)
+//
+// Environment variables:
+//
+//	GOIPMI_SERVER_PORT            – UDP listen port (default: 623)
+//	GOIPMI_SERVER_USER            – BMC username (default: ADMIN)
+//	GOIPMI_SERVER_PASS            – BMC password (default: ADMIN)
+//	GOIPMI_SERVER_CIPHER_SUITES   – RMCP+ cipher suite IDs, comma-separated (default: 3,17)
+//	GOIPMI_SERVER_V15_AUTH_TYPES  – v1.5 auth types: none,md2,md5,password,oem (default: md5)
+//	GOIPMI_SERVER_V15             – set to 0/false to disable v1.5 while keeping lanplus (default: 1)
 package main
 
 import (
@@ -11,8 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
@@ -20,7 +27,6 @@ import (
 	"github.com/bougou/go-ipmi/pkg/hal/mock"
 	"github.com/bougou/go-ipmi/pkg/server"
 	"github.com/bougou/go-ipmi/pkg/transport/udp"
-	ipmi "github.com/bougou/go-ipmi/pkg/types"
 )
 
 func main() {
@@ -31,13 +37,17 @@ func main() {
 }
 
 func run() error {
-	// BMC identity (used in Get Device ID).
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		return err
+	}
+
 	info := bmc.DeviceInfo{
 		DeviceID:                32,
 		DeviceRevision:          1,
 		FirmwareMajor:           1,
 		FirmwareMinor:           0,
-		IPMIVersion:             0x20, // IPMI 2.0
+		IPMIVersion:             0x20,
 		ManufacturerID:          0x000157,
 		ProductID:               0x0001,
 		AdditionalDeviceSupport: 0x3D,
@@ -46,46 +56,20 @@ func run() error {
 	copy(guid[:], "go-ipmi-e2e\x00\x00\x00\x00")
 
 	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clock.Real))
+	applyRuntimeConfig(b, cfg)
 
-	// Optional cipher suite override. GOIPMI_SERVER_CIPHER_SUITES is a
-	// comma-separated list of RMCP+ cipher suite IDs (e.g. "3,17" or
-	// "1,2,15,16"). Empty/unset falls back to bmc.DefaultCipherSuites.
-	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_CIPHER_SUITES")); raw != "" {
-		ids, err := parseCipherSuites(raw)
-		if err != nil {
-			return err
-		}
-		b.SetCipherSuites(ids)
-	}
-
-	// User credentials for IPMI session authentication.
-	userName := os.Getenv("GOIPMI_SERVER_USER")
-	if userName == "" {
-		userName = "ADMIN"
-	}
-	userPass := os.Getenv("GOIPMI_SERVER_PASS")
-	if userPass == "" {
-		userPass = "ADMIN"
-	}
-
-	// Add the user with Administrator privilege on LAN channel 1.
-	user, err := b.Users.Add(2, userName)
+	user, err := b.Users.Add(2, cfg.User)
 	if err != nil {
 		return fmt.Errorf("add user: %w", err)
 	}
-	user.SetPassword([]byte(userPass))
+	user.SetPassword([]byte(cfg.Password))
 	user.Enabled = true
 	user.ChannelAccess[1] = bmc.UserChannelAccess{
 		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
 		Enabled:      true,
 	}
 
-	// Bind UDP on the configured port.
-	port := os.Getenv("GOIPMI_SERVER_PORT")
-	if port == "" {
-		port = "623"
-	}
-	addr := ":" + port
+	addr := ":" + cfg.Port
 	conn, err := udp.Listen(addr)
 	if err != nil {
 		return fmt.Errorf("listen udp: %w", err)
@@ -97,47 +81,16 @@ func run() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	// Close the server when the process receives a signal to unblock Serve().
 	go func() {
 		<-ctx.Done()
 		srv.Close()
 	}()
 
-	fmt.Printf("goipmi-server: listening on %s (lanplus, user=%s, pass=%s)\n", addr, userName, userPass)
-	if len(b.ResolvedCipherSuites()) != 0 {
-		fmt.Printf("goipmi-server: cipher suites: %v\n", b.ResolvedCipherSuites())
-	}
+	printRuntimeBanner(cfg, b)
+
 	if err := srv.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("serve: %w", err)
 	}
 	fmt.Println("goipmi-server: stopped")
 	return nil
-}
-
-// parseCipherSuites parses a comma-separated list of cipher suite IDs from the
-// GOIPMI_SERVER_CIPHER_SUITES env var and validates each against the reference
-// server's supported set. Returns a descriptive error for bad input rather than
-// letting bmc.SetCipherSuites panic.
-func parseCipherSuites(raw string) ([]ipmi.CipherSuiteID, error) {
-	parts := strings.Split(raw, ",")
-	ids := make([]ipmi.CipherSuiteID, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		n, err := strconv.Atoi(p)
-		if err != nil || n < 0 || n > 255 {
-			return nil, fmt.Errorf("invalid cipher suite id %q: expected an integer 0..255", p)
-		}
-		id := ipmi.CipherSuiteID(n)
-		if !bmc.SupportedCipherSuite(id) {
-			return nil, fmt.Errorf("cipher suite %d is not implemented by the reference server", id)
-		}
-		ids = append(ids, id)
-	}
-	if len(ids) == 0 {
-		return nil, fmt.Errorf("GOIPMI_SERVER_CIPHER_SUITES contained no valid ids")
-	}
-	return ids, nil
 }

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -48,6 +48,13 @@ type BMC struct {
 	Channels *ChannelStore
 	Sessions *SessionStore
 
+	// V15Sessions tracks IPMI v1.5 LAN sessions (separate from RMCP+ sessions).
+	V15Sessions *V15SessionStore
+	// V15AuthTypes lists the v1.5 authentication types this BMC advertises and accepts.
+	V15AuthTypes []V15AuthType
+	// v15Disabled disables IPMI v1.5 LAN sessions when true.
+	v15Disabled bool
+
 	hal   hal.HAL
 	clock clock.Clock
 }
@@ -68,6 +75,53 @@ func WithKG(kg []byte) Option {
 // WithClock injects a custom [clock.Clock].  Defaults to [clock.Real].
 func WithClock(c clock.Clock) Option {
 	return func(b *BMC) { b.clock = c }
+}
+
+// WithV15AuthTypes sets the IPMI v1.5 authentication types the BMC advertises
+// and accepts. Pass nil/empty to restore [DefaultV15AuthTypes].
+func WithV15AuthTypes(types []V15AuthType) Option {
+	return func(b *BMC) {
+		if len(types) == 0 {
+			b.V15AuthTypes = nil
+			return
+		}
+		b.V15AuthTypes = append(b.V15AuthTypes[:0:0], types...)
+		b.v15Disabled = false
+	}
+}
+
+// WithV15Disabled turns off IPMI v1.5 LAN session support. RMCP+ (v2.0) is unaffected.
+func WithV15Disabled() Option {
+	return func(b *BMC) { b.v15Disabled = true }
+}
+
+// V15LANEnabled reports whether the BMC advertises and accepts IPMI v1.5 sessions.
+func (b *BMC) V15LANEnabled() bool {
+	return b != nil && !b.v15Disabled && len(b.ResolvedV15AuthTypes()) > 0
+}
+
+// ResolvedV15AuthTypes returns the v1.5 auth type list, defaulting to MD5.
+func (b *BMC) ResolvedV15AuthTypes() []V15AuthType {
+	if b.v15Disabled {
+		return nil
+	}
+	if len(b.V15AuthTypes) > 0 {
+		return b.V15AuthTypes
+	}
+	return DefaultV15AuthTypes
+}
+
+// V15AuthTypeEnabled reports whether authType is configured on this BMC.
+func (b *BMC) V15AuthTypeEnabled(authType V15AuthType) bool {
+	if !b.V15LANEnabled() {
+		return false
+	}
+	for _, t := range b.ResolvedV15AuthTypes() {
+		if t == authType {
+			return true
+		}
+	}
+	return false
 }
 
 // WithCipherSuites sets the RMCP+ cipher suites the server advertises and
@@ -115,15 +169,17 @@ func New(info DeviceInfo, guid [16]byte, h hal.HAL, opts ...Option) *BMC {
 		hal:   h,
 		clock: clock.Real,
 
-		Users:    NewUserStore(),
-		Channels: NewChannelStore(),
-		Sessions: NewSessionStore(clock.Real),
+		Users:       NewUserStore(),
+		Channels:    NewChannelStore(),
+		Sessions:    NewSessionStore(clock.Real),
+		V15Sessions: NewV15SessionStore(clock.Real),
 	}
 	for _, o := range opts {
 		o(b)
 	}
-	// Re-apply clock to SessionStore after options in case WithClock was used.
+	// Re-apply clock to session stores after options in case WithClock was used.
 	b.Sessions.clock = b.clock
+	b.V15Sessions.clock = b.clock
 	return b
 }
 

--- a/pkg/bmc/session.go
+++ b/pkg/bmc/session.go
@@ -11,8 +11,18 @@ import (
 	"github.com/bougou/go-ipmi/pkg/clock"
 )
 
-// Session inactivity timeout per IPMI spec section 6.12.15.
+// Session inactivity timeout per IPMI spec:
+//   - v1.5 §6.11.13 Session Inactivity Timeout
+//   - v2.0 §6.12.15 Session Inactivity Timeout
 const DefaultInactivityTimeout = 60 * time.Second
+
+// DefaultSessionEvictInterval is how often the server scans for idle sessions.
+// The spec defines the 60-second inactivity limit, not the scan period.
+const DefaultSessionEvictInterval = 3 * time.Second
+
+// DefaultInactivityTimeoutTolerance is the LAN inactivity tolerance per
+// IPMI v1.5 Table 6-7 (+/- 3 seconds).
+const DefaultInactivityTimeoutTolerance = 3 * time.Second
 
 // MaxSessions is the minimum number of concurrent sessions required by the spec.
 const MaxSessions = 4
@@ -230,7 +240,7 @@ func (s *SessionStore) evictExpiredLocked() int {
 	now := s.clock.Now()
 	n := 0
 	for id, sess := range s.sessions {
-		if now.Sub(sess.LastActivity) > s.timeout {
+		if now.Sub(sess.LastActivity) > s.timeout+DefaultInactivityTimeoutTolerance {
 			delete(s.sessions, id)
 			n++
 		}

--- a/pkg/bmc/session_v15.go
+++ b/pkg/bmc/session_v15.go
@@ -1,0 +1,391 @@
+package bmc
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/clock"
+)
+
+// V15AuthType mirrors IPMI v1.5 authentication type codes.
+type V15AuthType uint8
+
+const (
+	V15AuthTypeNone     V15AuthType = 0x00
+	V15AuthTypeMD2      V15AuthType = 0x01
+	V15AuthTypeMD5      V15AuthType = 0x02
+	V15AuthTypePassword V15AuthType = 0x04
+	V15AuthTypeOEM      V15AuthType = 0x05
+)
+
+// v15InboundWindow is the inbound sequence sliding window (spec §6.11.11 Option 1).
+const v15InboundWindow = 8
+
+// DefaultV15AuthTypes is the default set of v1.5 auth types the reference BMC
+// advertises and accepts.
+var DefaultV15AuthTypes = []V15AuthType{V15AuthTypeMD5}
+
+// V15AuthTypeToCapsBit maps an auth type to the corresponding bit in Get
+// Channel Authentication Capabilities response byte 3 (bits [5:0]).
+func V15AuthTypeToCapsBit(t V15AuthType) uint8 {
+	switch t {
+	case V15AuthTypeNone:
+		return 1 << 0
+	case V15AuthTypeMD2:
+		return 1 << 1
+	case V15AuthTypeMD5:
+		return 1 << 2
+	case V15AuthTypePassword:
+		return 1 << 4
+	case V15AuthTypeOEM:
+		return 1 << 5
+	default:
+		return 0
+	}
+}
+
+// V15SessionState tracks IPMI v1.5 session negotiation progress.
+type V15SessionState uint8
+
+const (
+	V15SessionStatePending V15SessionState = iota
+	V15SessionStateActive
+	V15SessionStateClosed
+)
+
+// V15Session holds IPMI v1.5 session state.
+type V15Session struct {
+	TempSessionID uint32
+	SessionID     uint32
+	State         V15SessionState
+
+	AuthType  V15AuthType
+	Challenge [16]byte
+
+	InboundSeq  uint32
+	InboundRcvd uint8 // bitmap: bit i => (InboundSeq - i) received
+	OutboundSeq uint32
+
+	User           *User
+	PrivilegeLevel PrivilegeLevel
+	MaxPrivilege   PrivilegeLevel
+
+	Channel uint8
+
+	CreatedAt    time.Time
+	LastActivity time.Time
+}
+
+// V15SessionStore is a thread-safe registry of IPMI v1.5 sessions.
+type V15SessionStore struct {
+	mu       sync.Mutex
+	sessions map[uint32]*V15Session
+	max      int
+	timeout  time.Duration
+	clock    clock.Clock
+}
+
+// NewV15SessionStore creates a V15SessionStore with the default limits.
+func NewV15SessionStore(clk clock.Clock) *V15SessionStore {
+	return &V15SessionStore{
+		sessions: make(map[uint32]*V15Session, MaxSessions),
+		max:      MaxSessions,
+		timeout:  DefaultInactivityTimeout,
+		clock:    clk,
+	}
+}
+
+// CreatePending allocates a pending v1.5 session after Get Session Challenge.
+func (s *V15SessionStore) CreatePending(authType V15AuthType, user *User, challenge [16]byte, channel uint8) (*V15Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.evictExpiredLocked()
+
+	if len(s.sessions) >= s.max {
+		if !s.evictOldestPendingLocked() {
+			return nil, ErrSessionFull
+		}
+	}
+
+	tempID, err := randomUint32()
+	if err != nil {
+		return nil, fmt.Errorf("generate temp session ID: %w", err)
+	}
+	for s.sessions[tempID] != nil || tempID == 0 {
+		tempID, err = randomUint32()
+		if err != nil {
+			return nil, fmt.Errorf("generate temp session ID: %w", err)
+		}
+	}
+
+	now := s.clock.Now()
+	sess := &V15Session{
+		TempSessionID: tempID,
+		State:         V15SessionStatePending,
+		AuthType:      authType,
+		Challenge:     challenge,
+		User:          user,
+		Channel:       channel,
+		CreatedAt:     now,
+		LastActivity:  now,
+	}
+	s.sessions[tempID] = sess
+	return sess, nil
+}
+
+// Get returns a session by its current lookup ID without updating activity.
+func (s *V15SessionStore) Get(id uint32) (*V15Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil, fmt.Errorf("v1.5 session 0x%08x: %w", id, ErrNoSession)
+	}
+	return sess, nil
+}
+
+// Touch records valid session activity for inactivity timeout (spec §6.11.13).
+func (s *V15SessionStore) Touch(sess *V15Session) {
+	if sess == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess.LastActivity = s.clock.Now()
+}
+
+// CountActiveSessions returns the number of active v1.5 sessions.
+func (s *V15SessionStore) CountActiveSessions() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, sess := range s.sessions {
+		if sess.State == V15SessionStateActive {
+			n++
+		}
+	}
+	return n
+}
+
+// CountActiveSessionsForUser returns active sessions owned by userID.
+func (s *V15SessionStore) CountActiveSessionsForUser(userID uint8) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, sess := range s.sessions {
+		if sess.State == V15SessionStateActive && sess.User != nil && sess.User.ID == userID {
+			n++
+		}
+	}
+	return n
+}
+
+// CountActiveSessionsWithMaxPrivilegeAtLeast counts active sessions whose
+// negotiated maximum privilege is >= min (for Table 18-17 completion 0x83).
+func (s *V15SessionStore) CountActiveSessionsWithMaxPrivilegeAtLeast(min PrivilegeLevel) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, sess := range s.sessions {
+		if sess.State == V15SessionStateActive && sess.MaxPrivilege >= min {
+			n++
+		}
+	}
+	return n
+}
+
+// Activate transitions a pending session to active with a new permanent ID.
+// maxPrivilege is the requested ceiling; initial privilege is USER per §18.16
+// (Callback when max is Callback).
+func (s *V15SessionStore) Activate(pending *V15Session, permanentID, inboundSeq, outboundSeq uint32, maxPrivilege PrivilegeLevel) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if pending.State != V15SessionStatePending {
+		return errors.New("session is not pending")
+	}
+	delete(s.sessions, pending.TempSessionID)
+
+	for s.sessions[permanentID] != nil || permanentID == 0 {
+		var err error
+		permanentID, err = randomUint32()
+		if err != nil {
+			return fmt.Errorf("generate permanent session ID: %w", err)
+		}
+	}
+
+	initialPriv := PrivilegeLevelUser
+	if maxPrivilege == PrivilegeLevelCallback {
+		initialPriv = PrivilegeLevelCallback
+	}
+
+	pending.SessionID = permanentID
+	pending.State = V15SessionStateActive
+	pending.InboundSeq = inboundSeq
+	pending.InboundRcvd = 0
+	pending.OutboundSeq = outboundSeq
+	pending.PrivilegeLevel = initialPriv
+	pending.MaxPrivilege = maxPrivilege
+	pending.LastActivity = s.clock.Now()
+
+	s.sessions[permanentID] = pending
+	return nil
+}
+
+// Close removes a session by permanent or temp ID.
+func (s *V15SessionStore) Close(id uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return fmt.Errorf("v1.5 session 0x%08x: %w", id, ErrNoSession)
+	}
+	delete(s.sessions, id)
+	if sess.State == V15SessionStateActive && sess.TempSessionID != id && sess.TempSessionID != 0 {
+		delete(s.sessions, sess.TempSessionID)
+	}
+	return nil
+}
+
+// EvictExpired removes inactive v1.5 sessions past the timeout.
+func (s *V15SessionStore) EvictExpired() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evictExpiredLocked()
+}
+
+func (s *V15SessionStore) evictExpiredLocked() int {
+	now := s.clock.Now()
+	limit := s.timeout + DefaultInactivityTimeoutTolerance
+	n := 0
+	for id, sess := range s.sessions {
+		if now.Sub(sess.LastActivity) > limit {
+			delete(s.sessions, id)
+			n++
+		}
+	}
+	return n
+}
+
+func (s *V15SessionStore) evictOldestPendingLocked() bool {
+	var oldest *V15Session
+	var oldestID uint32
+	for id, sess := range s.sessions {
+		if sess.State == V15SessionStatePending {
+			if oldest == nil || sess.CreatedAt.Before(oldest.CreatedAt) {
+				oldest = sess
+				oldestID = id
+			}
+		}
+	}
+	if oldest == nil {
+		return false
+	}
+	delete(s.sessions, oldestID)
+	return true
+}
+
+// v15SeqDiff returns seq-high as a signed delta with uint32 wrap-around.
+func v15SeqDiff(high, seq uint32) int64 {
+	diff := int64(seq) - int64(high)
+	if diff > 1<<31 {
+		diff -= 1 << 32
+	} else if diff < -(1 << 31) {
+		diff += 1 << 32
+	}
+	return diff
+}
+
+// TryAcceptInboundSeq implements spec §6.11.11 Option 1 (+/-8 window, no dupes).
+func (sess *V15Session) TryAcceptInboundSeq(seq uint32) bool {
+	if seq == 0 {
+		return false
+	}
+	high := sess.InboundSeq
+	diff := v15SeqDiff(high, seq)
+
+	if diff == 0 {
+		return false
+	}
+	if diff > v15InboundWindow || diff < -v15InboundWindow {
+		return false
+	}
+
+	if diff > 0 {
+		shift := uint(diff)
+		if shift > v15InboundWindow {
+			return false
+		}
+		sess.InboundRcvd <<= shift
+		sess.InboundRcvd |= 1
+		sess.InboundSeq = seq
+		return true
+	}
+
+	behind := uint(-diff)
+	bit := uint8(1) << (behind - 1)
+	if sess.InboundRcvd&bit != 0 {
+		return false
+	}
+	sess.InboundRcvd |= bit
+	return true
+}
+
+// V15InboundSeqValid reports whether seq is acceptable under Option 1 without
+// mutating session state (for tests).
+func V15InboundSeqValid(sess *V15Session, seq uint32) bool {
+	if sess == nil || seq == 0 {
+		return false
+	}
+	high := sess.InboundSeq
+	diff := v15SeqDiff(high, seq)
+	if diff == 0 {
+		return false
+	}
+	if diff > v15InboundWindow || diff < -v15InboundWindow {
+		return false
+	}
+	if diff < 0 {
+		bit := uint8(1) << (uint(-diff) - 1)
+		return sess.InboundRcvd&bit == 0
+	}
+	return true
+}
+
+// NextOutboundSeq returns the sequence number for the current outbound message
+// and advances the counter for the next one.
+func (sess *V15Session) NextOutboundSeq() uint32 {
+	seq := sess.OutboundSeq
+	sess.OutboundSeq++
+	return seq
+}
+
+// GenerateChallenge fills dst with random bytes for Get Session Challenge.
+func GenerateChallenge(dst *[16]byte) error {
+	_, err := rand.Read(dst[:])
+	return err
+}
+
+// GenerateInboundSeq returns a non-zero initial inbound sequence number.
+func GenerateInboundSeq() (uint32, error) {
+	seq, err := randomUint32()
+	if err != nil {
+		return 0, err
+	}
+	if seq == 0 {
+		seq = 1
+	}
+	return seq, nil
+}
+
+// PackSessionIDLE is a helper for auth code input construction.
+func PackSessionIDLE(id uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, id)
+	return b
+}

--- a/pkg/bmc/session_v15_test.go
+++ b/pkg/bmc/session_v15_test.go
@@ -1,0 +1,29 @@
+package bmc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestV15SessionStore_EvictExpired(t *testing.T) {
+	clk := &mockClock{now: time.Now()}
+	s := NewV15SessionStore(clk)
+
+	user := &User{ID: 2, Enabled: true}
+	var challenge [16]byte
+	sess, err := s.CreatePending(V15AuthTypeMD5, user, challenge, 1)
+	if err != nil {
+		t.Fatalf("CreatePending: %v", err)
+	}
+	if err := s.Activate(sess, 0xAABBCCDD, 1, 0x01020304, PrivilegeLevelAdministrator); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	clk.now = clk.now.Add(2 * DefaultInactivityTimeout)
+	if n := s.EvictExpired(); n != 1 {
+		t.Fatalf("expected 1 eviction, got %d", n)
+	}
+	if _, err := s.Get(0xAABBCCDD); err == nil {
+		t.Fatal("session should have been evicted")
+	}
+}

--- a/pkg/bmc/user.go
+++ b/pkg/bmc/user.go
@@ -52,6 +52,14 @@ func (u *User) SetPassword(raw []byte) {
 	u.Password = p
 }
 
+// PasswordV15Padded returns the user's password zero-padded to 16 bytes per
+// IPMI v1.5 AuthCode algorithms (spec §18.15.1).
+func (u *User) PasswordV15Padded() []byte {
+	var p [16]byte
+	copy(p[:], u.Password[:])
+	return p[:]
+}
+
 // VerifyPassword returns true when the supplied raw bytes match the stored password.
 // Uses constant-time comparison to avoid timing attacks.
 func (u *User) VerifyPassword(raw []byte) bool {
@@ -129,6 +137,28 @@ func (s *UserStore) GetByName(name string) (*User, error) {
 		}
 	}
 	return nil, fmt.Errorf("user %q: %w", name, ErrUserNotFound)
+}
+
+// FindEnabledByNameOnChannel scans user IDs 1..MaxUsers in order and returns
+// the first enabled user with a matching name and channel access (spec §18.14).
+func (s *UserStore) FindEnabledByNameOnChannel(name string, channel uint8) (*User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for id := uint8(1); id <= MaxUsers; id++ {
+		u, ok := s.users[id]
+		if !ok || !u.Enabled {
+			continue
+		}
+		if u.Name != name {
+			continue
+		}
+		access, ok := u.ChannelAccess[channel]
+		if !ok || !access.Enabled {
+			continue
+		}
+		return u, nil
+	}
+	return nil, fmt.Errorf("user %q on channel %d: %w", name, channel, ErrUserNotFound)
 }
 
 // Delete removes a user by ID.  User 1 (anonymous) cannot be deleted.

--- a/pkg/bmc/v15_config.go
+++ b/pkg/bmc/v15_config.go
@@ -1,0 +1,84 @@
+package bmc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// V15AuthTypeName returns a human-readable name for t.
+func V15AuthTypeName(t V15AuthType) string {
+	switch t {
+	case V15AuthTypeNone:
+		return "none"
+	case V15AuthTypeMD2:
+		return "md2"
+	case V15AuthTypeMD5:
+		return "md5"
+	case V15AuthTypePassword:
+		return "password"
+	case V15AuthTypeOEM:
+		return "oem"
+	default:
+		return fmt.Sprintf("0x%02x", uint8(t))
+	}
+}
+
+// FormatV15AuthTypes formats auth types for logging (e.g. "md5,md2").
+func FormatV15AuthTypes(types []V15AuthType) string {
+	if len(types) == 0 {
+		return ""
+	}
+	names := make([]string, len(types))
+	for i, t := range types {
+		names[i] = V15AuthTypeName(t)
+	}
+	return strings.Join(names, ",")
+}
+
+// ParseV15AuthType parses a single auth type name (case-insensitive).
+func ParseV15AuthType(name string) (V15AuthType, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "none", "0", "00":
+		return V15AuthTypeNone, nil
+	case "md2", "1", "01":
+		return V15AuthTypeMD2, nil
+	case "md5", "2", "02":
+		return V15AuthTypeMD5, nil
+	case "password", "straight", "4", "04":
+		return V15AuthTypePassword, nil
+	case "oem", "5", "05":
+		return V15AuthTypeOEM, nil
+	default:
+		return 0, fmt.Errorf("unknown v1.5 auth type %q (want none, md2, md5, password, or oem)", name)
+	}
+}
+
+// ParseV15AuthTypes parses a comma-separated list of v1.5 auth type names.
+func ParseV15AuthTypes(raw string) ([]V15AuthType, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("v1.5 auth type list is empty")
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]V15AuthType, 0, len(parts))
+	seen := make(map[V15AuthType]struct{}, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		t, err := ParseV15AuthType(p)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("v1.5 auth type list contained no valid entries")
+	}
+	return out, nil
+}

--- a/pkg/bmc/v15_config_test.go
+++ b/pkg/bmc/v15_config_test.go
@@ -1,0 +1,23 @@
+package bmc
+
+import "testing"
+
+func TestParseV15AuthTypes(t *testing.T) {
+	types, err := ParseV15AuthTypes("md5, MD2, password")
+	if err != nil {
+		t.Fatalf("ParseV15AuthTypes: %v", err)
+	}
+	if len(types) != 3 {
+		t.Fatalf("want 3 types, got %v", types)
+	}
+	if types[0] != V15AuthTypeMD5 || types[1] != V15AuthTypeMD2 || types[2] != V15AuthTypePassword {
+		t.Fatalf("unexpected types: %v", types)
+	}
+}
+
+func TestFormatV15AuthTypes(t *testing.T) {
+	got := FormatV15AuthTypes([]V15AuthType{V15AuthTypeMD5, V15AuthTypeMD2})
+	if got != "md5,md2" {
+		t.Fatalf("FormatV15AuthTypes: got %q", got)
+	}
+}

--- a/pkg/client/client_auth_code.go
+++ b/pkg/client/client_auth_code.go
@@ -32,7 +32,9 @@ func (a AuthCodeSingleSessionInput) AuthCode(authType ipmi.AuthType) []byte {
 	case ipmi.AuthTypePassword:
 		authCode = password
 	case ipmi.AuthTypeMD2:
-		authCode = md2.New().Sum(input)
+		h := md2.New()
+		h.Write(input)
+		authCode = h.Sum(nil)
 		authCode = authCode[:16]
 	case ipmi.AuthTypeMD5:
 		c := md5.Sum(input) // can not use md5.New().Sum(input)
@@ -81,7 +83,9 @@ func (i *AuthCodeMultiSessionInput) AuthCode(authType ipmi.AuthType) []byte {
 	case ipmi.AuthTypePassword:
 		authCode = password
 	case ipmi.AuthTypeMD2:
-		authCode = md2.New().Sum(input)
+		h := md2.New()
+		h.Write(input)
+		authCode = h.Sum(nil)
 		authCode = authCode[:16]
 	case ipmi.AuthTypeMD5:
 		c := md5.Sum(input) // can not use md5.New().Sum(input)

--- a/pkg/client/server_session_eviction_test.go
+++ b/pkg/client/server_session_eviction_test.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/server"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+)
+
+// TestServerSessionInactivityEviction verifies that idle v1.5 and RMCP+ sessions
+// are removed after the spec-mandated 60s inactivity timeout. The test injects a
+// manual clock so CI does not need to sleep a full minute.
+func TestServerSessionInactivityEviction(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+
+	t.Run("lan v1.5", func(t *testing.T) {
+		testSessionInactivityEviction(t, username, password, InterfaceLan)
+	})
+	t.Run("lanplus v2.0", func(t *testing.T) {
+		testSessionInactivityEviction(t, username, password, InterfaceLanplus)
+	})
+}
+
+func testSessionInactivityEviction(t *testing.T, username, password string, intf Interface) {
+	t.Helper()
+
+	clk := newManualClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	b := newTestBMC(t, clk, username, password)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	conn := udp.Wrap(pc)
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(intf).
+		WithTimeout(2 * time.Second).
+		WithRetry(0)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+
+	if _, err := c.GetDeviceID(context.Background()); err != nil {
+		t.Fatalf("GetDeviceID before idle: %v", err)
+	}
+
+	// Advance past inactivity timeout, tolerance, and one eviction scan.
+	clk.Advance(bmc.DefaultInactivityTimeout + bmc.DefaultInactivityTimeoutTolerance + bmc.DefaultSessionEvictInterval + time.Second)
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := c.GetDeviceID(context.Background()); err == nil {
+		t.Fatal("expected GetDeviceID to fail on evicted session")
+	}
+
+	c2, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient reconnect: %v", err)
+	}
+	c2.WithInterface(intf).WithTimeout(2 * time.Second).WithRetry(0)
+	if err := c2.Connect(context.Background()); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	defer func() { _ = c2.Close(context.Background()) }()
+	if _, err := c2.GetDeviceID(context.Background()); err != nil {
+		t.Fatalf("GetDeviceID after reconnect: %v", err)
+	}
+}
+
+func newTestBMC(t *testing.T, clk clock.Clock, username, password string) *bmc.BMC {
+	t.Helper()
+	info := bmc.DeviceInfo{
+		DeviceID:                32,
+		DeviceRevision:          1,
+		FirmwareMajor:           1,
+		FirmwareMinor:           0,
+		IPMIVersion:             0x20,
+		ManufacturerID:          0x000157,
+		ProductID:               0x0001,
+		AdditionalDeviceSupport: 0x3D,
+	}
+	var guid [16]byte
+	copy(guid[:], "go-ipmi-test\x00\x00\x00\x00\x00")
+	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clk))
+
+	user, err := b.Users.Add(2, username)
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte(password))
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+	return b
+}
+
+// manualClock drives BMC/session timestamps and the server's eviction ticker.
+type manualClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	tickers []*manualTicker
+}
+
+type manualTicker struct {
+	clock    *manualClock
+	interval time.Duration
+	next     time.Time
+	ch       chan time.Time
+	stopped  bool
+}
+
+func newManualClock(start time.Time) *manualClock {
+	return &manualClock{now: start}
+}
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) NewTimer(d time.Duration) clock.Timer {
+	return clock.Real.NewTimer(d)
+}
+
+func (c *manualClock) NewTicker(d time.Duration) clock.Ticker {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := &manualTicker{
+		clock:    c,
+		interval: d,
+		next:     c.now.Add(d),
+		ch:       make(chan time.Time, 4),
+	}
+	c.tickers = append(c.tickers, t)
+	return t
+}
+
+func (t *manualTicker) C() <-chan time.Time { return t.ch }
+
+func (t *manualTicker) Stop() {
+	t.clock.mu.Lock()
+	t.stopped = true
+	t.clock.mu.Unlock()
+}
+
+func (c *manualClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	now := c.now
+	for _, t := range c.tickers {
+		if t.stopped {
+			continue
+		}
+		for !now.Before(t.next) {
+			select {
+			case t.ch <- now:
+			default:
+			}
+			t.next = t.next.Add(t.interval)
+		}
+	}
+	c.mu.Unlock()
+}

--- a/pkg/client/server_v15_test.go
+++ b/pkg/client/server_v15_test.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/server"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestServerV15SessionActivation verifies the reference BMC server accepts a
+// full IPMI v1.5 session handshake (Get Channel Auth Caps → Get Session
+// Challenge → Activate Session) and executes commands over the authenticated
+// session. This mirrors ipmitool -I lan -A MD5.
+func TestServerV15SessionActivation(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+
+	b := newV15TestBMC(t, username, password)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	conn := udp.Wrap(pc)
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLan).
+		WithTimeout(2 * time.Second).
+		WithRetry(1)
+	c.session.authType = ipmi.AuthTypeMD5
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect (v1.5): %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+
+	resp, err := c.GetDeviceID(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceID: %v", err)
+	}
+	if resp.DeviceID == 0 {
+		t.Fatalf("unexpected device ID: %d", resp.DeviceID)
+	}
+}
+
+func TestServerV15SessionActivationMD2(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+
+	b := newV15TestBMC(t, username, password)
+	bmc.WithV15AuthTypes([]bmc.V15AuthType{bmc.V15AuthTypeMD2})(b)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	conn := udp.Wrap(pc)
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLan).
+		WithTimeout(2 * time.Second).
+		WithRetry(1)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect (v1.5 MD2): %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+
+	if c.session.authType != ipmi.AuthTypeMD2 {
+		t.Fatalf("want MD2 auth type, got %v", c.session.authType)
+	}
+
+	resp, err := c.GetDeviceID(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceID: %v", err)
+	}
+	if resp.DeviceID == 0 {
+		t.Fatalf("unexpected device ID: %d", resp.DeviceID)
+	}
+}
+
+func newV15TestBMC(t *testing.T, username, password string) *bmc.BMC {
+	t.Helper()
+	info := bmc.DeviceInfo{
+		DeviceID:                32,
+		DeviceRevision:          1,
+		FirmwareMajor:           1,
+		FirmwareMinor:           0,
+		IPMIVersion:             0x20,
+		ManufacturerID:          0x000157,
+		ProductID:               0x0001,
+		AdditionalDeviceSupport: 0x3D,
+	}
+	var guid [16]byte
+	copy(guid[:], "go-ipmi-v15\x00\x00\x00\x00\x00")
+	b := bmc.New(info, guid, mock.New(), bmc.WithClock(clock.Real))
+
+	user, err := b.Users.Add(2, username)
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte(password))
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+	return b
+}

--- a/pkg/handlers/context.go
+++ b/pkg/handlers/context.go
@@ -27,9 +27,11 @@ type HandlerContext struct {
 	// BMC is the top-level BMC state.
 	BMC *bmc.BMC
 
-	// Session is the authenticated session this request arrived on, or nil for
-	// pre-session (unauthenticated) requests.
+	// Session is the authenticated RMCP+ session, or nil for pre-session requests.
 	Session *bmc.Session
+
+	// V15Session is the authenticated IPMI v1.5 session, or nil.
+	V15Session *bmc.V15Session
 
 	// Channel is the channel the request arrived on.
 	Channel *bmc.Channel

--- a/pkg/handlers/privilege.go
+++ b/pkg/handlers/privilege.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+// privilegeExempt reports commands that do not require session privilege checks.
+func privilegeExempt(netFn, cmd uint8) bool {
+	if netFn != NetFnAppRequest {
+		return false
+	}
+	switch cmd {
+	case CmdGetChannelAuthCapabilities,
+		CmdGetSessionChallenge,
+		CmdActivateSession,
+		CmdGetChannelCipherSuites:
+		return true
+	}
+	return false
+}
+
+func sessionPrivilege(hctx *HandlerContext) (bmc.PrivilegeLevel, bool) {
+	if hctx.V15Session != nil && hctx.V15Session.State == bmc.V15SessionStateActive {
+		return hctx.V15Session.PrivilegeLevel, true
+	}
+	if hctx.Session != nil {
+		return hctx.Session.PrivilegeLevel, true
+	}
+	return 0, false
+}
+
+// checkCommandPrivilege enforces per-command minimum privilege (spec §18.16).
+func checkCommandPrivilege(hctx *HandlerContext, netFn, cmd uint8) CompletionCode {
+	if privilegeExempt(netFn, cmd) {
+		return CodeOK
+	}
+	priv, ok := sessionPrivilege(hctx)
+	if !ok {
+		return CodeOK
+	}
+	if priv < MinimumPrivilege(netFn, cmd) {
+		return CodeInsufficientPrivilege
+	}
+	return CodeOK
+}
+
+type dispatchingHandler struct {
+	inner Handler
+	netFn uint8
+	cmd   uint8
+}
+
+func (d *dispatchingHandler) Handle(ctx context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if cc := checkCommandPrivilege(hctx, d.netFn, d.cmd); cc != CodeOK {
+		return nil, cc, nil
+	}
+	return d.inner.Handle(ctx, hctx, req)
+}

--- a/pkg/handlers/privilege_test.go
+++ b/pkg/handlers/privilege_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+func TestChassisControlRequiresOperatorPrivilege(t *testing.T) {
+	b := newTestBMC()
+	reg := NewRegistry()
+	RegisterChassisHandlers(reg)
+
+	sess := &bmc.V15Session{
+		State:          bmc.V15SessionStateActive,
+		PrivilegeLevel: bmc.PrivilegeLevelUser,
+		MaxPrivilege:   bmc.PrivilegeLevelAdministrator,
+	}
+	hctx := &HandlerContext{BMC: b, V15Session: sess}
+
+	_, cc, err := reg.Dispatch(context.Background(), hctx, NetFnChassisRequest, CmdChassisControl, []byte{0x00})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if cc != CodeInsufficientPrivilege {
+		t.Fatalf("want insufficient privilege, got %02x", cc)
+	}
+}
+
+func TestActivateSessionRejectsReservedPrivilegeZero(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	var challenge [16]byte
+	sess, err := b.V15Sessions.CreatePending(bmc.V15AuthTypeMD5, user, challenge, lanChannelNumber)
+	if err != nil {
+		t.Fatalf("CreatePending: %v", err)
+	}
+
+	req := make([]byte, 22)
+	req[0] = uint8(bmc.V15AuthTypeMD5)
+	req[1] = 0 // reserved
+	copy(req[2:18], challenge[:])
+
+	hctx := &HandlerContext{BMC: b, V15Session: sess, User: user}
+	_, cc, err := handleActivateSession(context.Background(), hctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CodeParamOutOfRange {
+		t.Fatalf("want param out of range for privilege 0, got %02x", cc)
+	}
+}

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -93,8 +93,14 @@ func NewRegistry() *Registry {
 
 // Register adds or replaces the handler for (netFn, cmd).
 // netFn should be the *request* NetFn (even value).
+//
+// The handler is wrapped with a privilege check (innermost) and then any
+// registered middleware so that middleware can observe privilege rejections
+// (e.g. audit logging). Both wrappings happen at registration time to avoid
+// per-dispatch allocations.
 func (r *Registry) Register(netFn, cmd uint8, h Handler) {
-	r.handlers[makeKey(netFn, cmd)] = r.applyMiddleware(h)
+	checked := &dispatchingHandler{inner: h, netFn: netFn, cmd: cmd}
+	r.handlers[makeKey(netFn, cmd)] = r.applyMiddleware(checked)
 }
 
 // RegisterFunc is a convenience wrapper around [Register] for plain functions.
@@ -119,6 +125,8 @@ func (r *Registry) Merge(other *Registry) {
 }
 
 // Dispatch looks up and calls the handler for (netFn, cmd).
+// Privilege checking and middleware were applied at registration time
+// ([Register]), so this is a simple lookup with no per-call wrapping.
 // Returns [CodeCommandNotSupported] when no handler is registered.
 func (r *Registry) Dispatch(ctx context.Context, hctx *HandlerContext, netFn, cmd uint8, data []byte) ([]byte, CompletionCode, error) {
 	h, ok := r.handlers[makeKey(netFn, cmd)]

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -12,6 +12,7 @@ import (
 // IPMI session-management command IDs (NetFn 0x06 App).
 const (
 	CmdGetChannelAuthCapabilities uint8 = 0x38
+	CmdGetSessionChallenge        uint8 = 0x39
 	CmdActivateSession            uint8 = 0x3A
 	CmdSetSessionPrivilegeLevel   uint8 = 0x3B
 	CmdCloseSession               uint8 = 0x3C
@@ -27,6 +28,7 @@ func RegisterSessionHandlers(r *Registry) {
 	r.Register(NetFnAppRequest, CmdGetChannelCipherSuites, HandlerFunc(handleGetChannelCipherSuites))
 	r.Register(NetFnAppRequest, CmdSetSessionPrivilegeLevel, HandlerFunc(handleSetSessionPrivilegeLevel))
 	r.Register(NetFnAppRequest, CmdCloseSession, HandlerFunc(handleCloseSession))
+	registerV15SessionHandlers(r)
 }
 
 // ---------------------------------------------------------------------------
@@ -34,8 +36,7 @@ func RegisterSessionHandlers(r *Registry) {
 // ---------------------------------------------------------------------------
 
 // handleGetChannelAuthCaps implements Get Channel Authentication Capabilities (App 0x38).
-// Handles the pre-session probe that lanplus clients send in IPMI 1.5 framing,
-// while advertising only IPMI 2.0/RMCP+ session support.
+// Advertises both IPMI v1.5 (lan) and v2.0/RMCP+ (lanplus) when enabled on the BMC.
 func handleGetChannelAuthCaps(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
 	if len(req) < 2 {
 		return nil, CodeRequestDataTruncated, nil
@@ -50,19 +51,24 @@ func handleGetChannelAuthCaps(_ context.Context, hctx *HandlerContext, req []byt
 	// resp[1] — auth type support (IPMI spec Table 22-15, byte 3):
 	//   bit 7 = IPMI v2.0 extended capabilities available
 	//   bits 5:0 = enabled IPMI v1.5 auth types
-	// We support only IPMI v2.0/RMCP+ sessions, so no v1.5 auth type is
-	// advertised; only the extended-capabilities bit is set.
-	resp[1] = 0x80 // 0b1000_0000: IPMI v2.0 ext only, no v1.5 auth types
-	// resp[2] — byte 4 of Table 22-15:
-	//   bit 5 = KgStatus (1b = Kg set to non-zero value)
-	//   bit 2 = Non-Null usernames enabled
-	resp[2] = 0x04 // 0b0000_0100: Non-Null usernames enabled
-	if hctx.BMC != nil && len(hctx.BMC.KG) > 0 {
-		resp[2] |= 0x20 // Kg is set to a non-zero value
+	resp[1] = 0x80
+	if hctx.BMC != nil && hctx.BMC.V15LANEnabled() {
+		for _, t := range hctx.BMC.ResolvedV15AuthTypes() {
+			resp[1] |= bmc.V15AuthTypeToCapsBit(t)
+		}
 	}
+	chNum := resolveChannelNumber(req[0])
+	var ch *bmc.Channel
+	if hctx.BMC != nil {
+		ch, _ = hctx.BMC.Channels.Get(chNum)
+	}
+	fillChannelAuthCapsByte4(resp, hctx.BMC, ch)
 	// resp[3] — extended capabilities (byte 5):
 	//   bit 1 = IPMI v2.0 connections supported; bit 0 = IPMI v1.5 supported
-	resp[3] = 0x02 // IPMI v2.0 connections only
+	resp[3] = 0x02 // IPMI v2.0 (lanplus) always available on the reference server
+	if hctx.BMC != nil && hctx.BMC.V15LANEnabled() {
+		resp[3] |= 0x01
+	}
 	resp[4] = 0x00 // OEM ID byte 1
 	resp[5] = 0x00 // OEM ID byte 2
 	resp[6] = 0x00 // OEM ID byte 3
@@ -128,11 +134,24 @@ func handleSetSessionPrivilegeLevel(_ context.Context, hctx *HandlerContext, req
 	if len(req) < 1 {
 		return nil, CodeRequestDataTruncated, nil
 	}
+
+	requested := bmc.PrivilegeLevel(req[0] & 0x0F)
+
+	if hctx.V15Session != nil {
+		if requested == 0 {
+			return []byte{uint8(hctx.V15Session.PrivilegeLevel)}, CodeOK, nil
+		}
+		if requested > hctx.V15Session.MaxPrivilege {
+			return nil, CodeInsufficientPrivilege, nil
+		}
+		hctx.V15Session.PrivilegeLevel = requested
+		return []byte{uint8(requested)}, CodeOK, nil
+	}
+
 	if hctx.Session == nil {
 		return nil, CodeNotSupportedInState, nil
 	}
 
-	requested := bmc.PrivilegeLevel(req[0] & 0x0F)
 	// Privilege 0 means "return current level" per spec.
 	if requested == 0 {
 		return []byte{uint8(hctx.Session.PrivilegeLevel)}, CodeOK, nil
@@ -154,7 +173,10 @@ func handleCloseSession(_ context.Context, hctx *HandlerContext, req []byte) ([]
 	}
 	sessionID := binary.LittleEndian.Uint32(req[0:4])
 
-	if err := hctx.BMC.Sessions.Close(sessionID); err != nil {
+	if err := hctx.BMC.Sessions.Close(sessionID); err == nil {
+		return nil, CodeOK, nil
+	}
+	if err := hctx.BMC.V15Sessions.Close(sessionID); err != nil {
 		return nil, CodeParamOutOfRange, nil
 	}
 	return nil, CodeOK, nil

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestHandleGetChannelAuthCapsAdvertisesRMCPPlusOnly(t *testing.T) {
-	resp, cc, err := handleGetChannelAuthCaps(context.Background(), &HandlerContext{}, []byte{0x8e, 0x04})
+	b := newTestBMC()
+	resp, cc, err := handleGetChannelAuthCaps(context.Background(), &HandlerContext{BMC: b}, []byte{0x8e, 0x04})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -24,11 +25,14 @@ func TestHandleGetChannelAuthCapsAdvertisesRMCPPlusOnly(t *testing.T) {
 	if resp[1]&0x80 == 0 {
 		t.Fatalf("expected IPMI v2.0 extended capabilities to be available, byte=0x%02x", resp[1])
 	}
+	if resp[1]&0x04 == 0 {
+		t.Fatalf("expected MD5 v1.5 auth type, byte=0x%02x", resp[1])
+	}
 	if resp[3]&0x02 == 0 {
 		t.Fatalf("expected IPMI v2.0 connection support, byte=0x%02x", resp[3])
 	}
-	if resp[3]&0x01 != 0 {
-		t.Fatalf("must not advertise IPMI v1.5 session support, byte=0x%02x", resp[3])
+	if resp[3]&0x01 == 0 {
+		t.Fatalf("expected IPMI v1.5 connection support, byte=0x%02x", resp[3])
 	}
 }
 

--- a/pkg/handlers/session_v15.go
+++ b/pkg/handlers/session_v15.go
@@ -1,0 +1,208 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+// v1.5 Activate Session / Get Session Challenge completion codes (spec Table 18-16/18-17).
+const (
+	ccV15InvalidUserName       CompletionCode = 0x81
+	ccV15NullUserNotEnabled    CompletionCode = 0x82
+	ccV15NoSessionSlot         CompletionCode = 0x81
+	ccV15NoSlotForUser         CompletionCode = 0x82
+	ccV15NoSlotForPrivilege    CompletionCode = 0x83
+	CCV15SeqOutOfRange         CompletionCode = 0x84
+	CCV15InvalidSessionID      CompletionCode = 0x85
+	ccV15PrivilegeExceedsLimit CompletionCode = 0x86
+)
+
+func registerV15SessionHandlers(r *Registry) {
+	r.Register(NetFnAppRequest, CmdGetSessionChallenge, HandlerFunc(handleGetSessionChallenge))
+	r.Register(NetFnAppRequest, CmdActivateSession, HandlerFunc(handleActivateSession))
+}
+
+func handleGetSessionChallenge(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if len(req) < 17 {
+		return nil, CodeRequestDataTruncated, nil
+	}
+	if hctx.BMC == nil {
+		return nil, CodeUnspecifiedError, nil
+	}
+
+	authType := bmc.V15AuthType(req[0] & 0x0F)
+	if !hctx.BMC.V15AuthTypeEnabled(authType) {
+		return nil, CodeParamOutOfRange, nil
+	}
+
+	user, cc, ok := lookupV15User(hctx.BMC, req[1:17], lanChannelNumber)
+	if !ok {
+		return nil, cc, nil
+	}
+
+	var challenge [16]byte
+	if err := bmc.GenerateChallenge(&challenge); err != nil {
+		return nil, CodeUnspecifiedError, err
+	}
+
+	sess, err := hctx.BMC.V15Sessions.CreatePending(authType, user, challenge, lanChannelNumber)
+	if err != nil {
+		// Table 18-16 defines only 0x81/0x82; no slot-full code for this command.
+		return nil, CodeUnspecifiedError, nil
+	}
+
+	resp := make([]byte, 20)
+	binary.LittleEndian.PutUint32(resp[0:4], sess.TempSessionID)
+	copy(resp[4:20], challenge[:])
+	return resp, CodeOK, nil
+}
+
+func handleActivateSession(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, CompletionCode, error) {
+	if len(req) < 22 {
+		return nil, CodeRequestDataTruncated, nil
+	}
+	if hctx.V15Session == nil || hctx.V15Session.State != bmc.V15SessionStatePending {
+		return nil, CCV15InvalidSessionID, nil
+	}
+	sess := hctx.V15Session
+
+	authType := bmc.V15AuthType(req[0] & 0x0F)
+	if authType != sess.AuthType {
+		return nil, CCV15InvalidSessionID, nil
+	}
+
+	requested := bmc.PrivilegeLevel(req[1] & 0x0F)
+	if requested == 0 {
+		return nil, CodeParamOutOfRange, nil
+	}
+
+	var reqChallenge [16]byte
+	copy(reqChallenge[:], req[2:18])
+	if reqChallenge != sess.Challenge {
+		return nil, CCV15InvalidSessionID, nil
+	}
+
+	if cc, ok := authorizeV15Session(hctx.BMC, sess, requested); !ok {
+		return nil, cc, nil
+	}
+
+	initialOutbound := binary.LittleEndian.Uint32(req[18:22])
+	if initialOutbound == 0 {
+		return nil, CCV15InvalidSessionID, nil
+	}
+
+	if hctx.BMC.V15Sessions.CountActiveSessions() >= bmc.MaxSessions {
+		return nil, ccV15NoSessionSlot, nil
+	}
+	if sess.User != nil && hctx.BMC.V15Sessions.CountActiveSessionsForUser(sess.User.ID) >= 1 {
+		return nil, ccV15NoSlotForUser, nil
+	}
+	if requested >= bmc.PrivilegeLevelOperator &&
+		hctx.BMC.V15Sessions.CountActiveSessionsWithMaxPrivilegeAtLeast(bmc.PrivilegeLevelOperator) >= 2 {
+		return nil, ccV15NoSlotForPrivilege, nil
+	}
+
+	inboundSeq, err := bmc.GenerateInboundSeq()
+	if err != nil {
+		return nil, CodeUnspecifiedError, err
+	}
+
+	permanentID, err := bmc.GenerateInboundSeq()
+	if err != nil {
+		return nil, CodeUnspecifiedError, err
+	}
+
+	if err := hctx.BMC.V15Sessions.Activate(sess, permanentID, inboundSeq, initialOutbound, requested); err != nil {
+		return nil, ccV15NoSessionSlot, nil
+	}
+
+	ch, _ := hctx.BMC.Channels.Get(sess.Channel)
+	respAuthType := sess.AuthType
+	if ch != nil && !ch.PerMessageAuth {
+		respAuthType = bmc.V15AuthTypeNone
+	}
+
+	resp := make([]byte, 10)
+	resp[0] = uint8(respAuthType)
+	binary.LittleEndian.PutUint32(resp[1:5], sess.SessionID)
+	binary.LittleEndian.PutUint32(resp[5:9], inboundSeq)
+	resp[9] = uint8(requested) // maximum privilege allowed for session
+	return resp, CodeOK, nil
+}
+
+func lookupV15User(b *bmc.BMC, username []byte, channel uint8) (*bmc.User, CompletionCode, bool) {
+	isNull := true
+	for _, c := range username {
+		if c != 0 {
+			isNull = false
+			break
+		}
+	}
+
+	if isNull {
+		user, err := b.Users.Get(1)
+		if err != nil || !user.Enabled {
+			return nil, ccV15NullUserNotEnabled, false
+		}
+		access, ok := user.ChannelAccess[channel]
+		if !ok || !access.Enabled {
+			return nil, ccV15NullUserNotEnabled, false
+		}
+		return user, CodeOK, true
+	}
+
+	name := trimV15Username(username)
+	user, err := b.Users.FindEnabledByNameOnChannel(name, channel)
+	if err != nil {
+		return nil, ccV15InvalidUserName, false
+	}
+	return user, CodeOK, true
+}
+
+func trimV15Username(username []byte) string {
+	end := len(username)
+	for end > 0 && username[end-1] == 0 {
+		end--
+	}
+	return string(username[:end])
+}
+
+func authorizeV15Session(b *bmc.BMC, sess *bmc.V15Session, requested bmc.PrivilegeLevel) (CompletionCode, bool) {
+	if sess.User == nil || !sess.User.Enabled {
+		return CCV15InvalidSessionID, false
+	}
+
+	ch, err := b.Channels.Get(sess.Channel)
+	if err != nil || ch.AccessMode == bmc.ChannelAccessDisabled {
+		return ccV15PrivilegeExceedsLimit, false
+	}
+	if requested > ch.MaxPrivilege {
+		return ccV15PrivilegeExceedsLimit, false
+	}
+
+	access, ok := sess.User.ChannelAccess[sess.Channel]
+	if !ok || !access.Enabled {
+		return ccV15PrivilegeExceedsLimit, false
+	}
+	if access.CallbackOnly && requested != bmc.PrivilegeLevelCallback {
+		return ccV15PrivilegeExceedsLimit, false
+	}
+	if access.MaxPrivilege == bmc.PrivilegeLevelNoAccess || requested > access.MaxPrivilege {
+		return ccV15PrivilegeExceedsLimit, false
+	}
+	return CodeOK, true
+}
+
+// V15ResponseAuthType returns the session-header auth type for outbound v1.5
+// packets after activation (spec Table 18-17 response byte 1).
+func V15ResponseAuthType(ch *bmc.Channel, sess *bmc.V15Session) bmc.V15AuthType {
+	if sess == nil {
+		return bmc.V15AuthTypeNone
+	}
+	if ch != nil && !ch.PerMessageAuth {
+		return bmc.V15AuthTypeNone
+	}
+	return sess.AuthType
+}

--- a/pkg/handlers/session_v15_crypto.go
+++ b/pkg/handlers/session_v15_crypto.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"crypto/md5"
+	"crypto/subtle"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/utils/md2"
+)
+
+// genV15AuthCode computes the IPMI v1.5 multi-session AuthCode per spec
+// §18.15.1 Figure 18-1. Must match client [client.AuthCodeMultiSessionInput].
+func GenV15AuthCode(password []byte, authType bmc.V15AuthType, sessionID uint32, ipmiData []byte, sessionSeq uint32) []byte {
+	padded := padV15Password(password)
+	inputLen := 16 + 4 + len(ipmiData) + 4 + 16
+	input := make([]byte, inputLen)
+	copy(input[0:16], padded)
+	packUint32LE(sessionID, input, 16)
+	copy(input[20:], ipmiData)
+	packUint32LE(sessionSeq, input, 20+len(ipmiData))
+	copy(input[20+len(ipmiData)+4:], padded)
+
+	var authCode []byte
+	switch authType {
+	case bmc.V15AuthTypePassword:
+		authCode = padded
+	case bmc.V15AuthTypeMD2:
+		h := md2.New()
+		h.Write(input)
+		authCode = h.Sum(nil)
+		authCode = authCode[:16]
+	case bmc.V15AuthTypeMD5:
+		h := md5.Sum(input)
+		authCode = h[:]
+	default:
+		return nil
+	}
+	return authCode[:16]
+}
+
+// VerifyV15AuthCode returns true when got matches the expected AuthCode.
+func VerifyV15AuthCode(password []byte, authType bmc.V15AuthType, sessionID uint32, ipmiData []byte, sessionSeq uint32, got []byte) bool {
+	if len(got) != 16 {
+		return false
+	}
+	expected := GenV15AuthCode(password, authType, sessionID, ipmiData, sessionSeq)
+	if expected == nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare(expected, got) == 1
+}
+
+func padV15Password(password []byte) []byte {
+	var p [16]byte
+	copy(p[:], password)
+	return p[:]
+}
+
+func packUint32LE(v uint32, dst []byte, off int) {
+	dst[off] = byte(v)
+	dst[off+1] = byte(v >> 8)
+	dst[off+2] = byte(v >> 16)
+	dst[off+3] = byte(v >> 24)
+}

--- a/pkg/handlers/session_v15_crypto_test.go
+++ b/pkg/handlers/session_v15_crypto_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/client"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGenV15AuthCodeMD2MatchesClient(t *testing.T) {
+	password := []byte("secret")
+	sessionID := uint32(0x11223344)
+	ipmiData := []byte{0x20, 0x18, 0xc8, 0x81, 0x04, 0x38}
+
+	serverCode := GenV15AuthCode(password, bmc.V15AuthTypeMD2, sessionID, ipmiData, 1)
+	clientCode := (&client.AuthCodeMultiSessionInput{
+		Password:   string(password),
+		SessionID:  sessionID,
+		SessionSeq: 1,
+		IPMIData:   ipmiData,
+	}).AuthCode(ipmi.AuthTypeMD2)
+
+	if !bytes.Equal(serverCode, clientCode) {
+		t.Fatalf("MD2 auth code mismatch:\n server=%x\n client=%x", serverCode, clientCode)
+	}
+}
+
+func TestGenV15AuthCodePasswordMatchesClient(t *testing.T) {
+	password := []byte("straight-pass")
+	sessionID := uint32(0x55667788)
+	ipmiData := []byte{0x20, 0x18, 0xc8, 0x81, 0x04, 0x01}
+
+	serverCode := GenV15AuthCode(password, bmc.V15AuthTypePassword, sessionID, ipmiData, 2)
+	clientCode := (&client.AuthCodeMultiSessionInput{
+		Password:   string(password),
+		SessionID:  sessionID,
+		SessionSeq: 2,
+		IPMIData:   ipmiData,
+	}).AuthCode(ipmi.AuthTypePassword)
+
+	if !bytes.Equal(serverCode, clientCode) {
+		t.Fatalf("password auth code mismatch:\n server=%x\n client=%x", serverCode, clientCode)
+	}
+}

--- a/pkg/handlers/session_v15_policy.go
+++ b/pkg/handlers/session_v15_policy.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+// MinimumPrivilege returns the lowest session privilege required for (netFn, cmd)
+// on the reference server. Unknown commands default to User level.
+func MinimumPrivilege(netFn, cmd uint8) bmc.PrivilegeLevel {
+	switch netFn {
+	case NetFnChassisRequest:
+		switch cmd {
+		case CmdChassisControl:
+			return bmc.PrivilegeLevelOperator
+		default:
+			return bmc.PrivilegeLevelUser
+		}
+	case NetFnAppRequest:
+		switch cmd {
+		case CmdColdReset, CmdWarmReset:
+			return bmc.PrivilegeLevelAdministrator
+		default:
+			return bmc.PrivilegeLevelUser
+		}
+	default:
+		return bmc.PrivilegeLevelUser
+	}
+}
+
+// V15AllowsAuthTypeNone reports whether an active v1.5 session may accept a
+// post-activation packet with AuthType NONE per spec §6.11.4.
+func V15AllowsAuthTypeNone(ch *bmc.Channel, netFn, cmd uint8, sess *bmc.V15Session) bool {
+	if ch == nil || sess == nil || sess.State != bmc.V15SessionStateActive {
+		return false
+	}
+	if !ch.PerMessageAuth {
+		return true
+	}
+	minPriv := MinimumPrivilege(netFn, cmd)
+	if !ch.UserLevelAuth && minPriv <= bmc.PrivilegeLevelUser {
+		return sess.PrivilegeLevel >= minPriv
+	}
+	return false
+}
+
+// fillChannelAuthCapsByte4 sets byte 4 of Get Channel Authentication Capabilities
+// response (spec Table 22-15) from channel and user configuration.
+func fillChannelAuthCapsByte4(resp []byte, b *bmc.BMC, ch *bmc.Channel) {
+	if len(resp) < 3 || ch == nil {
+		return
+	}
+	resp[2] = 0x04 // Non-Null usernames enabled
+	if b != nil && len(b.KG) > 0 {
+		resp[2] |= 0x20
+	}
+	if !ch.PerMessageAuth {
+		resp[2] |= 0x10 // bit 4: per-message authentication disabled
+	}
+	if !ch.UserLevelAuth {
+		resp[2] |= 0x08 // bit 3: user level authentication disabled
+	}
+	if b != nil {
+		resp[2] |= anonymousLoginCapsBits(b)
+	}
+}
+
+func anonymousLoginCapsBits(b *bmc.BMC) uint8 {
+	var flags uint8
+	hasNonNull := false
+	hasNullName := false
+	hasAnonymous := false
+
+	for id := uint8(1); id <= bmc.MaxUsers; id++ {
+		user, err := b.Users.Get(id)
+		if err != nil || !user.Enabled {
+			continue
+		}
+		if user.Name == "" {
+			hasNullName = true
+			if isZeroPassword(user.Password) {
+				hasAnonymous = true
+			}
+		} else {
+			hasNonNull = true
+		}
+	}
+
+	if hasNonNull {
+		flags |= 0x04
+	}
+	if hasNullName {
+		flags |= 0x02
+	}
+	if hasAnonymous {
+		flags |= 0x01
+	}
+	return flags
+}
+
+func isZeroPassword(p [20]byte) bool {
+	for _, b := range p {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/handlers/session_v15_policy_test.go
+++ b/pkg/handlers/session_v15_policy_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+)
+
+func TestV15AllowsAuthTypeNonePerMessageDisabled(t *testing.T) {
+	ch := &bmc.Channel{Number: 1, PerMessageAuth: false, UserLevelAuth: true}
+	sess := &bmc.V15Session{State: bmc.V15SessionStateActive, PrivilegeLevel: bmc.PrivilegeLevelAdministrator}
+
+	if !V15AllowsAuthTypeNone(ch, NetFnChassisRequest, CmdChassisControl, sess) {
+		t.Fatal("expected operator chassis control allowed without per-message auth")
+	}
+}
+
+func TestV15AllowsAuthTypeNonePerMessageEnabled(t *testing.T) {
+	ch := &bmc.Channel{Number: 1, PerMessageAuth: true, UserLevelAuth: true}
+	sess := &bmc.V15Session{State: bmc.V15SessionStateActive, PrivilegeLevel: bmc.PrivilegeLevelAdministrator}
+
+	if V15AllowsAuthTypeNone(ch, NetFnChassisRequest, CmdGetChassisStatus, sess) {
+		t.Fatal("expected auth required when per-message auth enabled")
+	}
+}
+
+func TestV15AllowsAuthTypeNoneUserLevelDisabled(t *testing.T) {
+	ch := &bmc.Channel{Number: 1, PerMessageAuth: true, UserLevelAuth: false}
+	sess := &bmc.V15Session{State: bmc.V15SessionStateActive, PrivilegeLevel: bmc.PrivilegeLevelUser}
+
+	if !V15AllowsAuthTypeNone(ch, NetFnAppRequest, CmdGetDeviceID, sess) {
+		t.Fatal("expected user-level get device id without auth when user-level auth disabled")
+	}
+	if V15AllowsAuthTypeNone(ch, NetFnChassisRequest, CmdChassisControl, sess) {
+		t.Fatal("operator command should still require auth when only user-level auth disabled")
+	}
+}
+
+func TestFillChannelAuthCapsByte4ReflectsChannel(t *testing.T) {
+	b := newTestBMC()
+	ch, _ := b.Channels.Get(lanChannelNumber)
+	ch.PerMessageAuth = false
+	ch.UserLevelAuth = false
+
+	resp := make([]byte, 8)
+	fillChannelAuthCapsByte4(resp, b, ch)
+
+	if resp[2]&0x10 == 0 {
+		t.Fatalf("expected per-message auth disabled bit, byte=0x%02x", resp[2])
+	}
+	if resp[2]&0x08 == 0 {
+		t.Fatalf("expected user-level auth disabled bit, byte=0x%02x", resp[2])
+	}
+}

--- a/pkg/handlers/session_v15_test.go
+++ b/pkg/handlers/session_v15_test.go
@@ -1,0 +1,228 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/client"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestHandleGetChannelAuthCapsAdvertisesV15AndV20(t *testing.T) {
+	b := newTestBMC()
+	resp, cc, err := handleGetChannelAuthCaps(context.Background(), &HandlerContext{BMC: b}, []byte{0x8e, 0x04})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CodeOK {
+		t.Fatalf("want CodeOK, got %d", cc)
+	}
+	if resp[1]&0x04 == 0 {
+		t.Fatalf("expected MD5 auth type advertised, byte=0x%02x", resp[1])
+	}
+	if resp[3]&0x01 == 0 {
+		t.Fatalf("expected IPMI v1.5 connection support, byte=0x%02x", resp[3])
+	}
+	if resp[3]&0x02 == 0 {
+		t.Fatalf("expected IPMI v2.0 connection support, byte=0x%02x", resp[3])
+	}
+}
+
+func TestHandleGetSessionChallenge(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	req := make([]byte, 17)
+	req[0] = uint8(bmc.V15AuthTypeMD5)
+	copy(req[1:], []byte("ADMIN"))
+
+	resp, cc, err := handleGetSessionChallenge(context.Background(), &HandlerContext{BMC: b}, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CodeOK {
+		t.Fatalf("want CodeOK, got %d", cc)
+	}
+	if len(resp) != 20 {
+		t.Fatalf("want 20 response bytes, got %d", len(resp))
+	}
+	tempID := binary.LittleEndian.Uint32(resp[0:4])
+	if tempID == 0 {
+		t.Fatal("expected non-zero temporary session ID")
+	}
+	sess, err := b.V15Sessions.Get(tempID)
+	if err != nil {
+		t.Fatalf("pending session not found: %v", err)
+	}
+	if sess.State != bmc.V15SessionStatePending {
+		t.Fatalf("want pending state, got %v", sess.State)
+	}
+	if !bytes.Equal(sess.Challenge[:], resp[4:20]) {
+		t.Fatal("challenge mismatch")
+	}
+}
+
+func TestGenV15AuthCodeMatchesClient(t *testing.T) {
+	password := []byte("ADMIN")
+	sessionID := uint32(0xAABBCCDD)
+	sessionSeq := uint32(0)
+	ipmiData := []byte{0x20, 0x18, 0xc8, 0x81, 0x04, 0x3a}
+
+	serverCode := GenV15AuthCode(password, bmc.V15AuthTypeMD5, sessionID, ipmiData, sessionSeq)
+
+	clientInput := &client.AuthCodeMultiSessionInput{
+		Password:   string(password),
+		SessionID:  sessionID,
+		SessionSeq: sessionSeq,
+		IPMIData:   ipmiData,
+	}
+	clientCode := clientInput.AuthCode(ipmi.AuthTypeMD5)
+
+	if !bytes.Equal(serverCode, clientCode) {
+		t.Fatalf("auth code mismatch:\n server=%x\n client=%x", serverCode, clientCode)
+	}
+}
+
+func TestV15SessionActivationFlow(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	challengeReq := make([]byte, 17)
+	challengeReq[0] = uint8(bmc.V15AuthTypeMD5)
+	copy(challengeReq[1:], []byte("ADMIN"))
+	challengeResp, cc, err := handleGetSessionChallenge(context.Background(), &HandlerContext{BMC: b}, challengeReq)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("GetSessionChallenge: cc=%d err=%v", cc, err)
+	}
+	tempID := binary.LittleEndian.Uint32(challengeResp[0:4])
+	sess, _ := b.V15Sessions.Get(tempID)
+
+	activateReq := make([]byte, 22)
+	activateReq[0] = uint8(bmc.V15AuthTypeMD5)
+	activateReq[1] = uint8(bmc.PrivilegeLevelAdministrator)
+	copy(activateReq[2:18], challengeResp[4:20])
+	binary.LittleEndian.PutUint32(activateReq[18:22], 0x01020304)
+
+	hctx := &HandlerContext{BMC: b, V15Session: sess, User: user}
+	activateResp, cc, err := handleActivateSession(context.Background(), hctx, activateReq)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("ActivateSession: cc=%d err=%v", cc, err)
+	}
+	if len(activateResp) != 10 {
+		t.Fatalf("want 10-byte response, got %d", len(activateResp))
+	}
+	permID := binary.LittleEndian.Uint32(activateResp[1:5])
+	if permID == 0 || permID == tempID {
+		t.Fatalf("unexpected permanent session ID: 0x%08x", permID)
+	}
+	got, err := b.V15Sessions.Get(permID)
+	if err != nil {
+		t.Fatalf("active session not found: %v", err)
+	}
+	if got.State != bmc.V15SessionStateActive {
+		t.Fatalf("want active state, got %v", got.State)
+	}
+	if got.PrivilegeLevel != bmc.PrivilegeLevelUser {
+		t.Fatalf("initial privilege want USER, got %v", got.PrivilegeLevel)
+	}
+	if got.MaxPrivilege != bmc.PrivilegeLevelAdministrator {
+		t.Fatalf("max privilege want ADMIN, got %v", got.MaxPrivilege)
+	}
+	if got.OutboundSeq != 0x01020304 {
+		t.Fatalf("outbound seq: want 0x01020304, got 0x%08x", got.OutboundSeq)
+	}
+}
+
+func TestActivateSessionRejectsChallengeMismatch(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	challengeReq := make([]byte, 17)
+	challengeReq[0] = uint8(bmc.V15AuthTypeMD5)
+	copy(challengeReq[1:], []byte("ADMIN"))
+	challengeResp, cc, err := handleGetSessionChallenge(context.Background(), &HandlerContext{BMC: b}, challengeReq)
+	if err != nil || cc != CodeOK {
+		t.Fatalf("GetSessionChallenge: cc=%d err=%v", cc, err)
+	}
+	tempID := binary.LittleEndian.Uint32(challengeResp[0:4])
+	sess, _ := b.V15Sessions.Get(tempID)
+
+	activateReq := make([]byte, 22)
+	activateReq[0] = uint8(bmc.V15AuthTypeMD5)
+	activateReq[1] = uint8(bmc.PrivilegeLevelAdministrator)
+	copy(activateReq[2:18], challengeResp[4:20])
+	activateReq[2] ^= 0xff // corrupt challenge
+	binary.LittleEndian.PutUint32(activateReq[18:22], 0x01020304)
+
+	hctx := &HandlerContext{BMC: b, V15Session: sess, User: user}
+	_, cc, err = handleActivateSession(context.Background(), hctx, activateReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != CCV15InvalidSessionID {
+		t.Fatalf("want invalid session id, got cc=%d", cc)
+	}
+}
+
+func TestV15InboundSeqValid(t *testing.T) {
+	tests := []struct {
+		high, rcvd, seq uint32
+		want            bool
+	}{
+		{100, 1, 101, true},
+		{100, 1, 108, true},
+		{100, 1, 109, false},
+		{100, 1, 100, false},
+		{100, 1, 0, false},
+		{100, 1, 95, true},
+		{100, 1, 92, true},
+		{100, 1, 91, false},
+	}
+	for _, tc := range tests {
+		sess := &bmc.V15Session{InboundSeq: tc.high, InboundRcvd: uint8(tc.rcvd)}
+		got := bmc.V15InboundSeqValid(sess, tc.seq)
+		if got != tc.want {
+			t.Errorf("V15InboundSeqValid(high=%d, seq=%d) = %v, want %v", tc.high, tc.seq, got, tc.want)
+		}
+	}
+}
+
+func TestV15InboundSeqDuplicateRejected(t *testing.T) {
+	sess := &bmc.V15Session{InboundSeq: 100, InboundRcvd: 1}
+	if !sess.TryAcceptInboundSeq(101) {
+		t.Fatal("expected first accept")
+	}
+	if sess.TryAcceptInboundSeq(101) {
+		t.Fatal("duplicate seq should be rejected")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,6 +84,25 @@ func WithCipherSuites(ids []ipmi.CipherSuiteID) ServerOption {
 	}
 }
 
+// WithV15AuthTypes configures IPMI v1.5 authentication types the server
+// advertises and accepts (lan / -A MD5). Mirrors [bmc.WithV15AuthTypes].
+func WithV15AuthTypes(types []bmc.V15AuthType) ServerOption {
+	return func(s *Server) {
+		if s.bmc != nil {
+			bmc.WithV15AuthTypes(types)(s.bmc)
+		}
+	}
+}
+
+// WithV15Disabled disables IPMI v1.5 LAN sessions. RMCP+ (lanplus) is unaffected.
+func WithV15Disabled() ServerOption {
+	return func(s *Server) {
+		if s.bmc != nil {
+			bmc.WithV15Disabled()(s.bmc)
+		}
+	}
+}
+
 // NewServer creates a Server.
 //
 // b is the BMC state (create with [bmc.New]).
@@ -114,6 +133,10 @@ func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Ser
 // Serve reads packets from the transport and dispatches them until ctx is
 // cancelled or [Server.Close] is called.
 func (s *Server) Serve(ctx context.Context) error {
+	evictCtx, evictCancel := context.WithCancel(ctx)
+	defer evictCancel()
+	go s.runSessionEviction(evictCtx)
+
 	buf := make([]byte, s.bufSize)
 	for {
 		// Respect context cancellation between reads.
@@ -151,6 +174,24 @@ func (s *Server) isClosed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.closed
+}
+
+// runSessionEviction periodically removes v1.5 and RMCP+ sessions that exceeded
+// the configured inactivity timeout (spec: 60s default; see bmc.DefaultInactivityTimeout).
+func (s *Server) runSessionEviction(ctx context.Context) {
+	ticker := s.clk.NewTicker(bmc.DefaultSessionEvictInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C():
+			if s.bmc != nil {
+				s.bmc.Sessions.EvictExpired()
+				s.bmc.V15Sessions.EvictExpired()
+			}
+		}
+	}
 }
 
 // handlePacket is the top-level packet dispatcher.
@@ -197,53 +238,6 @@ func (s *Server) handleIPMI(_ context.Context, addr net.Addr, pkt []byte) {
 	} else {
 		s.handleIPMIv15(addr, pkt)
 	}
-}
-
-// handleIPMIv15 provides minimal IPMI 1.5 support for the pre-session phase.
-//
-// Only unauthenticated (AuthType NONE) packets with session ID zero are
-// dispatched — this covers the Get Channel Authentication Capabilities
-// command that clients send before deciding whether to proceed with IPMI
-// 1.5 or upgrade to RMCP+ (IPMI 2.0).
-//
-// Authenticated IPMI 1.5 sessions, Activate Session, Get Session Challenge,
-// and all other IPMI 1.5 stateful operations remain unimplemented.  Packets
-// that do not match the narrow pre-session criteria are silently dropped.
-func (s *Server) handleIPMIv15(addr net.Addr, pkt []byte) {
-	if len(pkt) < 14 {
-		return
-	}
-
-	// Reuse Session15.Unpack to parse the IPMI 1.5 session wrapper.
-	var sess ipmi.Session15
-	if err := sess.Unpack(pkt[4:]); err != nil {
-		return
-	}
-	if sess.SessionHeader15.AuthType != ipmi.AuthTypeNone {
-		return
-	}
-
-	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(sess.Payload)
-	if !ok {
-		return
-	}
-
-	ctx := context.Background()
-	hctx := &handlers.HandlerContext{BMC: s.bmc}
-	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
-
-	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
-
-	// Build IPMI 1.5 response header (AuthType NONE).
-	respHdr := ipmi.SessionHeader15{
-		AuthType:      ipmi.AuthTypeNone,
-		PayloadLength: uint8(len(ipmiResp)),
-	}
-
-	rmcp := []byte{pkt[0], pkt[1], 0xFF, pkt[3]}
-	out := append(rmcp, respHdr.Pack()...)
-	out = append(out, ipmiResp...)
-	_, _ = s.conn.WriteTo(out, addr)
 }
 
 // handleRMCPPlus routes RMCP+ (IPMI 2.0) packets.

--- a/pkg/server/server_v15.go
+++ b/pkg/server/server_v15.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"context"
+	"net"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+	ipmi "github.com/bougou/go-ipmi/pkg/types"
+)
+
+// handleIPMIv15 dispatches IPMI v1.5 LAN packets (AuthType != 0x06).
+func (s *Server) handleIPMIv15(addr net.Addr, pkt []byte) {
+	if len(pkt) < 14 {
+		return
+	}
+
+	var sess ipmi.Session15
+	if err := sess.Unpack(pkt[4:]); err != nil {
+		return
+	}
+	hdr := sess.SessionHeader15
+
+	if hdr.AuthType != ipmi.AuthTypeNone && (s.bmc == nil || !s.bmc.V15LANEnabled()) {
+		return
+	}
+
+	switch hdr.AuthType {
+	case ipmi.AuthTypeNone:
+		if hdr.SessionID != 0 {
+			s.dispatchIPMIv15SessionUnauth(addr, pkt, &sess)
+		} else {
+			s.dispatchIPMIv15UnAuth(addr, pkt, &sess)
+		}
+	case ipmi.AuthTypeMD2, ipmi.AuthTypeMD5, ipmi.AuthTypePassword:
+		s.dispatchIPMIv15Auth(addr, pkt, &sess)
+	default:
+		return
+	}
+}
+
+func (s *Server) dispatchIPMIv15UnAuth(addr net.Addr, pkt []byte, sess *ipmi.Session15) {
+	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(sess.Payload)
+	if !ok {
+		return
+	}
+
+	ctx := context.Background()
+	hctx := &handlers.HandlerContext{BMC: s.bmc}
+	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
+
+	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
+	s.sendIPMIv15UnAuth(addr, pkt, ipmiResp)
+}
+
+// dispatchIPMIv15SessionUnauth handles AuthType NONE packets on an established
+// session when per-message or user-level authentication is disabled (spec §6.11.4).
+func (s *Server) dispatchIPMIv15SessionUnauth(addr net.Addr, pkt []byte, sess *ipmi.Session15) {
+	hdr := sess.SessionHeader15
+	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(sess.Payload)
+	if !ok {
+		return
+	}
+
+	v15Sess, err := s.bmc.V15Sessions.Get(hdr.SessionID)
+	if err != nil || v15Sess.State != bmc.V15SessionStateActive {
+		return
+	}
+
+	ch, _ := s.bmc.Channels.Get(v15Sess.Channel)
+	if !handlers.V15AllowsAuthTypeNone(ch, netFn, cmd, v15Sess) {
+		return
+	}
+	if !v15Sess.TryAcceptInboundSeq(hdr.Sequence) {
+		return
+	}
+
+	hctx := &handlers.HandlerContext{
+		BMC:        s.bmc,
+		V15Session: v15Sess,
+		Channel:    ch,
+		User:       v15Sess.User,
+	}
+
+	ctx := context.Background()
+	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
+	s.bmc.V15Sessions.Touch(v15Sess)
+
+	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
+	outboundSeq := v15Sess.NextOutboundSeq()
+	s.sendIPMIv15Session(addr, pkt, v15Sess, ch, outboundSeq, ipmiResp, false)
+}
+
+func (s *Server) dispatchIPMIv15Auth(addr net.Addr, pkt []byte, sess *ipmi.Session15) {
+	hdr := sess.SessionHeader15
+	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(sess.Payload)
+	if !ok {
+		return
+	}
+
+	v15Sess, err := s.bmc.V15Sessions.Get(hdr.SessionID)
+	if err != nil {
+		return
+	}
+
+	authType := bmc.V15AuthType(hdr.AuthType)
+	if authType != v15Sess.AuthType {
+		if v15Sess.State == bmc.V15SessionStatePending && cmd == handlers.CmdActivateSession {
+			s.sendIPMIv15CommandCC(addr, pkt, v15Sess, netFn, cmd, seq, handlers.CCV15InvalidSessionID, true)
+		}
+		return
+	}
+
+	lookupID := hdr.SessionID
+	sessionSeq := hdr.Sequence
+	pendingActivate := v15Sess.State == bmc.V15SessionStatePending
+
+	if pendingActivate {
+		if cmd != handlers.CmdActivateSession {
+			return
+		}
+		if hdr.Sequence != 0 {
+			return
+		}
+		lookupID = v15Sess.TempSessionID
+		sessionSeq = 0
+	} else if v15Sess.State == bmc.V15SessionStateActive {
+		// Non-destructive window check first — do NOT consume the slot
+		// until the auth code is verified, otherwise a spoofed packet
+		// with an in-window sequence number can exhaust the window (DoS).
+		if !bmc.V15InboundSeqValid(v15Sess, hdr.Sequence) {
+			if cmd == handlers.CmdActivateSession {
+				s.sendIPMIv15CommandCC(addr, pkt, v15Sess, netFn, cmd, seq, handlers.CCV15SeqOutOfRange, true)
+			}
+			return
+		}
+	} else {
+		return
+	}
+
+	password := v15Sess.User.PasswordV15Padded()
+	if !handlers.VerifyV15AuthCode(password, authType, lookupID, sess.Payload, sessionSeq, hdr.AuthCode) {
+		if pendingActivate {
+			s.sendIPMIv15CommandCC(addr, pkt, v15Sess, netFn, cmd, seq, handlers.CCV15InvalidSessionID, true)
+		}
+		return
+	}
+
+	// Auth verified — now commit the sequence-window state.
+	if !pendingActivate {
+		if !v15Sess.TryAcceptInboundSeq(hdr.Sequence) {
+			// Lost a race (e.g. duplicate accepted concurrently); drop.
+			return
+		}
+	}
+
+	ch, _ := s.bmc.Channels.Get(v15Sess.Channel)
+	hctx := &handlers.HandlerContext{
+		BMC:        s.bmc,
+		V15Session: v15Sess,
+		Channel:    ch,
+		User:       v15Sess.User,
+	}
+
+	ctx := context.Background()
+	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
+	s.bmc.V15Sessions.Touch(v15Sess)
+
+	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
+	outboundSeq := v15Sess.NextOutboundSeq()
+	useAuth := cmd == handlers.CmdActivateSession ||
+		handlers.V15ResponseAuthType(ch, v15Sess) != bmc.V15AuthTypeNone
+	s.sendIPMIv15Session(addr, pkt, v15Sess, ch, outboundSeq, ipmiResp, useAuth)
+}
+
+func (s *Server) sendIPMIv15UnAuth(addr net.Addr, reqPkt []byte, ipmiResp []byte) {
+	respHdr := ipmi.SessionHeader15{
+		AuthType:      ipmi.AuthTypeNone,
+		PayloadLength: uint8(len(ipmiResp)),
+	}
+	rmcp := []byte{reqPkt[0], reqPkt[1], 0xFF, reqPkt[3]}
+	out := append(rmcp, respHdr.Pack()...)
+	out = append(out, ipmiResp...)
+	_, _ = s.conn.WriteTo(out, addr)
+}
+
+func (s *Server) sendIPMIv15CommandCC(addr net.Addr, reqPkt []byte, sess *bmc.V15Session, netFn, cmd, seq uint8, cc handlers.CompletionCode, authenticated bool) {
+	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), nil)
+	var outboundSeq uint32
+	if sess != nil && sess.State == bmc.V15SessionStateActive {
+		outboundSeq = sess.NextOutboundSeq()
+	}
+	ch, _ := s.bmc.Channels.Get(sess.Channel)
+	s.sendIPMIv15Session(addr, reqPkt, sess, ch, outboundSeq, ipmiResp, authenticated)
+}
+
+func (s *Server) sendIPMIv15Session(addr net.Addr, reqPkt []byte, sess *bmc.V15Session, ch *bmc.Channel, outboundSeq uint32, ipmiResp []byte, authenticated bool) {
+	var respHdr ipmi.SessionHeader15
+	if authenticated && sess != nil {
+		authType := handlers.V15ResponseAuthType(ch, sess)
+		if authType == bmc.V15AuthTypeNone {
+			respHdr = ipmi.SessionHeader15{
+				AuthType:      ipmi.AuthTypeNone,
+				Sequence:      outboundSeq,
+				SessionID:     sess.SessionID,
+				PayloadLength: uint8(len(ipmiResp)),
+			}
+		} else {
+			authCode := handlers.GenV15AuthCode(
+				sess.User.PasswordV15Padded(),
+				sess.AuthType,
+				sess.SessionID,
+				ipmiResp,
+				outboundSeq,
+			)
+			respHdr = ipmi.SessionHeader15{
+				AuthType:      ipmi.AuthType(sess.AuthType),
+				Sequence:      outboundSeq,
+				SessionID:     sess.SessionID,
+				AuthCode:      authCode,
+				PayloadLength: uint8(len(ipmiResp)),
+			}
+		}
+	} else {
+		sessionID := uint32(0)
+		if sess != nil {
+			if sess.State == bmc.V15SessionStatePending {
+				sessionID = sess.TempSessionID
+			} else {
+				sessionID = sess.SessionID
+			}
+		}
+		respHdr = ipmi.SessionHeader15{
+			AuthType:      ipmi.AuthTypeNone,
+			Sequence:      outboundSeq,
+			SessionID:     sessionID,
+			PayloadLength: uint8(len(ipmiResp)),
+		}
+	}
+
+	rmcp := []byte{reqPkt[0], reqPkt[1], 0xFF, reqPkt[3]}
+	out := append(rmcp, respHdr.Pack()...)
+	out = append(out, ipmiResp...)
+	_, _ = s.conn.WriteTo(out, addr)
+}

--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -34,6 +34,24 @@ e2e_run_chassis_cases() {
 	e2e_run_test "chassis power off" "$@" chassis power off || ((_fail++)) || true
 }
 
+# Run chassis cases over IPMI v2.0 / RMCP+ (ipmitool -I lanplus).
+e2e_run_chassis_cases_lanplus() {
+	local -n _fail="${1:?failures counter variable name required}"
+	shift
+	e2e_run_test "lanplus chassis status" "$@" chassis status || ((_fail++)) || true
+	e2e_run_test "lanplus chassis power on" "$@" chassis power on || ((_fail++)) || true
+	e2e_run_test "lanplus chassis power off" "$@" chassis power off || ((_fail++)) || true
+}
+
+# Run chassis cases over IPMI v1.5 (ipmitool -I lan -A MD5).
+e2e_run_chassis_cases_lan() {
+	local -n _fail="${1:?failures counter variable name required}"
+	shift
+	e2e_run_test "lan chassis status" "$@" chassis status || ((_fail++)) || true
+	e2e_run_test "lan chassis power on" "$@" chassis power on || ((_fail++)) || true
+	e2e_run_test "lan chassis power off" "$@" chassis power off || ((_fail++)) || true
+}
+
 e2e_report() {
 	local suite="$1"
 	local failures="$2"

--- a/test/e2e/self_test.sh
+++ b/test/e2e/self_test.sh
@@ -2,6 +2,9 @@
 # self_test.sh — go-ipmi self-test: use goipmi (client) to talk to
 # goipmi-server (server), validating both ends in a single test.
 #
+# Exercises dual-stack serving: IPMI v2.0 (lanplus) and v1.5 (lan) on the
+# same UDP port.
+#
 # Environment variables:
 #   GOIPMI_SERVER_PORT – server listen port (default: random high port)
 #
@@ -17,7 +20,6 @@ set -euo pipefail
 source "$(dirname "$0")/common.sh"
 e2e_init
 
-# Pick a random high port to avoid conflicts.
 PORT="${GOIPMI_SERVER_PORT:-$((9623 + RANDOM % 1000))}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
@@ -34,7 +36,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> Starting goipmi-server on :${PORT} ..."
+echo "==> Starting goipmi-server on :${PORT} (dual-stack: lanplus + lan) ..."
 env \
 	GOIPMI_SERVER_PORT="${PORT}" \
 	GOIPMI_SERVER_USER="${USER}" \
@@ -54,10 +56,15 @@ fi
 echo ""
 echo "========================================"
 echo " Self E2E: goipmi → goipmi-server (:${PORT})"
+echo " (lanplus + lan dual-stack)"
 echo "========================================"
 
 failures=0
-e2e_run_chassis_cases failures \
+
+e2e_run_chassis_cases_lanplus failures \
 	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus
+
+e2e_run_chassis_cases_lan failures \
+	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lan
 
 e2e_report "Self E2E" "${failures}"

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # server_test.sh — E2E test for go-ipmi as an IPMI BMC server.
 #
-# Starts goipmi-server, then connects with ipmitool (local or Docker) to
-# verify basic chassis commands.
+# Starts goipmi-server, then connects with ipmitool (local or Docker) over
+# both IPMI v2.0 (lanplus) and v1.5 (lan -A MD5) to verify dual-stack serving.
 #
 # Environment variables:
-#   GOIPMI_SERVER_PORT – port for the server to listen on (default: 623)
+#   GOIPMI_SERVER_PORT – port for the server to listen on (default: 9623)
 #                         Use a port >1024 to avoid sudo when testing locally.
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #   IPMITOOL_IMAGE     – Docker image to use when ipmitool is not found
@@ -43,9 +43,6 @@ if [ -n "${IPMITOOL_BIN}" ]; then
 	IPMITOOL_RUN="${IPMITOOL_BIN}"
 else
 	echo "==> ipmitool not found locally, will use Docker: ${IPMITOOL_IMAGE}"
-	# We need --network host only when the server is on localhost AND the
-	# port is not reachable from the default Docker bridge.  For port 623
-	# bound to 0.0.0.0 the bridge works as long as we use the host IP.
 	IPMITOOL_RUN="docker run --rm --network host ${IPMITOOL_IMAGE}"
 fi
 
@@ -61,13 +58,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Use sudo only when binding to a privileged port.
 USE_SUDO=""
 if [ "${GOIPMI_SERVER_PORT}" -lt 1024 ]; then
 	USE_SUDO="sudo"
 fi
 
-echo "==> Starting goipmi-server on :${GOIPMI_SERVER_PORT} ..."
+echo "==> Starting goipmi-server on :${GOIPMI_SERVER_PORT} (dual-stack: lanplus + lan) ..."
 ${USE_SUDO} env \
 	GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT}" \
 	GOIPMI_SERVER_USER="${GOIPMI_USER}" \
@@ -76,7 +72,6 @@ ${USE_SUDO} env \
 SERVER_PID=$!
 sleep 2
 
-# Verify the server is listening.
 if ! ss -uln | grep -q ":${GOIPMI_SERVER_PORT} "; then
 	echo "ERROR: server failed to bind port ${GOIPMI_SERVER_PORT}" >&2
 	exit 1
@@ -89,16 +84,20 @@ echo "==> Server is listening on :${GOIPMI_SERVER_PORT}"
 echo ""
 echo "========================================"
 echo " Server E2E: ipmitool → goipmi-server"
+echo " (lanplus + lan dual-stack)"
 echo "========================================"
-
-IPMITOOL_ARGS=(-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus)
 
 run_ipmitool() {
 	# shellcheck disable=SC2086
-	${IPMITOOL_RUN} "${IPMITOOL_ARGS[@]}" "$@"
+	${IPMITOOL_RUN} "$@"
 }
 
 failures=0
-e2e_run_chassis_cases failures run_ipmitool
+
+e2e_run_chassis_cases_lanplus failures run_ipmitool \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus
+
+e2e_run_chassis_cases_lan failures run_ipmitool \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5
 
 e2e_report "Server E2E" "${failures}"

--- a/utils/md2/md2_test.go
+++ b/utils/md2/md2_test.go
@@ -1,0 +1,90 @@
+package md2
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// RFC 1319 test vectors.
+func TestMD2_RFC1319_Vectors(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "8350e5a3e24c153df2275c9f80692773"},
+		{"a", "32ec01ec4a6dac72c0ab96fb34c0b5d1"},
+		{"abc", "da853b0d3f88d99b30283a69e6ded6bb"},
+		{"message digest", "ab4f496bfb2a530b219ff33031fe06b0"},
+		{"abcdefghijklmnopqrstuvwxyz", "4e8ddff3650292ab5a4108c3aa47940b"},
+		{"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", "da33def2a42df13975352846c30338cd"},
+		{"12345678901234567890123456789012345678901234567890123456789012345678901234567890", "d5976f79d83d3a0dc9806c3c66f3efd8"},
+	}
+	for _, tc := range tests {
+		h := New()
+		h.Write([]byte(tc.input))
+		got := hex.EncodeToString(h.Sum(nil))
+		if got != tc.want {
+			t.Errorf("MD2(%q) = %s, want %s", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestMD2_SumWithoutWrite demonstrates the bug: calling Sum(input) on a
+// fresh hasher WITHOUT Write does NOT hash input. It computes MD2("") and
+// appends it to input — input bytes never enter the hash state.
+func TestMD2_SumWithoutWrite_IsBroken(t *testing.T) {
+	payload := []byte("this data is NOT hashed")
+
+	// Correct usage.
+	good := New()
+	good.Write(payload)
+	correct := good.Sum(nil)
+
+	// Broken usage: the pattern found in the original auth code.
+	broken := New().Sum(payload)
+	broken = broken[:Size] // original code sliced to 16 bytes
+
+	// Correct hash should differ from the first 16 bytes of payload.
+	if bytes.Equal(correct, payload[:Size]) {
+		t.Errorf("correct MD2 hash happens to equal first 16 bytes of input? extremely unlikely")
+	}
+
+	// Broken "hash" is just the first 16 bytes of input (plus MD2("") appended),
+	// so after [:Size] it's the cleartext input prefix.
+	if !bytes.Equal(broken, payload[:Size]) {
+		t.Errorf("New().Sum(payload)[:16] = %x, want payload[:16] = %x — "+
+			"expected Sum to NOT hash the argument", broken, payload[:Size])
+	}
+
+	// Hard proof: broken == payload[:16] means the auth code was cleartext password.
+	t.Logf("correct MD2(input) = %x", correct)
+	t.Logf("broken New().Sum(input)[:16] = %x (cleartext input prefix)", broken)
+	t.Logf("MD2(empty) appended to input: New().Sum(input) full = %x", New().Sum(payload))
+
+	// Also confirm: New().Sum(nil) with no Write = MD2("").
+	emptyHash := New().Sum(nil)
+	if hex.EncodeToString(emptyHash) != "8350e5a3e24c153df2275c9f80692773" {
+		t.Errorf("MD2('') = %x, want 8350e5a3e24c153df2275c9f80692773", emptyHash)
+	}
+}
+
+// TestMD2_SameInputDifferentWrite confirms that after Write+Sum, the hasher
+// state is reset correctly (Sum copies and finalizes, leaving original reusable).
+func TestMD2_SameInputDifferentWrite(t *testing.T) {
+	a := []byte("hello")
+	b := []byte("world")
+
+	h := New()
+	h.Write(a)
+	sumA := h.Sum(nil)
+
+	h.Write(b)
+	sumB := h.Sum(nil)
+
+	if bytes.Equal(sumA, sumB) {
+		t.Errorf("MD2('hello') and MD2('helloworld') should differ")
+	}
+	t.Logf("MD2('hello')          = %x", sumA)
+	t.Logf("MD2('hello')+MD2('world') = %x", sumB)
+}


### PR DESCRIPTION
Implement v1.5 session handshake, AuthCode verification, per-message auth policy, command privilege enforcement, and spec-aligned session lifecycle (60s inactivity, Option 1 sequence window) so lan and lanplus share one UDP port with configurable v1.5 auth types in goipmi-server.