### PR TITLE
feat(handlers)!: identify the dispatched command on HandlerContext

### DIFF
--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -19,6 +19,7 @@ type runtimeConfig struct {
 	CipherSuites []types.CipherSuiteID
 	V15AuthTypes []bmc.V15AuthType // nil = default (md5)
 	V15Disabled  bool
+	Trace        bool
 }
 
 func loadRuntimeConfig() (runtimeConfig, error) {
@@ -42,6 +43,14 @@ func loadRuntimeConfig() (runtimeConfig, error) {
 			return cfg, fmt.Errorf("GOIPMI_SERVER_V15: %w", err)
 		}
 		cfg.V15Disabled = !enabled
+	}
+
+	if v := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_TRACE")); v != "" {
+		trace, err := parseBoolEnv(v)
+		if err != nil {
+			return cfg, fmt.Errorf("GOIPMI_SERVER_TRACE: %w", err)
+		}
+		cfg.Trace = trace
 	}
 
 	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_V15_AUTH_TYPES")); raw != "" {
@@ -74,6 +83,9 @@ func printRuntimeBanner(cfg runtimeConfig, b *bmc.BMC) {
 		fmt.Printf("goipmi-server: IPMI v1.5 (lan) auth types: %s\n", bmc.FormatV15AuthTypes(b.ResolvedV15AuthTypes()))
 	} else {
 		fmt.Println("goipmi-server: IPMI v1.5 (lan) disabled")
+	}
+	if cfg.Trace {
+		fmt.Println("goipmi-server: per-command trace enabled (stderr)")
 	}
 }
 

