### PR TITLE
ci: sync e2e with make test-e2e and add PR fmt/vet checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+---
+name: Go Checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  fmt-vet:
+    name: gofmt & go vet
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Check gofmt
+        run: |
+          make fmt
+          git diff --exit-code
+
+      - name: Run go vet
+        run: make vet

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,19 +7,20 @@ on:
       - "main"
   pull_request:
     types:
-    - opened
-    - synchronize
+      - opened
+      - synchronize
   workflow_dispatch:
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Client E2E: goipmi → ipmi-simulator
-  # ---------------------------------------------------------------------------
-  client-e2e:
-    name: Client E2E (go-ipmi → ipmi-simulator)
+  # Single entry point: Makefile `test-e2e` is the source of truth for which
+  # suites run. Keep CI and local in sync by only extending that target.
+  e2e:
+    name: E2E (make test-e2e)
     runs-on: ubuntu-latest
 
     services:
+      # Client suite (goipmi → ipmi-simulator) defaults to 127.0.0.1:9623.
+      # The script can also auto-start Docker if this service is absent.
       ipmi-simulator:
         image: vaporio/ipmi-simulator:master
         ports:
@@ -33,41 +34,5 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Run client E2E tests
-        run: make test-e2e-client
-
-  # ---------------------------------------------------------------------------
-  # Server E2E: ipmitool → goipmi-server
-  # ---------------------------------------------------------------------------
-  server-e2e:
-    name: Server E2E (ipmitool → go-ipmi server)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - name: Run server E2E tests
-        run: make test-e2e-server
-
-  # ---------------------------------------------------------------------------
-  # Self E2E: goipmi → goipmi-server (both from this repo)
-  # ---------------------------------------------------------------------------
-  self-e2e:
-    name: Self E2E (goipmi → goipmi-server)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - name: Run self E2E tests
-        run: make test-e2e-self
+      - name: Run E2E tests
+        run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,17 @@ lint:
 dependencies:
 	test -d $(BINDIR) || mkdir $(BINDIR)
 	GOBIN=$(BINDIR) go install github.com/onsi/ginkgo/ginkgo@v1.16.4
-
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(BINDIR) latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(BINDIR) latest
 
 # ---------------------------------------------------------------------------
 # E2E tests
 # ---------------------------------------------------------------------------
-#   make test-e2e-client  — goipmi → ipmi-simulator
-#   make test-e2e-server  — ipmitool → goipmi-server
-#   make test-e2e-self    — goipmi → goipmi-server
-#   make test-e2e         — run all three
+#   make test-e2e-client         — goipmi → ipmi-simulator
+#   make test-e2e-server         — ipmitool → goipmi-server
+#   make test-e2e-self           — goipmi → goipmi-server
+#   make test-e2e-chassis-codec  — typed chassis codec / boot options
+#   make test-e2e-cipher         — RMCP+ cipher suite coverage
+#   make test-e2e                — run all suites (CI uses this)
 
 test-e2e-client: build
 	./test/e2e/client_test.sh

--- a/pkg/types/types_fru_codec_test.go
+++ b/pkg/types/types_fru_codec_test.go
@@ -441,13 +441,13 @@ func TestFRUProduct_NullFieldEndsCustomWithoutC1(t *testing.T) {
 	}
 	body = append(body, packFRUASCIIField("Acme")...)
 	body = append(body, packFRUASCIIField("BMC")...)
-	body = append(body, packFRUASCIIField("")...) // part
-	body = append(body, packFRUASCIIField("")...) // version
-	body = append(body, packFRUASCIIField("")...) // serial
-	body = append(body, packFRUASCIIField("")...) // asset
-	body = append(body, packFRUASCIIField("")...) // file id
+	body = append(body, packFRUASCIIField("")...)   // part
+	body = append(body, packFRUASCIIField("")...)   // version
+	body = append(body, packFRUASCIIField("")...)   // serial
+	body = append(body, packFRUASCIIField("")...)   // asset
+	body = append(body, packFRUASCIIField("")...)   // file id
 	body = append(body, packFRUASCIIField("XY")...) // one custom (TL must not be C1h)
