### PR TITLE
fix(server): v1.5 accept Activate Session starting inbound seq on first packet

### DIFF
--- a/pkg/bmc/session_v15.go
+++ b/pkg/bmc/session_v15.go
@@ -202,6 +202,14 @@ func (s *V15SessionStore) CountActiveSessionsWithMaxPrivilegeAtLeast(min Privile
 // Activate transitions a pending session to active with a new permanent ID.
 // maxPrivilege is the requested ceiling; initial privilege is USER per §18.16
 // (Callback when max is Callback).
+//
+// inboundSeq is the Activate Session response "Session inbound sequence number"
+// (spec §18.15 / §6.12.9): the starting sequence the remote console must use on
+// its first authenticated packet. InboundSeq on the session tracks the highest
+// sequence already accepted, so it is seeded to inboundSeq-1 (wrapping) with an
+// empty receive bitmap — otherwise the first packet (seq == inboundSeq) is
+// rejected as a duplicate and clients such as ipmitool stall for a full LAN
+// timeout before retrying with inboundSeq+1.
 func (s *V15SessionStore) Activate(pending *V15Session, permanentID, inboundSeq, outboundSeq uint32, maxPrivilege PrivilegeLevel) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -226,7 +234,11 @@ func (s *V15SessionStore) Activate(pending *V15Session, permanentID, inboundSeq,
 
 	pending.SessionID = permanentID
 	pending.State = V15SessionStateActive
-	pending.InboundSeq = inboundSeq
+	// Seq 0 is reserved for pre-session; never advertise/seed it as a start.
+	if inboundSeq == 0 {
+		inboundSeq = 1
+	}
+	pending.InboundSeq = inboundSeq - 1
 	pending.InboundRcvd = 0
 	pending.OutboundSeq = outboundSeq
 	pending.PrivilegeLevel = initialPriv
@@ -358,10 +370,18 @@ func V15InboundSeqValid(sess *V15Session, seq uint32) bool {
 }
 
 // NextOutboundSeq returns the sequence number for the current outbound message
-// and advances the counter for the next one.
+// and advances the counter for the next one. Sequence 0 is reserved for
+// pre-session packets and is skipped on wrap (§6.12.9).
 func (sess *V15Session) NextOutboundSeq() uint32 {
+	if sess.OutboundSeq == 0 {
+		sess.OutboundSeq = 1
+	}
 	seq := sess.OutboundSeq
 	sess.OutboundSeq++
+	// fix overflow
+	if sess.OutboundSeq == 0 {
+		sess.OutboundSeq = 1
+	}
 	return seq
 }
 

--- a/pkg/bmc/session_v15_test.go
+++ b/pkg/bmc/session_v15_test.go
@@ -27,3 +27,75 @@ func TestV15SessionStore_EvictExpired(t *testing.T) {
 		t.Fatal("session should have been evicted")
 	}
 }
+
+// TestV15ActivateAcceptsStartingInboundSeq reproduces the ipmitool -I lan stall:
+// Activate returns starting inbound seq N, and the console's first authenticated
+// packet uses sequence N. That packet must be accepted immediately.
+func TestV15ActivateAcceptsStartingInboundSeq(t *testing.T) {
+	s := NewV15SessionStore(&mockClock{now: time.Now()})
+	user := &User{ID: 2, Enabled: true}
+	var challenge [16]byte
+	sess, err := s.CreatePending(V15AuthTypeMD5, user, challenge, 1)
+	if err != nil {
+		t.Fatalf("CreatePending: %v", err)
+	}
+
+	const startInbound uint32 = 0xf5f6fd46
+	if err := s.Activate(sess, 0x7c5267b7, startInbound, 0x91e741d3, PrivilegeLevelAdministrator); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	got, err := s.Get(0x7c5267b7)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.InboundSeq != startInbound-1 {
+		t.Fatalf("InboundSeq high-water: want 0x%08x, got 0x%08x", startInbound-1, got.InboundSeq)
+	}
+	if !V15InboundSeqValid(got, startInbound) {
+		t.Fatalf("starting inbound seq 0x%08x should be valid before first packet", startInbound)
+	}
+	if !got.TryAcceptInboundSeq(startInbound) {
+		t.Fatal("first post-Activate packet with starting inbound seq must be accepted")
+	}
+	if got.TryAcceptInboundSeq(startInbound) {
+		t.Fatal("duplicate starting inbound seq must be rejected")
+	}
+}
+
+func TestV15ActivateRemapsReservedInboundSeqZero(t *testing.T) {
+	s := NewV15SessionStore(&mockClock{now: time.Now()})
+	user := &User{ID: 2, Enabled: true}
+	var challenge [16]byte
+	sess, err := s.CreatePending(V15AuthTypeMD5, user, challenge, 1)
+	if err != nil {
+		t.Fatalf("CreatePending: %v", err)
+	}
+	if err := s.Activate(sess, 0x11111111, 0, 0x01020304, PrivilegeLevelAdministrator); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	got, err := s.Get(0x11111111)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// inboundSeq 0 remapped to 1 → high-water 0; first packet must use 1.
+	if got.InboundSeq != 0 {
+		t.Fatalf("InboundSeq high-water: want 0, got 0x%08x", got.InboundSeq)
+	}
+	if !got.TryAcceptInboundSeq(1) {
+		t.Fatal("first packet with remapped starting seq 1 must be accepted")
+	}
+}
+
+func TestV15NextOutboundSeqSkipsZero(t *testing.T) {
+	sess := &V15Session{OutboundSeq: 0xffffffff}
+	if got := sess.NextOutboundSeq(); got != 0xffffffff {
+		t.Fatalf("first: want 0xffffffff, got 0x%08x", got)
+	}
+	if got := sess.NextOutboundSeq(); got != 1 {
+		t.Fatalf("wrap: want 1 (skip 0), got 0x%08x", got)
+	}
+	if sess.OutboundSeq != 2 {
+		t.Fatalf("after wrap: next OutboundSeq want 2, got 0x%08x", sess.OutboundSeq)
+	}
+}

--- a/pkg/client/api_app.go
+++ b/pkg/client/api_app.go
@@ -683,9 +683,22 @@ func (c *Client) ActivateSession(ctx context.Context) (response *app.ActivateSes
 
 	c.session.v15.sessionID = response.SessionID
 
-	c.session.v15.inSeq = response.InitialInboundSequenceNumber
+	// Seed to N-1 so the pre-increment in genSession15 emits N on the first
+	// post-Activate request (spec §18.15 / §6.12.9).
+	c.session.v15.inSeq = v15SeedInSeq(response.InitialInboundSequenceNumber)
 
 	return
+}
+
+// v15SeedInSeq returns the inSeq high-water to store after Activate so the
+// next pre-increment emits starting. Seq 0 is reserved; a non-compliant BMC
+// returning 0 is remapped to 1 (same as GenerateInboundSeq) so the first
+// packet is 1 rather than wrapping through 0xffffffff to 0.
+func v15SeedInSeq(starting uint32) uint32 {
+	if starting == 0 {
+		starting = 1
+	}
+	return starting - 1
 }
 
 func (c *Client) CloseSession(ctx context.Context, request *app.CloseSessionRequest) (response *app.CloseSessionResponse, err error) {

--- a/pkg/client/api_app_v15_seq_test.go
+++ b/pkg/client/api_app_v15_seq_test.go
@@ -1,0 +1,36 @@
+package client
+
+import "testing"
+
+func TestV15SeedInSeq(t *testing.T) {
+	tests := []struct {
+		starting uint32
+		want     uint32
+	}{
+		{0, 0}, // reserved 0 → treat as 1 → seed 0 (first packet 1)
+		{1, 0}, // start 1 → seed 0
+		{0xf5f6fd46, 0xf5f6fd45},
+		{0xffffffff, 0xfffffffe},
+	}
+	for _, tc := range tests {
+		if got := v15SeedInSeq(tc.starting); got != tc.want {
+			t.Errorf("v15SeedInSeq(0x%08x)=0x%08x, want 0x%08x", tc.starting, got, tc.want)
+		}
+	}
+}
+
+func TestV15InSeqIncrementSkipsZero(t *testing.T) {
+	c := &Client{session: &session{}}
+	c.session.v15.active = true
+	c.session.v15.inSeq = 0xffffffff
+	sess, err := c.genSession15([]byte{0x20, 0x18, 0xc8, 0x81, 0x00, 0x01, 0x00})
+	if err != nil {
+		t.Fatalf("genSession15: %v", err)
+	}
+	if sess.SessionHeader15.Sequence != 1 {
+		t.Fatalf("wrap sequence: want 1, got 0x%08x", sess.SessionHeader15.Sequence)
+	}
+	if c.session.v15.inSeq != 1 {
+		t.Fatalf("inSeq after wrap: want 1, got 0x%08x", c.session.v15.inSeq)
+	}
+}

--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -38,9 +38,10 @@ type v15 struct {
 
 	sessionID uint32
 
-	// Sequence number that BMC wants remote console to use for subsequent messages in the session.
-	// Remote console use "inSeq" and increment it when sending Request to BMC.
-	// "inSeq" is first updated by returned ActivateSession response.
+	// Sequence number that BMC wants remote console to use for subsequent messages
+	// in the session (Activate Session response "Session inbound sequence number").
+	// Seeded to N-1 after Activate so the pre-increment on send emits N first
+	// (spec §18.15 / §6.12.9); then incremented for each Request to the BMC.
 	inSeq uint32
 
 	// "outSeq" is set by Remote Console to indicate the sequence number should picked by BMC.

--- a/pkg/client/server_v15_test.go
+++ b/pkg/client/server_v15_test.go
@@ -48,7 +48,7 @@ func TestServerV15SessionActivation(t *testing.T) {
 	}
 	c.WithInterface(InterfaceLan).
 		WithTimeout(2 * time.Second).
-		WithRetry(1)
+		WithRetry(0)
 	c.session.authType = ipmi.AuthTypeMD5
 
 	if err := c.Connect(context.Background()); err != nil {
@@ -96,7 +96,7 @@ func TestServerV15SessionActivationMD2(t *testing.T) {
 	}
 	c.WithInterface(InterfaceLan).
 		WithTimeout(2 * time.Second).
-		WithRetry(1)
+		WithRetry(0)
 
 	if err := c.Connect(context.Background()); err != nil {
 		t.Fatalf("Connect (v1.5 MD2): %v", err)
@@ -113,6 +113,74 @@ func TestServerV15SessionActivationMD2(t *testing.T) {
 	}
 	if resp.DeviceID == 0 {
 		t.Fatalf("unexpected device ID: %d", resp.DeviceID)
+	}
+}
+
+// TestV15ClientActivateSeedsInboundSeq locks the client half of the Activate
+// Session inbound-seq contract (spec §18.15 / §6.12.9): after Activate returns
+// starting seq N, inSeq must be N-1 so the pre-increment on the next send
+// emits N. Against a correct BMC the sliding window often still accepts N+1,
+// so client-e2e alone may not catch a regression — this assertion does.
+func TestV15ClientActivateSeedsInboundSeq(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+
+	b := newV15TestBMC(t, username, password)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	conn := udp.Wrap(pc)
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLan).
+		WithTimeout(2 * time.Second).
+		WithRetry(0)
+	c.v20 = false
+	c.session.authType = ipmi.AuthTypeMD5
+	c.maxPrivilegeLevel = ipmi.PrivilegeLevelAdministrator
+
+	bg := context.Background()
+	if _, err := c.GetChannelAuthenticationCapabilities(bg, ipmi.ChannelNumberSelf, c.maxPrivilegeLevel); err != nil {
+		t.Fatalf("GetChannelAuthenticationCapabilities: %v", err)
+	}
+	if _, err := c.GetSessionChallenge(bg); err != nil {
+		t.Fatalf("GetSessionChallenge: %v", err)
+	}
+	c.session.v15.preSession = true
+
+	activate, err := c.ActivateSession(bg)
+	if err != nil {
+		t.Fatalf("ActivateSession: %v", err)
+	}
+	wantSeed := activate.InitialInboundSequenceNumber - 1
+	if c.session.v15.inSeq != wantSeed {
+		t.Fatalf("after Activate: inSeq=0x%08x, want 0x%08x (returned N-1; N=0x%08x)",
+			c.session.v15.inSeq, wantSeed, activate.InitialInboundSequenceNumber)
+	}
+
+	if _, err := c.SetSessionPrivilegeLevel(bg, c.maxPrivilegeLevel); err != nil {
+		t.Fatalf("SetSessionPrivilegeLevel with starting inbound seq: %v", err)
+	}
+	if c.session.v15.inSeq != activate.InitialInboundSequenceNumber {
+		t.Fatalf("after first post-Activate cmd: inSeq=0x%08x, want returned N 0x%08x",
+			c.session.v15.inSeq, activate.InitialInboundSequenceNumber)
 	}
 }
 

--- a/pkg/client/session_crypto_client.go
+++ b/pkg/client/session_crypto_client.go
@@ -25,7 +25,12 @@ func (c *Client) genSession15(rawPayload []byte) (*types.Session15, error) {
 	}
 
 	if c.session.v15.active {
-		c.session.v15.inSeq += 1
+		c.session.v15.inSeq++
+		// Spec reserves sequence 0 for pre-session packets; skip on wrap
+		// (same as ipmitool lan.c).
+		if c.session.v15.inSeq == 0 {
+			c.session.v15.inSeq = 1
+		}
 		sessionHeader.Sequence = c.session.v15.inSeq
 	}
 

--- a/pkg/cmd/app/cmd_get_auth_code.go
+++ b/pkg/cmd/app/cmd_get_auth_code.go
@@ -1,13 +1,11 @@
 package app
 
-import
+import "github.com/bougou/go-ipmi/pkg/types"
 
-// see 22.21
-//
-// This command is used to send a block of data to the BMC, whereupon the BMC will
-// return a hash of the data together concatenated with the internally stored password for the given channel and user
-	"github.com/bougou/go-ipmi/pkg/types"
-
+// GetAuthCodeRequest sends a block of data to the BMC, whereupon the BMC will
+// return a hash of the data together concatenated with the internally stored
+// password for the given channel and user.
+// See 22.21.
 type GetAuthCodeRequest struct {
 	AuthType types.AuthType
 

--- a/pkg/handlers/session_v15_test.go
+++ b/pkg/handlers/session_v15_test.go
@@ -152,6 +152,16 @@ func TestV15SessionActivationFlow(t *testing.T) {
 	if got.OutboundSeq != 0x01020304 {
 		t.Fatalf("outbound seq: want 0x01020304, got 0x%08x", got.OutboundSeq)
 	}
+	returnedInbound := binary.LittleEndian.Uint32(activateResp[5:9])
+	if returnedInbound == 0 {
+		t.Fatal("Activate Session must return a non-zero starting inbound seq")
+	}
+	if got.InboundSeq != returnedInbound-1 {
+		t.Fatalf("InboundSeq high-water: want 0x%08x (returned-1), got 0x%08x", returnedInbound-1, got.InboundSeq)
+	}
+	if !bmc.V15InboundSeqValid(got, returnedInbound) {
+		t.Fatalf("returned inbound seq 0x%08x must be acceptable as the first console packet", returnedInbound)
+	}
 }
 
 func TestActivateSessionRejectsChallengeMismatch(t *testing.T) {

--- a/test/e2e/client_test.sh
+++ b/test/e2e/client_test.sh
@@ -113,6 +113,8 @@ echo ""
 echo "========================================"
 echo " IPMI v1.5 / RMCP (-I lan)"
 echo "========================================"
-e2e_run_chassis_cases failures "${GOIPMI_BASE[@]}" -I lan
+# -R 0: goipmi additional-retries; exercise Activate→first-packet against a
+# third-party simulator without retransmission masking timeouts.
+e2e_run_chassis_cases failures "${GOIPMI_BASE[@]}" -I lan -R 0
 
 e2e_report "Client E2E" "${failures}"

--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -43,7 +43,15 @@ e2e_run_chassis_cases_lanplus() {
 	e2e_run_test "lanplus chassis power off" "$@" chassis power off || ((_fail++)) || true
 }
 
-# Run chassis cases over IPMI v1.5 (ipmitool -I lan -A MD5).
+# Run chassis cases over IPMI v1.5 (ipmitool -I lan -A MD5 / goipmi -I lan).
+#
+# Pass a no-retransmit retry count so the first post-Activate packet must
+# succeed on the first attempt. The flag value differs by client:
+#   ipmitool: -R 1  (total attempts; -R 0 is ignored and remapped to 4)
+#   goipmi:   -R 0  (additional retries; 0 means one attempt only)
+# With default retries, an Activate inbound-seq off-by-one (server rejects
+# starting seq N, client retries with N+1 after ~2s) still eventually passes
+# and hides the stall that ipmitool users see.
 e2e_run_chassis_cases_lan() {
 	local -n _fail="${1:?failures counter variable name required}"
 	shift

--- a/test/e2e/self_test.sh
+++ b/test/e2e/self_test.sh
@@ -64,7 +64,9 @@ failures=0
 e2e_run_chassis_cases_lanplus failures \
 	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus
 
+# -R 0: goipmi retryCount is additional retries (0 = one attempt). Unlike
+# ipmitool, -R 1 here would still allow one retransmission and hide the bug.
 e2e_run_chassis_cases_lan failures \
-	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lan
+	"${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lan -R 0
 
 e2e_report "Self E2E" "${failures}"

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -97,8 +97,11 @@ failures=0
 e2e_run_chassis_cases_lanplus failures run_ipmitool \
 	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lanplus
 
+# -R 1: single attempt (ipmitool ignores -R 0). First authenticated packet
+# after Activate Session must succeed immediately (starting inbound seq N).
+# Default retries hide the ~2s stall when that packet is dropped.
 e2e_run_chassis_cases_lan failures run_ipmitool \
-	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5 -R 1
 
 # Set System Boot Options param #3 (spec Table 28-14, BMC boot flag valid bit
 # clearing) must be accepted as a no-op: the reference BMC never auto-clears
@@ -110,7 +113,7 @@ e2e_run_test "lanplus boot flag valid bit clearing (param 3)" run_ipmitool \
 	raw 0x00 0x08 0x03 0x08 || ((failures++)) || true
 
 e2e_run_test "lan boot flag valid bit clearing (param 3)" run_ipmitool \
-	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5 \
+	-H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" -U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" -I lan -A MD5 -R 1 \
 	raw 0x00 0x08 0x03 0x08 || ((failures++)) || true
 
 # The follow-up step of the client sequence above: after disabling the 60s


### PR DESCRIPTION
Seed v1.5 InboundSeq to N-1 so ipmitool's first post-Activate packet (using returned seq N) is not dropped as a duplicate, avoiding a full LAN timeout stall. Align the client seed and harden lan e2e with -R 0.

Fix a LAN timeout report by kubevirtbmc
```
/ # time ipmitool -I lanplus -H 10.96.3.7 -U admin -P password  chassis power status
Chassis Power is on
real	0m 0.00s
user	0m 0.00s
sys	0m 0.00s
/ # time ipmitool -I lan -H 10.96.3.7 -U admin -P password  chassis power status
Chassis Power is on
real	0m 2.01s
user	0m 0.00s
sys	0m 0.00s
```