--- a/cmd/goipmi-server/config_test.go
+++ b/cmd/goipmi-server/config_test.go
@@ -43,6 +43,7 @@ func TestLoadRuntimeConfigDefaultsDualStack(t *testing.T) {
 	t.Setenv("GOIPMI_SERVER_CIPHER_SUITES", "")
 	t.Setenv("GOIPMI_SERVER_V15", "")
 	t.Setenv("GOIPMI_SERVER_V15_AUTH_TYPES", "")
+	t.Setenv("GOIPMI_SERVER_TRACE", "")
 
 	cfg, err := loadRuntimeConfig()
 	if err != nil {
@@ -50,6 +51,11 @@ func TestLoadRuntimeConfigDefaultsDualStack(t *testing.T) {
 	}
 	if cfg.V15Disabled {
 		t.Fatal("v1.5 should be enabled by default")
+	}
+	// E2E runs this server with stdout and stderr attached to the terminal, so
+	// the trace stays off unless asked for.
+	if cfg.Trace {
+		t.Fatal("trace should be off by default")
 	}
 	if len(cfg.V15AuthTypes) != 0 {
 		t.Fatalf("expected nil v15 auth types (use BMC default), got %v", cfg.V15AuthTypes)
@@ -74,6 +80,23 @@ func TestLoadRuntimeConfigCustomV15Auth(t *testing.T) {
 	}
 	if len(cfg.V15AuthTypes) != 2 {
 		t.Fatalf("want 2 auth types, got %v", cfg.V15AuthTypes)
+	}
+}
+
+func TestLoadRuntimeConfigEnableTrace(t *testing.T) {
+	t.Setenv("GOIPMI_SERVER_TRACE", "1")
+
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig: %v", err)
+	}
+	if !cfg.Trace {
+		t.Fatal("expected trace enabled")
+	}
+
+	t.Setenv("GOIPMI_SERVER_TRACE", "nonsense")
+	if _, err := loadRuntimeConfig(); err == nil {
+		t.Fatal("expected an error for an unparseable GOIPMI_SERVER_TRACE")
 	}
 }
 

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -12,6 +12,7 @@
 //	GOIPMI_SERVER_CIPHER_SUITES   – RMCP+ cipher suite IDs, comma-separated (default: 3,17)
 //	GOIPMI_SERVER_V15_AUTH_TYPES  – v1.5 auth types: none,md2,md5,password,oem (default: md5)
 //	GOIPMI_SERVER_V15             – set to 0/false to disable v1.5 while keeping lanplus (default: 1)
+//	GOIPMI_SERVER_TRACE           – set to 1/true to log every dispatched command to stderr (default: 0)
 package main
 
 import (
@@ -81,7 +82,11 @@ func run() error {
 	}
 	defer conn.Close()
 
-	srv := server.NewServer(b, conn)
+	var opts []server.ServerOption
+	if cfg.Trace {
+		opts = append(opts, server.WithHandlerRegistry(tracingRegistry()))
+	}
+	srv := server.NewServer(b, conn, opts...)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/goipmi-server/trace.go
+++ b/cmd/goipmi-server/trace.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// tracingRegistry builds the standard command set with [traceCommands] wrapped
+// around it. Middleware is not applied retroactively, so Use must come before
+// the handlers are registered — which is also why this cannot just decorate the
+// registry [server.NewServer] would have built by default.
+func tracingRegistry() *handlers.Registry {
+	reg := handlers.NewRegistry()
+	reg.Use(traceCommands)
+	handlers.RegisterAppHandlers(reg)
+	handlers.RegisterSessionHandlers(reg)
+	handlers.RegisterChassisHandlers(reg)
+	handlers.RegisterStorageHandlers(reg)
+	return reg
+}
+
+// traceCommands logs one line per dispatched command. Driving this server with
+// `ipmitool -I lanplus ... chassis power on` produces, abridged:
+//
+//	trace "Get Channel Authentication Capabilities" netfn=0x06 cmd=0x38 user=-         priv=-             cc=0x00 req=2B resp=8B 60.828µs
+//	trace "Get Channel Cipher Suites"               netfn=0x06 cmd=0x54 user=-         priv=-             cc=0x00 req=3B resp=11B 8.759µs
+//	trace "Set Session Privilege Level"             netfn=0x06 cmd=0x3b user=ADMIN     priv=ADMINISTRATOR cc=0x00 req=1B resp=1B 422ns
+//	trace <unregistered>                            netfn=0x2c cmd=0x3e user=ADMIN     priv=ADMINISTRATOR cc=0xc1 req=2B resp=0B 1.953µs err=no handler for netFn=0x2c cmd=0x3e
+//	trace "Get Device ID"                           netfn=0x06 cmd=0x01 user=ADMIN     priv=ADMINISTRATOR cc=0x00 req=0B resp=11B 3.908µs
+//	trace "Chassis Control"                         netfn=0x00 cmd=0x02 user=ADMIN     priv=ADMINISTRATOR cc=0x00 req=1B resp=0B 963ns
+//	trace "Close Session"                           netfn=0x06 cmd=0x3c user=ADMIN     priv=ADMINISTRATOR cc=0x00 req=4B resp=0B 1.001µs
+//
+// Every field comes from what the dispatcher already knew, which is the point:
+// middleware is the layer that wants to describe a request, so
+// [handlers.HandlerContext] hands it the description. Naming the command needs
+// no table of its own here — without [types.Command] on the context this would
+// print bare numbers, or each handler would have to report its own name upward,
+// putting the knowledge in the layer least able to act on it.
+//
+// The two lines that are not a chassis power-on show why that matters. The
+// pre-session commands carry no user or privilege because they are the exchange
+// that establishes them, and they are exactly the commands the privilege check
+// exempts. The 0x2c/0x3e line is ipmitool probing for DCMI support, which this
+// server does not implement: unregistered commands run middleware before
+// answering [types.CodeInvalidCommand], because an initiator probing for
+// commands the BMC does not have is what an audit log exists to catch, and
+// short-circuiting would make it invisible.
+func traceCommands(next handlers.Handler) handlers.Handler {
+	return handlers.HandlerFunc(func(ctx context.Context, hctx *handlers.HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+		start := time.Now()
+		resp, cc, err := next.Handle(ctx, hctx, req)
+
+		fmt.Fprintln(os.Stderr, "goipmi-server: "+traceLine(hctx, cc, err, len(req), len(resp), time.Since(start)))
+
+		return resp, cc, err
+	})
+}
+
+// traceLine formats one trace record. Splitting it from the middleware keeps
+// the interesting half testable without capturing stderr.
+func traceLine(hctx *handlers.HandlerContext, cc types.CompletionCode, err error, reqLen, respLen int, elapsed time.Duration) string {
+	// 41 columns fits the widest name this server registers, "Get Channel
+	// Authentication Capabilities", in quotes.
+	line := fmt.Sprintf("trace %-41s netfn=0x%02x cmd=0x%02x user=%-9s priv=%-13s cc=0x%02x req=%dB resp=%dB %v",
+		commandName(hctx), uint8(hctx.Command.NetFn), hctx.Command.ID,
+		userName(hctx), privilege(hctx), uint8(cc), reqLen, respLen, elapsed)
+	if err != nil {
+		line += " err=" + err.Error()
+	}
+	return line
+}
+
+// commandName prefers the spec name the registry recorded. Commands with no
+// handler never got one, and are worth telling apart from the rest.
+func commandName(hctx *handlers.HandlerContext) string {
+	if hctx.Command.Name == "" {
+		return "<unregistered>"
+	}
+	return `"` + hctx.Command.Name + `"`
+}
+
+func userName(hctx *handlers.HandlerContext) string {
+	if hctx.User == nil || hctx.User.Name == "" {
+		return "-"
+	}
+	return hctx.User.Name
+}
+
+// privilege reports the level the session negotiated, which is what the
+// privilege check inside the dispatch chain compared against. A request with no
+// session yet — Get Channel Authentication Capabilities and the rest of the
+// setup exchange — has none, and those are the commands exempt from the check.
+// The conversion is what [bmc.PrivilegeLevel] documents itself as: a mirror of
+// the wire type, kept distinct so bmc holds no wire conversions. Only the wire
+// type spells the levels out.
+func privilege(hctx *handlers.HandlerContext) string {
+	switch {
+	case hctx.Session != nil:
+		return types.PrivilegeLevel(hctx.Session.PrivilegeLevel).String()
+	case hctx.V15Session != nil:
+		return types.PrivilegeLevel(hctx.V15Session.PrivilegeLevel).String()
+	default:
+		return "-"
+	}
+}

--- a/cmd/goipmi-server/trace_test.go
+++ b/cmd/goipmi-server/trace_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestTraceLineNamesTheCommand covers what the trace exists to demonstrate: the
+// middleware describes a request from HandlerContext alone, including one that
+// reached no handler.
+func TestTraceLineNamesTheCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		hctx    *handlers.HandlerContext
+		cc      types.CompletionCode
+		err     error
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "registered command reports its spec name",
+			hctx: &handlers.HandlerContext{
+				Command: types.CommandChassisControl,
+				Session: &bmc.Session{PrivilegeLevel: bmc.PrivilegeLevelAdministrator},
+				User:    &bmc.User{Name: "ADMIN"},
+			},
+			cc:   types.CodeOK,
+			want: []string{`"Chassis Control"`, "netfn=0x00", "cmd=0x02", "user=ADMIN", "priv=ADMINISTRATOR", "cc=0x00"},
+		},
+		{
+			name: "unregistered command still reports its numbers",
+			hctx: &handlers.HandlerContext{
+				Command: types.Command{ID: 0x3e, NetFn: 0x2c},
+				Session: &bmc.Session{PrivilegeLevel: bmc.PrivilegeLevelAdministrator},
+				User:    &bmc.User{Name: "ADMIN"},
+			},
+			cc:   types.CodeInvalidCommand,
+			err:  errors.New("no handler for netFn=0x2c cmd=0x3e"),
+			want: []string{"<unregistered>", "netfn=0x2c", "cmd=0x3e", "cc=0xc1", "err=no handler for netFn=0x2c cmd=0x3e"},
+		},
+		{
+			name: "pre-session command has neither user nor privilege",
+			hctx: &handlers.HandlerContext{
+				Command: types.CommandGetChannelAuthCapabilities,
+			},
+			cc:      types.CodeOK,
+			want:    []string{`"Get Channel Authentication Capabilities"`, "user=-", "priv=-"},
+			notWant: []string{"ADMINISTRATOR"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := traceLine(tc.hctx, tc.cc, tc.err, 1, 4, 2*time.Microsecond)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("line missing %q:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(got, notWant) {
+					t.Errorf("line should not contain %q:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+// TestTracingRegistryObservesUnknownCommands pins the ordering the example
+// depends on: Use before Register, so every dispatch runs the middleware --
+// including one with no handler, which would otherwise be answered behind it.
+func TestTracingRegistryObservesUnknownCommands(t *testing.T) {
+	var seen []types.Command
+	reg := handlers.NewRegistry()
+	reg.Use(func(next handlers.Handler) handlers.Handler {
+		return handlers.HandlerFunc(func(ctx context.Context, hctx *handlers.HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+			seen = append(seen, hctx.Command)
+			return next.Handle(ctx, hctx, data)
+		})
+	})
+	handlers.RegisterChassisHandlers(reg)
+
+	hctx := &handlers.HandlerContext{BMC: bmc.New(bmc.DeviceInfo{}, [16]byte{}, mock.New())}
+	reg.Dispatch(context.Background(), hctx, uint8(types.NetFnChassisRequest), types.CommandGetChassisStatus.ID, nil)
+	reg.Dispatch(context.Background(), hctx, 0x2c, 0x3e, nil)
+
+	if len(seen) != 2 {
+		t.Fatalf("middleware ran %d times, want 2", len(seen))
+	}
+	if seen[0].Name != "Get Chassis Status" {
+		t.Errorf("registered command name = %q, want %q", seen[0].Name, "Get Chassis Status")
+	}
+	if seen[1].Name != "" || seen[1].ID != 0x3e || uint8(seen[1].NetFn) != 0x2c {
+		t.Errorf("unregistered command = %+v, want nameless 0x2c/0x3e", seen[1])
+	}
+}

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -7,34 +7,31 @@ import (
 	"github.com/bougou/go-ipmi/pkg/types"
 )
 
-// IPMI NetFn codes used in this file.
+// NetFn and command codes for the requests this package inspects as raw wire
+// bytes, before dispatch has resolved them to a [types.Command] (privilege
+// rules, v1.5 authentication policy, session state machine). Registration uses
+// the [types] command table directly and needs none of these.
+//
+// TestWireConstantsMatchCommandTable keeps the values in step with that table.
 const (
 	NetFnAppRequest     uint8 = 0x06
 	NetFnChassisRequest uint8 = 0x00
-	NetFnStorageRequest uint8 = 0x0A
-	NetFnSensorRequest  uint8 = 0x04
 )
 
 // IPMI App command IDs.
 const (
-	CmdGetDeviceID            uint8 = 0x01
 	CmdColdReset              uint8 = 0x02
 	CmdWarmReset              uint8 = 0x03
-	CmdGetSelfTestResults     uint8 = 0x04
-	CmdGetDeviceGUID          uint8 = 0x08
-	CmdSetBMCGlobalEnables    uint8 = 0x2E
-	CmdGetBMCGlobalEnables    uint8 = 0x2F
-	CmdGetChannelAuthCaps     uint8 = 0x38
 	CmdGetChannelCipherSuites uint8 = 0x54
 )
 
 // RegisterAppHandlers adds all App/Global command handlers to r.
 func RegisterAppHandlers(r *Registry) {
-	r.Register(NetFnAppRequest, CmdGetDeviceID, HandlerFunc(handleGetDeviceID))
-	r.Register(NetFnAppRequest, CmdColdReset, HandlerFunc(handleColdReset))
-	r.Register(NetFnAppRequest, CmdWarmReset, HandlerFunc(handleWarmReset))
-	r.Register(NetFnAppRequest, CmdGetSelfTestResults, HandlerFunc(handleGetSelfTestResults))
-	r.Register(NetFnAppRequest, CmdGetDeviceGUID, HandlerFunc(handleGetDeviceGUID))
+	r.RegisterFunc(types.CommandGetDeviceID, handleGetDeviceID)
+	r.RegisterFunc(types.CommandColdReset, handleColdReset)
+	r.RegisterFunc(types.CommandWarmReset, handleWarmReset)
+	r.RegisterFunc(types.CommandGetSelfTestResults, handleGetSelfTestResults)
+	r.RegisterFunc(types.CommandGetDeviceGUID, handleGetDeviceGUID)
 }
 
 // handleGetDeviceID implements Get Device ID (App 0x01).

--- a/pkg/handlers/chassis.go
+++ b/pkg/handlers/chassis.go
@@ -9,22 +9,17 @@ import (
 
 // IPMI Chassis command IDs (spec §28).
 const (
-	CmdGetChassisCapabilities uint8 = 0x00
-	CmdGetChassisStatus       uint8 = 0x01
-	CmdChassisControl         uint8 = 0x02
-	CmdChassisIdentify        uint8 = 0x04
-	CmdSetSystemBootOptions   uint8 = 0x08
-	CmdGetSystemBootOptions   uint8 = 0x09
+	CmdChassisControl uint8 = 0x02
 )
 
 // RegisterChassisHandlers adds all Chassis command handlers to r.
 func RegisterChassisHandlers(r *Registry) {
-	r.Register(NetFnChassisRequest, CmdGetChassisCapabilities, HandlerFunc(handleGetChassisCapabilities))
-	r.Register(NetFnChassisRequest, CmdGetChassisStatus, HandlerFunc(handleGetChassisStatus))
-	r.Register(NetFnChassisRequest, CmdChassisControl, HandlerFunc(handleChassisControl))
-	r.Register(NetFnChassisRequest, CmdChassisIdentify, HandlerFunc(handleChassisIdentify))
-	r.Register(NetFnChassisRequest, CmdSetSystemBootOptions, HandlerFunc(handleSetSystemBootOptions))
-	r.Register(NetFnChassisRequest, CmdGetSystemBootOptions, HandlerFunc(handleGetSystemBootOptions))
+	r.RegisterFunc(types.CommandGetChassisCapabilities, handleGetChassisCapabilities)
+	r.RegisterFunc(types.CommandGetChassisStatus, handleGetChassisStatus)
+	r.RegisterFunc(types.CommandChassisControl, handleChassisControl)
+	r.RegisterFunc(types.CommandChassisIdentify, handleChassisIdentify)
+	r.RegisterFunc(types.CommandSetSystemBootOptions, handleSetSystemBootOptions)
+	r.RegisterFunc(types.CommandGetSystemBootOptions, handleGetSystemBootOptions)
 }
 
 // handleGetChassisCapabilities returns a minimal static response.

--- a/pkg/handlers/context.go
+++ b/pkg/handlers/context.go
@@ -18,12 +18,19 @@ package handlers
 
 import (
 	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
 )
 
 // HandlerContext carries per-request BMC state to a [Handler].
 // All fields are read-only from the handler's perspective; mutations must go
 // through the store methods (which are goroutine-safe).
 type HandlerContext struct {
+	// Command identifies the request being dispatched.  [Registry.Dispatch]
+	// fills it in from the command table, so middleware and handlers can name
+	// the request without re-deriving it from NetFn/Cmd.  For a command with no
+	// entry in the table, only ID and NetFn are populated and Name is empty.
+	Command types.Command
+
 	// BMC is the top-level BMC state.
 	BMC *bmc.BMC
 

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -43,6 +43,7 @@ func makeKey(netFn, cmd uint8) commandKey {
 // Registry maps (NetFn, Cmd) pairs to [Handler] implementations.
 type Registry struct {
 	handlers   map[commandKey]Handler
+	commands   map[commandKey]types.Command
 	middleware []Middleware
 }
 
@@ -50,24 +51,32 @@ type Registry struct {
 func NewRegistry() *Registry {
 	return &Registry{
 		handlers: make(map[commandKey]Handler),
+		commands: make(map[commandKey]types.Command),
 	}
 }
 
-// Register adds or replaces the handler for (netFn, cmd).
-// netFn should be the *request* NetFn (even value).
+// Register adds or replaces the handler for c, whose NetFn must be the
+// *request* NetFn (even value).  c is remembered so that dispatching the
+// command reports it through [HandlerContext.Command]; pass one of the
+// [types] command-table entries to get its spec name, or a literal such as
+// types.Command{ID: 0x01, NetFn: 0x2e, Name: "Acme Set Fan Curve"} for an OEM
+// command with no table entry.
 //
 // The handler is wrapped with a privilege check (innermost) and then any
 // registered middleware so that middleware can observe privilege rejections
 // (e.g. audit logging). Both wrappings happen at registration time to avoid
 // per-dispatch allocations.
-func (r *Registry) Register(netFn, cmd uint8, h Handler) {
+func (r *Registry) Register(c types.Command, h Handler) {
+	netFn, cmd := uint8(c.NetFn), c.ID
 	checked := &dispatchingHandler{inner: h, netFn: netFn, cmd: cmd}
-	r.handlers[makeKey(netFn, cmd)] = r.applyMiddleware(checked)
+	key := makeKey(netFn, cmd)
+	r.commands[key] = c
+	r.handlers[key] = r.applyMiddleware(checked)
 }
 
 // RegisterFunc is a convenience wrapper around [Register] for plain functions.
-func (r *Registry) RegisterFunc(netFn, cmd uint8, fn func(context.Context, *HandlerContext, []byte) ([]byte, types.CompletionCode, error)) {
-	r.Register(netFn, cmd, HandlerFunc(fn))
+func (r *Registry) RegisterFunc(c types.Command, fn func(context.Context, *HandlerContext, []byte) ([]byte, types.CompletionCode, error)) {
+	r.Register(c, HandlerFunc(fn))
 }
 
 // Use appends middleware.  Middleware is applied in the order it was added,
@@ -84,18 +93,49 @@ func (r *Registry) Merge(other *Registry) {
 	for k, h := range other.handlers {
 		r.handlers[k] = h
 	}
+	for k, c := range other.commands {
+		r.commands[k] = c
+	}
 }
 
-// Dispatch looks up and calls the handler for (netFn, cmd).
+// Dispatch identifies the request on hctx, then looks up and calls its handler.
 // Privilege checking and middleware were applied at registration time
-// ([Register]), so this is a simple lookup with no per-call wrapping.
-// Returns [types.CodeInvalidCommand] when no handler is registered.
+// ([Register]), so the found path is a simple lookup with no per-call wrapping.
+//
+// An unregistered command still runs the middleware chain before returning
+// [types.CodeInvalidCommand]: an initiator probing for commands the BMC does not
+// implement is exactly the kind of event middleware exists to observe, and
+// short-circuiting here would make it invisible.  Having no registration to be
+// wrapped at, that path builds its chain per call and therefore sees the
+// middleware present now rather than the snapshot [Register] would have taken.
+// Both differences are confined to a path that answers with an error.
 func (r *Registry) Dispatch(ctx context.Context, hctx *HandlerContext, netFn, cmd uint8, data []byte) ([]byte, types.CompletionCode, error) {
-	h, ok := r.handlers[makeKey(netFn, cmd)]
+	key := makeKey(netFn, cmd)
+	if hctx != nil {
+		hctx.Command = r.lookup(key, netFn, cmd)
+	}
+
+	h, ok := r.handlers[key]
 	if !ok {
-		return nil, types.CodeInvalidCommand, fmt.Errorf("no handler for netFn=0x%02x cmd=0x%02x", netFn, cmd)
+		return r.applyMiddleware(unsupportedHandler(netFn, cmd)).Handle(ctx, hctx, data)
 	}
 	return h.Handle(ctx, hctx, data)
+}
+
+// lookup returns the command registered under key, falling back to the raw
+// NetFn/Cmd pair so callers always get the numbers even for commands the
+// registry does not know by name.
+func (r *Registry) lookup(key commandKey, netFn, cmd uint8) types.Command {
+	if c, ok := r.commands[key]; ok {
+		return c
+	}
+	return types.Command{ID: cmd, NetFn: types.NetFn(netFn)}
+}
+
+func unsupportedHandler(netFn, cmd uint8) Handler {
+	return HandlerFunc(func(context.Context, *HandlerContext, []byte) ([]byte, types.CompletionCode, error) {
+		return nil, types.CodeInvalidCommand, fmt.Errorf("no handler for netFn=0x%02x cmd=0x%02x", netFn, cmd)
+	})
 }
 
 // applyMiddleware wraps h with all currently registered middleware.

--- a/pkg/handlers/registry_test.go
+++ b/pkg/handlers/registry_test.go
@@ -28,7 +28,7 @@ func TestRegistry_Dispatch(t *testing.T) {
 			netFn: 0x06,
 			cmd:   0x01,
 			setup: func(r *Registry) {
-				r.RegisterFunc(0x06, 0x01, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
+				r.RegisterFunc(types.Command{ID: 0x01, NetFn: 0x06}, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
 					return []byte{0xAB}, types.CodeOK, nil
 				})
 			},
@@ -47,7 +47,7 @@ func TestRegistry_Dispatch(t *testing.T) {
 						return next.Handle(ctx, hctx, data)
 					})
 				})
-				r.RegisterFunc(0x06, 0x02, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
+				r.RegisterFunc(types.Command{ID: 0x02, NetFn: 0x06}, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
 					return nil, types.CodeOK, nil
 				})
 				_ = called
@@ -71,14 +71,118 @@ func TestRegistry_Dispatch(t *testing.T) {
 	}
 }
 
+func TestRegistry_DispatchIdentifiesCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*Registry)
+		netFn    uint8
+		cmd      uint8
+		wantName string
+	}{
+		{
+			name: "registered from the command table carries the spec name",
+			setup: func(r *Registry) {
+				r.RegisterFunc(types.CommandGetChassisStatus, okHandler)
+			},
+			netFn:    uint8(types.NetFnChassisRequest),
+			cmd:      types.CommandGetChassisStatus.ID,
+			wantName: "Get Chassis Status",
+		},
+		{
+			name: "registered from a nameless literal reports NetFn/Cmd only",
+			setup: func(r *Registry) {
+				r.RegisterFunc(types.Command{ID: 0x01, NetFn: 0x06}, okHandler)
+			},
+			netFn: 0x06,
+			cmd:   0x01,
+		},
+		{
+			name:  "unregistered command is still identified",
+			setup: func(*Registry) {},
+			netFn: 0x06,
+			cmd:   0xFF,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRegistry()
+			tc.setup(r)
+
+			hctx := &HandlerContext{}
+			r.Dispatch(context.Background(), hctx, tc.netFn, tc.cmd, nil)
+
+			if hctx.Command.ID != tc.cmd {
+				t.Errorf("command ID: want 0x%02x, got 0x%02x", tc.cmd, hctx.Command.ID)
+			}
+			if uint8(hctx.Command.NetFn) != tc.netFn {
+				t.Errorf("command NetFn: want 0x%02x, got 0x%02x", tc.netFn, uint8(hctx.Command.NetFn))
+			}
+			if hctx.Command.Name != tc.wantName {
+				t.Errorf("command name: want %q, got %q", tc.wantName, hctx.Command.Name)
+			}
+		})
+	}
+}
+
+// TestRegistry_DispatchRunsMiddlewareForUnknownCommand pins the behaviour audit
+// logging depends on: an initiator probing for an unimplemented command must be
+// observable, not silently short-circuited.
+func TestRegistry_DispatchRunsMiddlewareForUnknownCommand(t *testing.T) {
+	r := NewRegistry()
+
+	var seen types.Command
+	called := 0
+	r.Use(func(next Handler) Handler {
+		return HandlerFunc(func(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+			called++
+			seen = hctx.Command
+			return next.Handle(ctx, hctx, data)
+		})
+	})
+
+	_, cc, err := r.Dispatch(context.Background(), &HandlerContext{}, 0x06, 0xFF, nil)
+
+	if called != 1 {
+		t.Errorf("middleware calls: want 1, got %d", called)
+	}
+	if cc != types.CodeInvalidCommand {
+		t.Errorf("cc: want %d, got %d", types.CodeInvalidCommand, cc)
+	}
+	if err == nil {
+		t.Error("want an error describing the missing handler, got nil")
+	}
+	if seen.ID != 0xFF || uint8(seen.NetFn) != 0x06 {
+		t.Errorf("middleware saw netFn=0x%02x cmd=0x%02x, want 0x06/0xff", uint8(seen.NetFn), seen.ID)
+	}
+}
+
+func TestRegistry_MergeCarriesCommandNames(t *testing.T) {
+	a := NewRegistry()
+	b := NewRegistry()
+	b.RegisterFunc(types.CommandGetDeviceID, okHandler)
+
+	a.Merge(b)
+
+	hctx := &HandlerContext{}
+	a.Dispatch(context.Background(), hctx, uint8(types.NetFnAppRequest), types.CommandGetDeviceID.ID, nil)
+	if hctx.Command.Name != "Get Device ID" {
+		t.Errorf("command name after merge: want %q, got %q", "Get Device ID", hctx.Command.Name)
+	}
+}
+
+func okHandler(context.Context, *HandlerContext, []byte) ([]byte, types.CompletionCode, error) {
+	return nil, types.CodeOK, nil
+}
+
 func TestRegistry_Merge(t *testing.T) {
 	a := NewRegistry()
-	a.RegisterFunc(0x06, 0x01, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
+	a.RegisterFunc(types.Command{ID: 0x01, NetFn: 0x06}, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
 		return []byte{0x01}, types.CodeOK, nil
 	})
 
 	b := NewRegistry()
-	b.RegisterFunc(0x06, 0x02, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
+	b.RegisterFunc(types.Command{ID: 0x02, NetFn: 0x06}, func(_ context.Context, _ *HandlerContext, _ []byte) ([]byte, types.CompletionCode, error) {
 		return []byte{0x02}, types.CodeOK, nil
 	})
 

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -16,8 +16,6 @@ const (
 	CmdGetChannelAuthCapabilities uint8 = 0x38
 	CmdGetSessionChallenge        uint8 = 0x39
 	CmdActivateSession            uint8 = 0x3A
-	CmdSetSessionPrivilegeLevel   uint8 = 0x3B
-	CmdCloseSession               uint8 = 0x3C
 
 	lanChannelNumber uint8 = 1
 )
@@ -26,10 +24,10 @@ const (
 // Open Session and RAKP messages are dispatched differently (they arrive before
 // a session exists); see [HandleOpenSession], [HandleRAKP1], [HandleRAKP3].
 func RegisterSessionHandlers(r *Registry) {
-	r.Register(NetFnAppRequest, CmdGetChannelAuthCapabilities, HandlerFunc(handleGetChannelAuthCaps))
-	r.Register(NetFnAppRequest, CmdGetChannelCipherSuites, HandlerFunc(handleGetChannelCipherSuites))
-	r.Register(NetFnAppRequest, CmdSetSessionPrivilegeLevel, HandlerFunc(handleSetSessionPrivilegeLevel))
-	r.Register(NetFnAppRequest, CmdCloseSession, HandlerFunc(handleCloseSession))
+	r.RegisterFunc(types.CommandGetChannelAuthCapabilities, handleGetChannelAuthCaps)
+	r.RegisterFunc(types.CommandGetChannelCipherSuites, handleGetChannelCipherSuites)
+	r.RegisterFunc(types.CommandSetSessionPrivilegeLevel, handleSetSessionPrivilegeLevel)
+	r.RegisterFunc(types.CommandCloseSession, handleCloseSession)
 	registerV15SessionHandlers(r)
 }
 

--- a/pkg/handlers/session_v15.go
+++ b/pkg/handlers/session_v15.go
@@ -21,8 +21,8 @@ const (
 )
 
 func registerV15SessionHandlers(r *Registry) {
-	r.Register(NetFnAppRequest, CmdGetSessionChallenge, HandlerFunc(handleGetSessionChallenge))
-	r.Register(NetFnAppRequest, CmdActivateSession, HandlerFunc(handleActivateSession))
+	r.RegisterFunc(types.CommandGetSessionChallenge, handleGetSessionChallenge)
+	r.RegisterFunc(types.CommandActivateSession, handleActivateSession)
 }
 
 func handleGetSessionChallenge(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {

--- a/pkg/handlers/session_v15_policy_test.go
+++ b/pkg/handlers/session_v15_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
 )
 
 func TestV15AllowsAuthTypeNonePerMessageDisabled(t *testing.T) {
@@ -19,7 +20,7 @@ func TestV15AllowsAuthTypeNonePerMessageEnabled(t *testing.T) {
 	ch := &bmc.Channel{Number: 1, PerMessageAuth: true, UserLevelAuth: true}
 	sess := &bmc.V15Session{State: bmc.V15SessionStateActive, PrivilegeLevel: bmc.PrivilegeLevelAdministrator}
 
-	if V15AllowsAuthTypeNone(ch, NetFnChassisRequest, CmdGetChassisStatus, sess) {
+	if V15AllowsAuthTypeNone(ch, NetFnChassisRequest, types.CommandGetChassisStatus.ID, sess) {
 		t.Fatal("expected auth required when per-message auth enabled")
 	}
 }
@@ -28,7 +29,7 @@ func TestV15AllowsAuthTypeNoneUserLevelDisabled(t *testing.T) {
 	ch := &bmc.Channel{Number: 1, PerMessageAuth: true, UserLevelAuth: false}
 	sess := &bmc.V15Session{State: bmc.V15SessionStateActive, PrivilegeLevel: bmc.PrivilegeLevelUser}
 
-	if !V15AllowsAuthTypeNone(ch, NetFnAppRequest, CmdGetDeviceID, sess) {
+	if !V15AllowsAuthTypeNone(ch, NetFnAppRequest, types.CommandGetDeviceID.ID, sess) {
 		t.Fatal("expected user-level get device id without auth when user-level auth disabled")
 	}
 	if V15AllowsAuthTypeNone(ch, NetFnChassisRequest, CmdChassisControl, sess) {

--- a/pkg/handlers/storage.go
+++ b/pkg/handlers/storage.go
@@ -1,14 +1,6 @@
 package handlers
 
-// Storage command IDs (spec v2.0§33–§34).
-const (
-	CmdGetFRUInventoryAreaInfo uint8 = 0x10
-	CmdReadFRUData             uint8 = 0x11
-	CmdGetSDRRepoInfo          uint8 = 0x20
-	CmdGetSDRRepoAllocInfo     uint8 = 0x21
-	CmdReserveSDRRepo          uint8 = 0x22
-	CmdGetSDR                  uint8 = 0x23
-)
+import "github.com/bougou/go-ipmi/pkg/types"
 
 const (
 	maxSDRReadBytes = 16
@@ -16,10 +8,10 @@ const (
 
 // RegisterStorageHandlers adds P0 read-only Storage NetFn handlers to r.
 func RegisterStorageHandlers(r *Registry) {
-	r.Register(NetFnStorageRequest, CmdGetFRUInventoryAreaInfo, HandlerFunc(handleGetFRUInventoryAreaInfo))
-	r.Register(NetFnStorageRequest, CmdReadFRUData, HandlerFunc(handleReadFRUData))
-	r.Register(NetFnStorageRequest, CmdGetSDRRepoInfo, HandlerFunc(handleGetSDRRepoInfo))
-	r.Register(NetFnStorageRequest, CmdGetSDRRepoAllocInfo, HandlerFunc(handleGetSDRRepoAllocInfo))
-	r.Register(NetFnStorageRequest, CmdReserveSDRRepo, HandlerFunc(handleReserveSDRRepo))
-	r.Register(NetFnStorageRequest, CmdGetSDR, HandlerFunc(handleGetSDR))
+	r.RegisterFunc(types.CommandGetFRUInventoryAreaInfo, handleGetFRUInventoryAreaInfo)
+	r.RegisterFunc(types.CommandReadFRUData, handleReadFRUData)
+	r.RegisterFunc(types.CommandGetSDRRepoInfo, handleGetSDRRepoInfo)
+	r.RegisterFunc(types.CommandGetSDRRepoAllocInfo, handleGetSDRRepoAllocInfo)
+	r.RegisterFunc(types.CommandReserveSDRRepo, handleReserveSDRRepo)
+	r.RegisterFunc(types.CommandGetSDR, handleGetSDR)
 }

--- a/pkg/handlers/wire_constants_test.go
+++ b/pkg/handlers/wire_constants_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestWireConstantsMatchCommandTable pins the raw NetFn/command bytes this
+// package compares against to the [types] command table.
+//
+// The two cannot be collapsed: types.Command entries are struct values, so no
+// untyped constant can be derived from them, and the policy switches below want
+// constants for the duplicate-case check the compiler gives them. Asserting the
+// values here turns a silent drift into a failing test instead.
+func TestWireConstantsMatchCommandTable(t *testing.T) {
+	netFns := map[string]struct {
+		got  uint8
+		want types.NetFn
+	}{
+		"NetFnAppRequest":     {NetFnAppRequest, types.NetFnAppRequest},
+		"NetFnChassisRequest": {NetFnChassisRequest, types.NetFnChassisRequest},
+	}
+	for name, tc := range netFns {
+		if tc.got != uint8(tc.want) {
+			t.Errorf("%s = 0x%02x, command table says 0x%02x", name, tc.got, uint8(tc.want))
+		}
+	}
+
+	commands := map[string]struct {
+		got  uint8
+		want types.Command
+	}{
+		"CmdColdReset":                  {CmdColdReset, types.CommandColdReset},
+		"CmdWarmReset":                  {CmdWarmReset, types.CommandWarmReset},
+		"CmdGetChannelCipherSuites":     {CmdGetChannelCipherSuites, types.CommandGetChannelCipherSuites},
+		"CmdChassisControl":             {CmdChassisControl, types.CommandChassisControl},
+		"CmdGetChannelAuthCapabilities": {CmdGetChannelAuthCapabilities, types.CommandGetChannelAuthCapabilities},
+		"CmdGetSessionChallenge":        {CmdGetSessionChallenge, types.CommandGetSessionChallenge},
+		"CmdActivateSession":            {CmdActivateSession, types.CommandActivateSession},
+	}
+	for name, tc := range commands {
+		if tc.got != tc.want.ID {
+			t.Errorf("%s = 0x%02x, %q in the command table is 0x%02x", name, tc.got, tc.want.Name, tc.want.ID)
+		}
+	}
+}


### PR DESCRIPTION
Middleware could see a request's payload and its completion code but not which command it was: Dispatch held the NetFn/Cmd pair and dropped it on the way in. Anything wanting to name a request for audit logging or metrics had to smuggle the name up from the handler, which put the knowledge in the layer least able to act on it and left commands with no handler nameless.

Resolve the command during dispatch and publish it on HandlerContext. Lookups come from the registry, so a command registered from the types command table reports its spec name, while one that is not registered at all still reports its NetFn and Cmd. Unregistered commands now also run the middleware chain before returning CodeInvalidCommand: an initiator probing for commands the BMC does not implement is exactly the kind of event middleware exists to observe, and short-circuiting made it invisible.

Registration takes the command it serves, rather than the two bytes that identify it, so this identity cannot be lost by construction. That subsumes the numeric Register, whose only remaining callers were its own wrappers. OEM commands, absent from Appendix G, pass a types.Command literal and get a name of their choosing instead of none at all.

Doing so strands the command ID constants that existed only to supply those bytes -- 19 of 26, among them CmdGetChannelAuthCaps, a second name for the 0x38 that session.go already declared as CmdGetChannelAuthCapabilities. They are removed. The seven that survive serve a different purpose: bytes compared before dispatch has resolved them, in the privilege rules, the v1.5 authentication policy and the session state machine. Those keep their constants rather than reaching for types.CommandX.ID, because the table entries are struct values and cannot yield an untyped constant, which would cost the switches their duplicate-case check. Test inputs have no such need and use the table directly. A test asserts the two agree so the overlap that remains cannot drift unnoticed.

goipmi-server gains the worked example, an audit-log middleware behind GOIPMI_SERVER_TRACE that names each command from the context. It also demonstrates the ordering Use requires -- before Register, hence a registry built by hand rather than the default one -- and the unregistered path: driving the server with ipmitool shows it probing 0x2c/0x3e for DCMI, traffic a chain that skipped that path would never see. Off by default, since E2E runs this binary with stderr attached to the terminal.

BREAKING CHANGE: Register and RegisterFunc take a types.Command in place of (netFn, cmd uint8), and the command ID constants that no longer have a caller are removed -- use the corresponding types.Command entry.