-	body = append(body, 0xC0)                        // null field (no C1h)
+	body = append(body, 0xC0)                       // null field (no C1h)
 	// Pad to 8-byte multiple including checksum byte.
 	for (len(body)+1)%8 != 0 {
 		body = append(body, 0x00)

--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -14,13 +14,17 @@ e2e_init() {
 e2e_run_test() {
 	local name="$1"
 	shift
+	local start_ns elapsed_ms rc=0
 	echo ""
 	echo "--- ${name} ---"
-	if "$@"; then
-		echo -e "${GREEN}✓ ${name}${NC}"
+	start_ns=$(date +%s%N)
+	"$@" || rc=$?
+	elapsed_ms=$(( ($(date +%s%N) - start_ns) / 1000000 ))
+	if [ "${rc}" -eq 0 ]; then
+		echo -e "${GREEN}✓ ${name}${NC} (${elapsed_ms}ms)"
 	else
-		echo -e "${RED}✗ ${name}${NC}" >&2
-		return 1
+		echo -e "${RED}✗ ${name}${NC} (${elapsed_ms}ms)" >&2
+		return "${rc}"
 	fi
 }
 

--- a/test/e2e/self_test.sh
+++ b/test/e2e/self_test.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 source "$(dirname "$0")/common.sh"
 e2e_init
 
-PORT="${GOIPMI_SERVER_PORT:-$((9623 + RANDOM % 1000))}"
+# Stay clear of client e2e / CI ipmi-simulator default (9623).
+PORT="${GOIPMI_SERVER_PORT:-$((9700 + RANDOM % 1000))}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
 
@@ -45,6 +46,10 @@ env \
 SERVER_PID=$!
 sleep 1
 
+if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+	echo -e "${RED}ERROR: goipmi-server exited early (port ${PORT} likely in use)${NC}" >&2
+	exit 1
+fi
 if ! ss -uln | grep -q ":${PORT} "; then
 	echo -e "${RED}ERROR: server failed to start${NC}" >&2
 	exit 1

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -5,8 +5,9 @@
 # both IPMI v2.0 (lanplus) and v1.5 (lan -A MD5) to verify dual-stack serving.
 #
 # Environment variables:
-#   GOIPMI_SERVER_PORT – port for the server to listen on (default: 9623)
-#                         Use a port >1024 to avoid sudo when testing locally.
+#   GOIPMI_SERVER_PORT – port for the server to listen on
+#                         (default: random high port; avoid clashing with the
+#                         client e2e / CI ipmi-simulator on 9623)
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #   IPMITOOL_IMAGE     – Docker image to use when ipmitool is not found
 #                         (default: ghcr.io/halfcrazy/ipmitool:eecd64f)
@@ -14,8 +15,8 @@
 # Requires: make build  (or: make test-e2e-server)
 #
 # Usage:
-#   ./test/e2e/server_test.sh                          # port 623   (needs root)
-#   GOIPMI_SERVER_PORT=9623 ./test/e2e/server_test.sh  # port 9623 (no root needed)
+#   ./test/e2e/server_test.sh
+#   GOIPMI_SERVER_PORT=9623 ./test/e2e/server_test.sh
 
 set -euo pipefail
 
@@ -23,7 +24,8 @@ set -euo pipefail
 source "$(dirname "$0")/common.sh"
 e2e_init
 
-GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-9623}"
+# Stay clear of client e2e / CI service container default (9623).
+GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-$((9700 + RANDOM % 1000))}"
 GOIPMI_USER="${GOIPMI_USER:-ADMIN}"
 GOIPMI_PASS="${GOIPMI_PASS:-ADMIN}"
 IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
@@ -72,8 +74,14 @@ ${USE_SUDO} env \
 SERVER_PID=$!
 sleep 2
 
+# Port alone is not enough: another process (e.g. CI ipmi-simulator on 9623)
+# can own the UDP port after goipmi-server exits on bind failure.
+if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+	echo -e "${RED}ERROR: goipmi-server exited early (port ${GOIPMI_SERVER_PORT} likely in use)${NC}" >&2
+	exit 1
+fi
 if ! ss -uln | grep -q ":${GOIPMI_SERVER_PORT} "; then
-	echo "ERROR: server failed to bind port ${GOIPMI_SERVER_PORT}" >&2
+	echo -e "${RED}ERROR: server failed to bind port ${GOIPMI_SERVER_PORT}${NC}" >&2
 	exit 1
 fi
 echo "==> Server is listening on :${GOIPMI_SERVER_PORT}"


### PR DESCRIPTION
Drive E2E CI from `make test-e2e` so local and GitHub stay aligned, and add a PR workflow for `make fmt` (git diff) plus `go vet`. golangci-lint is fixed to install/run locally but not wired into CI yet — the tree still fails with a large backlog of lint findings.