### PR TITLE
feat(types): name command-specific completion codes per command

### DIFF
--- a/pkg/types/types_completion_code.go
+++ b/pkg/types/types_completion_code.go
@@ -104,15 +104,224 @@ func (cc CompletionCode) String() string {
 // codes live in CC; this table holds only the per-command additions, keyed by
 // Command so that code holding just the dispatched command (server-side
 // dispatch/middleware, without a decoded Response) can still name a code.
-var commandSpecificCC = map[Command]map[uint8]string{
-	// v2.0§28.12 Table 28-12 / §28.13 Table 28-13.
-	CommandSetSystemBootOptions: {
+// Names follow the spec's wording with the first letter capitalized, matching
+// the style of CC.
+
+// Shared command-specific sets. The parameter-configuration commands repeat
+// the same 80h-83h pattern across their spec sections; the Set commands split
+// into those without write-only parameters (System Info §22.16a, Boot Options
+// §28.12) and those with them (LAN §23.2, Serial/Modem §25.2, SOL §26.3, PEF
+// §30.4); every Get counterpart (§22.16b, §23.3, §25.3, §26.4, §28.13, §30.5)
+// defines 80h only.
+var (
+	paramConfigSetCC = map[uint8]string{
 		0x80: "Parameter not supported",
-		0x81: "Attempt to set 'set in progress' when not in 'set complete' state",
+		0x81: "Attempt to set 'set in progress' value (in parameter #0) when not in 'set complete' state",
 		0x82: "Attempt to write read-only parameter",
-	},
-	CommandGetSystemBootOptions: {
+	}
+	paramConfigSetRWCC = map[uint8]string{
 		0x80: "Parameter not supported",
+		0x81: "Attempt to set 'set in progress' value (in parameter #0) when not in 'set complete' state",
+		0x82: "Attempt to write read-only parameter",
+		0x83: "Attempt to read write-only parameter",
+	}
+	paramConfigGetCC = map[uint8]string{
+		0x80: "Parameter not supported",
+	}
+	// selEraseCC is returned by the SEL Device commands that cannot run while
+	// a Clear SEL is in progress (Tables 31-2, 31-4, 31-5, 31-7) and by
+	// Set/Get Last Processed Event ID (Tables 30-7, 30-8).
+	selEraseCC = map[uint8]string{
+		0x81: "Cannot execute command, SEL erase in progress",
+	}
+	// fruBusyCC is returned by Read/Write FRU Data (Tables 34-3, 34-4) when the
+	// logical FRU device is temporarily unavailable; software may retry.
+	fruBusyCC = map[uint8]string{
+		0x81: "FRU device busy",
+	}
+	// queueEmptyCC is returned by Get Message (Table 22-7) and Read Event
+	// Message Buffer (Table 22-11) when no message is waiting.
+	queueEmptyCC = map[uint8]string{
+		0x80: "Data not available (queue / buffer empty)",
+	}
+)
+
+var commandSpecificCC = map[Command]map[uint8]string{
+	// §21 BMC Device and LUN commands.
+	CommandSetCommandEnables: {
+		0x80: "Attempt to enable an unsupported or un-configurable command",
+	},
+	CommandSetCommandSubfunctionEnables: {
+		// Spec Table 21-9, "Set Configurable Command Sub-function Enables".
+		0x80: "Attempt to enable an unsupported or un-configurable sub-function",
+	},
+	CommandGetConfigurableCommandSubfunctions: {
+		// Table 21-10 lists the Set wording verbatim; a Get can only hit this
+		// for an unsupported or un-configurable command number.
+		0x80: "Attempt to enable an unsupported or un-configurable sub-function",
+	},
+
+	// §22 messaging and session commands.
+	CommandGetMessage:             queueEmptyCC,
+	CommandReadEventMessageBuffer: queueEmptyCC,
+	CommandSendMessage: {
+		0x80: "Invalid Session Handle",
+		0x81: "Lost Arbitration",
+		0x82: "Bus Error",
+		0x83: "NAK on Write",
+	},
+	CommandMasterWriteRead: {
+		0x81: "Lost Arbitration",
+		0x82: "Bus Error",
+		0x83: "NAK on Write",
+		0x84: "Truncated Read",
+	},
+	CommandSetSystemInfoParam: paramConfigSetCC,
+	CommandGetSystemInfoParam: paramConfigGetCC,
+	CommandGetSessionChallenge: {
+		0x81: "Invalid user name",
+		0x82: "Null user name (User 1) not enabled",
+	},
+	CommandActivateSession: {
+		0x81: "No session slot available (BMC cannot accept any more sessions)",
+		0x82: "No slot available for given user",
+		0x83: "No slot available to support user due to maximum privilege capability",
+		0x84: "Session sequence number out-of-range",
+		0x85: "Invalid Session ID in request",
+		0x86: "Requested maximum privilege level exceeds user and/or channel privilege limit",
+	},
+	CommandSetSessionPrivilegeLevel: {
+		0x80: "Requested level not available for this user",
+		0x81: "Requested level exceeds Channel and/or User Privilege Limit",
+		0x82: "Cannot disable User Level authentication",
+	},
+	CommandCloseSession: {
+		0x87: "Invalid Session ID in request",
+		0x88: "Invalid Session Handle in request",
+	},
+	CommandSetChannelAccess: {
+		0x82: "Set not supported on selected channel",
+		0x83: "Access mode not supported",
+	},
+	CommandGetChannelAccess: {
+		0x82: "Command not supported for selected channel",
+	},
+	CommandSetChannelSecurityKeys: {
+		0x80: "Cannot perform set / confirm. Key is locked",
+		0x81: "Insufficient key bytes",
+		0x82: "Too many key bytes",
+		0x83: "Key value does not meet criteria for specified type of key",
+		0x84: "KR is not used",
+	},
+	CommandSetUserPassword: {
+		0x80: "Password test failed. Password size correct, but password data does not match stored value",
+		0x81: "Password test failed. Wrong password size was used",
+	},
+
+	// §23 LAN commands.
+	CommandSetLanConfigParam: paramConfigSetRWCC,
+	CommandGetLanConfigParam: paramConfigGetCC,
+
+	// §24 payload commands.
+	CommandActivatePayload: {
+		0x80: "Payload already active on another session",
+		0x81: "Payload type is disabled",
+		0x82: "Payload activation limit reached",
+		0x83: "Cannot activate payload with encryption",
+		0x84: "Cannot activate payload without encryption",
+	},
+	CommandDeactivatePayload: {
+		0x80: "Payload already deactivated",
+		0x81: "Payload type is disabled",
+	},
+	CommandSuspendResumePayloadEncryption: {
+		0x80: "Operation not supported for given payload type",
+		0x81: "Operation not allowed under present configuration for given payload type",
+		0x82: "Encryption is not available for session that payload type is active under",
+		0x83: "The payload instance is not presently active",
+	},
+	CommandGetChannelPayloadVersion: {
+		0x80: "Payload type not available on given channel",
+	},
+	CommandGetChannelOEMPayloadInfo: {
+		0x80: "OEM Payload IANA and/or Payload ID not supported",
+	},
+
+	// §25 serial/modem and PPP commands.
+	CommandSetSerialConfig: paramConfigSetRWCC,
+	CommandGetSerialConfig: paramConfigGetCC,
+	CommandSendPPPPacket: {
+		0x80: "PPP Link is not up",
+		0x81: "IP Protocol is not up",
+	},
+	CommandGetPPPReceiveData: {
+		0x80: "No packet data available",
+	},
+	CommandCallback: {
+		0x81: "Callback rejected due to alert in progress on this channel",
+		0x82: "Callback rejected due to IPMI messaging session active on the callback channel",
+	},
+
+	// §26 SOL commands.
+	CommandSetSOLConfigParam: paramConfigSetRWCC,
+	CommandGetSOLConfigParam: paramConfigGetCC,
+
+	// §27 watchdog commands.
+	CommandResetWatchdogTimer: {
+		0x80: "Attempt to start un-initialized watchdog",
+	},
+
+	// §28 chassis commands.
+	CommandSetSystemBootOptions: paramConfigSetCC,
+	CommandGetSystemBootOptions: paramConfigGetCC,
+
+	// §30 PEF and alerting commands.
+	CommandSetPEFConfigParam:       paramConfigSetRWCC,
+	CommandGetPEFConfigParam:       paramConfigGetCC,
+	CommandSetLastProcessedEventId: selEraseCC,
+	CommandGetLastProcessedEventId: selEraseCC,
+	CommandAlertImmediate: {
+		0x81: "Alert Immediate rejected due to alert already in progress",
+		0x82: "Alert Immediate rejected due to IPMI messaging session active on this channel",
+		0x83: "Platform Event Parameters (4:11) not supported",
+	},
+
+	// §31 SEL Device commands. Add/Delete additionally reject Record Types
+	// they cannot store/remove with 80h (Tables 31-6, 31-8).
+	CommandGetSELInfo:         selEraseCC,
+	CommandReserveSEL:         selEraseCC,
+	CommandGetSELEntry:        selEraseCC,
+	CommandPartialAddSELEntry: selEraseCC,
+	CommandAddSELEntry: {
+		0x80: "Operation not supported for this Record Type",
+		0x81: "Cannot execute command, SEL erase in progress",
+	},
+	CommandDeleteSELEntry: {
+		0x80: "Operation not supported for this Record Type",
+		0x81: "Cannot execute command, SEL erase in progress",
+	},
+
+	// §33 SDR Repository commands.
+	CommandPartialAddSDR: {
+		0x80: "Record rejected due to mismatch between record length in header data and number of bytes written",
+	},
+
+	// §34 FRU commands.
+	CommandReadFRUData:  fruBusyCC,
+	CommandWriteFRUData: fruBusyCC,
+
+	// §35 sensor commands.
+	CommandGetDeviceSDR: {
+		0x80: "Record changed",
+	},
+	CommandSetSensorReadingAndEventStatus: {
+		0x80: "Attempt to change reading or set or clear status bits that are not settable via this command",
+		0x81: "Attempted to set Event Data Bytes, but setting Event Data Bytes is not supported for this sensor",
+	},
+
+	// §35b ICMB bridging commands.
+	CommandForwarded: {
+		0x80: "Target controller unavailable",
 	},
 }
 

--- a/pkg/types/types_completion_code.go
+++ b/pkg/types/types_completion_code.go
@@ -99,6 +99,34 @@ func (cc CompletionCode) String() string {
 	return fmt.Sprintf("0x%02x", uint8(cc))
 }
 
+// commandSpecificCC records the command-specific completion codes (80h-BEh,
+// v2.0§5.2 Table 5-2) defined in each command's own spec section. Generic
+// codes live in CC; this table holds only the per-command additions, keyed by
+// Command so that code holding just the dispatched command (server-side
+// dispatch/middleware, without a decoded Response) can still name a code.
+var commandSpecificCC = map[Command]map[uint8]string{
+	// v2.0§28.12 Table 28-12 / §28.13 Table 28-13.
+	CommandSetSystemBootOptions: {
+		0x80: "Parameter not supported",
+		0x81: "Attempt to set 'set in progress' when not in 'set complete' state",
+		0x82: "Attempt to write read-only parameter",
+	},
+	CommandGetSystemBootOptions: {
+		0x80: "Parameter not supported",
+	},
+}
+
+// StrCCForCommand returns the description of ccode for the specified command:
+// the command-specific name when the command defines one for ccode, otherwise
+// the generic name, otherwise the hex string. Unlike StrCC it needs no decoded
+// Response, so it works wherever only the Command is available.
+func StrCCForCommand(cmd Command, ccode uint8) string {
+	if s, ok := commandSpecificCC[cmd][ccode]; ok {
+		return s
+	}
+	return CompletionCode(ccode).String()
+}
+
 // Error makes CompletionCode implement the error interface.
 func (cc CompletionCode) Error() string {
 	return fmt.Sprintf("IPMI completion code %s", cc.String())

--- a/pkg/types/types_completion_code.go
+++ b/pkg/types/types_completion_code.go
@@ -323,6 +323,25 @@ var commandSpecificCC = map[Command]map[uint8]string{
 	CommandForwarded: {
 		0x80: "Target controller unavailable",
 	},
+
+	// DCMI commands (dcmi-spec-v1.5 §6). DCMI §8 Table 8-1 only mirrors the
+	// IPMI generic codes; the command-specific ones are called out in the
+	// command tables themselves. Set/Get DCMI Configuration Parameters follow
+	// the parameter-configuration pattern (Tables 6-4/6-5).
+	CommandGetDCMIPowerLimit: {
+		0x80: "No Active Set Power Limit",
+	},
+	CommandSetDCMIPowerLimit: {
+		0x84: "Power Limit out of range",
+		0x85: "Correction Time out of range",
+		0x89: "Statistics Reporting Period out of range",
+	},
+	CommandSetDCMIThermalLimit: {
+		0x84: "Thermal Limit out of range",
+		0x85: "Exception Time out of range",
+	},
+	CommandSetDCMIConfigParam: paramConfigSetCC,
+	CommandGetDCMIConfigParam: paramConfigGetCC,
 }
 
 // StrCCForCommand returns the description of ccode for the specified command:

--- a/pkg/types/types_completion_code_test.go
+++ b/pkg/types/types_completion_code_test.go
@@ -1,0 +1,51 @@
+package types
+
+import "testing"
+
+func TestStrCCForCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		cmd   Command
+		ccode uint8
+		want  string
+	}{
+		{
+			name:  "command-specific code named per command",
+			cmd:   CommandSetSystemBootOptions,
+			ccode: 0x80,
+			want:  "Parameter not supported",
+		},
+		{
+			name:  "command-specific code named for get variant",
+			cmd:   CommandGetSystemBootOptions,
+			ccode: 0x80,
+			want:  "Parameter not supported",
+		},
+		{
+			name:  "generic code named regardless of command",
+			cmd:   CommandSetSystemBootOptions,
+			ccode: 0xc0,
+			want:  "Node busy",
+		},
+		{
+			name:  "command-specific code on another command falls back to hex",
+			cmd:   CommandChassisControl,
+			ccode: 0x80,
+			want:  "0x80",
+		},
+		{
+			name:  "zero command falls back to hex for command-specific range",
+			cmd:   Command{},
+			ccode: 0x81,
+			want:  "0x81",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StrCCForCommand(tt.cmd, tt.ccode); got != tt.want {
+				t.Errorf("StrCCForCommand(%q, 0x%02x) = %q, want %q", tt.cmd.Name, tt.ccode, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/types/types_completion_code_test.go
+++ b/pkg/types/types_completion_code_test.go
@@ -34,6 +34,30 @@ func TestStrCCForCommand(t *testing.T) {
 			want:  "0x80",
 		},
 		{
+			name:  "shared parameter-config set applies to sibling commands",
+			cmd:   CommandSetPEFConfigParam,
+			ccode: 0x83,
+			want:  "Attempt to read write-only parameter",
+		},
+		{
+			name:  "set-in-progress conflict on boot options",
+			cmd:   CommandSetSystemBootOptions,
+			ccode: 0x81,
+			want:  "Attempt to set 'set in progress' value (in parameter #0) when not in 'set complete' state",
+		},
+		{
+			name:  "SEL erase in progress",
+			cmd:   CommandGetSELInfo,
+			ccode: 0x81,
+			want:  "Cannot execute command, SEL erase in progress",
+		},
+		{
+			name:  "codes above 84h are reachable",
+			cmd:   CommandCloseSession,
+			ccode: 0x88,
+			want:  "Invalid Session Handle in request",
+		},
+		{
 			name:  "zero command falls back to hex for command-specific range",
 			cmd:   Command{},
 			ccode: 0x81,

--- a/pkg/types/types_completion_code_test.go
+++ b/pkg/types/types_completion_code_test.go
@@ -58,6 +58,12 @@ func TestStrCCForCommand(t *testing.T) {
 			want:  "Invalid Session Handle in request",
 		},
 		{
+			name:  "DCMI set power limit out of range",
+			cmd:   CommandSetDCMIPowerLimit,
+			ccode: 0x84,
+			want:  "Power Limit out of range",
+		},
+		{
 			name:  "zero command falls back to hex for command-specific range",
 			cmd:   Command{},
 			ccode: 0x81,


### PR DESCRIPTION
  CompletionCode.String() only covers the generic range (00h, C0h–FFh) and degrades command-specific codes (80h–BEh) to a hex string. The existing StrCC cannot fill this gap:

  - it requires a decoded Response — a client-side artifact that server-side dispatch/middleware never constructs (the BMC assembles response bytes; the only command identity it holds is types.Command);
  - and the data isn't there anyway: the library's only CompletionCodes() implementation (SOLPayloadResponse) returns an empty map, so StrCC resolves generic codes only, for every command.

  This PR adds a command-keyed table plus a lookup helper:

  func StrCCForCommand(cmd Command, ccode uint8) string

  Resolution order: command-specific name → generic name → hex (the same fallback String() already established). It works wherever only the dispatched Command is available.