### PR TITLE
feat(handlers): accept boot flag valid bit clearing as no-op

### DIFF
--- a/pkg/handlers/chassis.go
+++ b/pkg/handlers/chassis.go
@@ -124,6 +124,7 @@ func handleChassisIdentify(ctx context.Context, hctx *HandlerContext, req []byte
 
 // handleSetSystemBootOptions implements Set System Boot Options (Chassis 0x08,
 // spec §28.12 Table 28-12).  Supported parameter selectors:
+//   - 0x03: BMC boot flag valid bit clearing (accepted as no-op)
 //   - 0x04: Boot Info Acknowledge (§28.14 Table 28-14 param #4)
 //   - 0x05: Boot Flags (§28.14 Table 28-14 param #5)
 //
@@ -171,6 +172,18 @@ func handleSetSystemBootOptions(ctx context.Context, hctx *HandlerContext, req [
 			return nil, CodeRequestDataTruncated, nil
 		}
 		return nil, codeFromHalErr(ch.SetBootFlags(ctx, &flags)), nil
+
+	case types.BootOptionParamSelector_BMCBootFlagValidBitClear:
+		// Parameter #3 (§28.14 Table 28-14) suppresses the conditions under
+		// which the BMC auto-clears the boot flags valid bit: the 60-second
+		// Chassis Control timeout (bit 3), plus resets/power cycles caused by
+		// PEF, watchdog timeout, pushbutton/soft-reset, or power-button/wake
+		// events (bits 4/2/1/0). The reference BMC never auto-clears the valid
+		// bit under any of these conditions, so every "don't clear" request is
+		// trivially satisfied. Accept it instead of returning 80h — clients
+		// that disable the timeout before setting boot flags abort on an
+		// error completion code.
+		return nil, CodeOK, nil
 
 	default:
 		// Per spec Table 28-12: unimplemented parameter → 80h.

--- a/pkg/handlers/chassis_test.go
+++ b/pkg/handlers/chassis_test.go
@@ -156,6 +156,35 @@ func TestHandleSetSystemBootOptions_BootFlags(t *testing.T) {
 	}
 }
 
+// TestHandleSetSystemBootOptions_BootFlagValidBitClear asserts parameter #3
+// "BMC boot flag valid bit clearing" (§28.14 Table 28-14) is accepted as a
+// no-op for any payload shape: 0x08 suppresses only the 60-second timeout,
+// 0x1f suppresses every condition, and an empty payload toggles no bits.
+// The reference BMC never auto-clears the valid bit, so CodeOK is the
+// truthful answer and the request must not reach the HAL.
+func TestHandleSetSystemBootOptions_BootFlagValidBitClear(t *testing.T) {
+	m := mock.New()
+	b := newTestBMCWithMock(m)
+	ch := b.HAL().Chassis().(*mock.Chassis)
+	hctx := &HandlerContext{BMC: b}
+
+	selector := byte(types.BootOptionParamSelector_BMCBootFlagValidBitClear)
+	for _, req := range [][]byte{
+		{selector, 0x08},
+		{selector, 0x1f},
+		{selector},
+		{0x80 | selector, 0x08}, // mark-invalid bit accepted
+	} {
+		_, cc, err := handleSetSystemBootOptions(context.Background(), hctx, req)
+		if err != nil || cc != CodeOK {
+			t.Fatalf("req=%x: want CodeOK, got cc=%d err=%v", req, cc, err)
+		}
+	}
+	if ch.BootFlags != nil {
+		t.Fatalf("no HAL side effect expected, HAL received %+v", ch.BootFlags)
+	}
+}
+
 func TestHandleGetSystemBootOptions_BootFlags(t *testing.T) {
 	m := mock.New()
 	b := newTestBMCWithMock(m)

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -100,4 +100,23 @@ e2e_run_chassis_cases_lanplus failures run_ipmitool \
 e2e_run_chassis_cases_lan failures run_ipmitool \
 	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5
 
+# Set System Boot Options param #3 (spec Table 28-14, BMC boot flag valid bit
+# clearing) must be accepted as a no-op: the reference BMC never auto-clears
+# the boot flags valid bit, so "don't clear" requests are trivially satisfied.
+# Clients such as OpenStack Ironic send raw 0x00 0x08 0x03 0x08 before every
+# set_boot_device and abort on an 80h completion code.
+e2e_run_test "lanplus boot flag valid bit clearing (param 3)" run_ipmitool \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus \
+	raw 0x00 0x08 0x03 0x08 || ((failures++)) || true
+
+e2e_run_test "lan boot flag valid bit clearing (param 3)" run_ipmitool \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5 \
+	raw 0x00 0x08 0x03 0x08 || ((failures++)) || true
+
+# The follow-up step of the client sequence above: after disabling the 60s
+# timeout, set the boot device (param #5).
+e2e_run_test "lanplus chassis bootdev pxe" run_ipmitool \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus \
+	chassis bootdev pxe || ((failures++)) || true
+
 e2e_report "Server E2E" "${failures}"


### PR DESCRIPTION
Set System Boot Options parameter #3 (spec Table 28-14) lets a client suppress the conditions under which the BMC auto-clears the boot flags valid bit: the 60-second Chassis Control timeout (bit 3), plus resets or power cycles caused by PEF, watchdog timeout, pushbutton/soft-reset, or power-button/wake events (bits 4/2/1/0).

The reference BMC never auto-clears the valid bit under any of these conditions, so every "don't clear" request is trivially satisfied. Return CodeOK instead of 80h: IPMI clients such as OpenStack Ironic send this parameter (raw 0x00 0x08 0x03 0x08) before every set_boot_device to disable the 60-second timeout, and abort the whole operation on an error completion code.

Covered by a unit test and by server E2E cases running the same raw bytes (plus a follow-up chassis bootdev pxe) over both lanplus and lan against goipmi-server.