### PR TITLE
fix(client): close UDP connection after session close failure

### DIFF
--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -447,6 +447,9 @@ func (c *Client) closeLAN(ctx context.Context) error {
 	// close the channel to notify the keepAliveSession goroutine to stop
 	close(c.closedCh)
 
+	// Closing the network connection must not depend on the BMC replying to
+	// close session, it always needs to be done or we will have a resource leak.
+	// For example a timed-out or unreachable BMC must not leave the socket open.
 	var sessionID uint32
 	if c.v20 {
 		sessionID = c.session.v20.bmcSessionID
@@ -457,15 +460,17 @@ func (c *Client) closeLAN(ctx context.Context) error {
 	request := &app.CloseSessionRequest{
 		SessionID: sessionID,
 	}
-	if _, err := c.CloseSession(ctx, request); err != nil {
-		return fmt.Errorf("CloseSession failed, err: %w", err)
+	_, sessionErr := c.CloseSession(ctx, request)
+	if sessionErr != nil {
+		sessionErr = fmt.Errorf("CloseSession failed, err: %w", sessionErr)
 	}
 
-	if err := c.udpClient.Close(); err != nil {
-		return fmt.Errorf("close udp connection failed, err: %w", err)
+	connectionErr := c.udpClient.Close()
+	if connectionErr != nil {
+		connectionErr = fmt.Errorf("close UDP connection failed, err: %w", connectionErr)
 	}
 
-	return nil
+	return errors.Join(sessionErr, connectionErr)
 }
 
 // 6.12.15 Session Inactivity Timeouts

--- a/pkg/client/interface_lan_test.go
+++ b/pkg/client/interface_lan_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// closeTrackingConn provides the minimal net.Conn behavior needed by closeLAN tests.
+type closeTrackingConn struct {
+	writeErr error
+	closed   bool
+}
+
+func (*closeTrackingConn) Read([]byte) (int, error)         { return 0, errors.New("unexpected read") }
+func (c *closeTrackingConn) Write([]byte) (int, error)      { return 0, c.writeErr }
+func (c *closeTrackingConn) Close() error                   { c.closed = true; return nil }
+func (*closeTrackingConn) LocalAddr() net.Addr              { return &net.UDPAddr{} }
+func (*closeTrackingConn) RemoteAddr() net.Addr             { return &net.UDPAddr{} }
+func (*closeTrackingConn) SetDeadline(time.Time) error      { return nil }
+func (*closeTrackingConn) SetReadDeadline(time.Time) error  { return nil }
+func (*closeTrackingConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestCloseConnectionWhenCloseSessionFails(t *testing.T) {
+	writeErr := errors.New("BMC is unreachable")
+	conn := &closeTrackingConn{writeErr: writeErr}
+	client, err := NewClient("127.0.0.1", 623, "user", "password")
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	client.WithInterface(InterfaceLan)
+	client.v20 = false
+	client.udpClient.conn = conn
+
+	err = client.Close(context.Background())
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("Close() error = %v, want wrapped CloseSession error", err)
+	}
+	if !conn.closed {
+		t.Fatal("UDP connection remained open after CloseSession failure")
+	}
+}


### PR DESCRIPTION
Ensure the local UDP connection is closed even when the BMC does not respond to the `Close Session` command.

Previously, `closeLAN` returned immediately when `CloseSession` failed. This skipped `UDPClient.Close()` and could leave the UDP socket open.