### PR TITLE
feat(client): expose typed RMCP+ session errors

### DIFF
--- a/exports_client.go
+++ b/exports_client.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	ErrDCMIGroupExtensionIDMismatch = types.ErrDCMIGroupExtensionIDMismatch
+	ErrRAKPAuthentication           = client.ErrRAKPAuthentication
 	ErrUnpackedDataTooShort         = types.ErrUnpackedDataTooShort
 )
 

--- a/exports_types.go
+++ b/exports_types.go
@@ -1170,6 +1170,7 @@ type (
 	Rmcp                                                 = types.Rmcp
 	RmcpAckMessage                                       = types.RmcpAckMessage
 	RmcpHeader                                           = types.RmcpHeader
+	RmcpStatusError                                      = types.RmcpStatusError
 	RmcpStatusCode                                       = types.RmcpStatusCode
 	SDR                                                  = types.SDR
 	SDRBMCChannelInfo                                    = types.SDRBMCChannelInfo
@@ -1304,6 +1305,7 @@ var (
 	NewResponseError           = types.NewResponseError
 	NewRmcpHeader              = types.NewRmcpHeader
 	NewRmcpHeaderASF           = types.NewRmcpHeaderASF
+	NewRmcpStatusError         = types.NewRmcpStatusError
 	OneSComplement             = types.OneSComplement
 	OneSComplementEncode       = types.OneSComplementEncode
 	PackBytes                  = types.PackBytes

--- a/pkg/client/cmd_open_session.go
+++ b/pkg/client/cmd_open_session.go
@@ -49,8 +49,7 @@ func (c *Client) OpenSession(ctx context.Context) (response *rmcpplus.OpenSessio
 	c.Debug("OPEN SESSION RESPONSE", response.Format())
 
 	if response.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
-		err = fmt.Errorf("rakp status code error: (%#02x) %s", uint8(response.RmcpStatusCode), response.RmcpStatusCode)
-		return
+		return response, types.NewRmcpStatusError(response.RmcpStatusCode)
 	}
 
 	c.session.v20.state = types.SessionStateOpenSessionReceived

--- a/pkg/client/cmd_rakp_message_1_2.go
+++ b/pkg/client/cmd_rakp_message_1_2.go
@@ -11,6 +11,10 @@ import (
 
 // ValidateRAKP2 validates RAKP Message 2 returned by BMC.
 func (c *Client) ValidateRAKP2(ctx context.Context, rakp2 *rmcpplus.RAKPMessage2) (bool, error) {
+	if rakp2.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		return false, types.NewRmcpStatusError(rakp2.RmcpStatusCode)
+	}
+
 	if c.session.v20.consoleSessionID != rakp2.RemoteConsoleSessionID {
 		return false, fmt.Errorf("session id not matched, cached console session id: %x, rakp2 returned session id: %x", c.session.v20.consoleSessionID, rakp2.RemoteConsoleSessionID)
 	}
@@ -23,7 +27,7 @@ func (c *Client) ValidateRAKP2(ctx context.Context, rakp2 *rmcpplus.RAKPMessage2
 	c.DebugBytes("rakp2 returned auth code", rakp2.KeyExchangeAuthenticationCode, 16)
 
 	if !isByteSliceEqual(authcode, rakp2.KeyExchangeAuthenticationCode) {
-		return false, fmt.Errorf("rakp2 authcode not equal, console: %x, bmc: %x", authcode, rakp2.KeyExchangeAuthenticationCode)
+		return false, fmt.Errorf("RAKP2 authentication code mismatch: %w", ErrRAKPAuthentication)
 	}
 	return true, nil
 }

--- a/pkg/client/cmd_rakp_message_3_4.go
+++ b/pkg/client/cmd_rakp_message_3_4.go
@@ -64,7 +64,7 @@ func (c *Client) RAKPMessage3(ctx context.Context) (response *rmcpplus.RAKPMessa
 
 func (c *Client) ValidateRAKP4(ctx context.Context, response *rmcpplus.RAKPMessage4) (bool, error) {
 	if response.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
-		return false, fmt.Errorf("rakp4 status code not ok, %x", response.RmcpStatusCode)
+		return false, types.NewRmcpStatusError(response.RmcpStatusCode)
 	}
 	if c.session.v20.consoleSessionID != response.MgmtConsoleSessionID {
 		return false, fmt.Errorf("session not activated")
@@ -79,7 +79,7 @@ func (c *Client) ValidateRAKP4(ctx context.Context, response *rmcpplus.RAKPMessa
 	c.DebugBytes("rakp4 bmc returned authcode", response.IntegrityCheckValue, 16)
 
 	if !isByteSliceEqual(response.IntegrityCheckValue, authCode) {
-		return false, fmt.Errorf("rakp4 returned integrity check not passed, console mac %0x, bmc mac: %0x", authCode, response.IntegrityCheckValue)
+		return false, fmt.Errorf("RAKP4 integrity check value does not match: %w", ErrRAKPAuthentication)
 	}
 	return true, nil
 }

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,6 @@
+package client
+
+import "errors"
+
+// ErrRAKPAuthentication reports that a RAKP authentication code or integrity check did not match.
+var ErrRAKPAuthentication = errors.New("RAKP authentication failed")

--- a/pkg/rmcpplus/rakp_message_1_2.go
+++ b/pkg/rmcpplus/rakp_message_1_2.go
@@ -103,7 +103,9 @@ func (res *RAKPMessage2) Unpack(msg []byte) error {
 	res.RemoteConsoleSessionID, _, _ = types.UnpackUint32L(msg, 4)
 
 	if res.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
-		return fmt.Errorf("the return status of rakp2 has error: %v", res.RmcpStatusCode)
+		// A non-zero status is a valid short RAKP2 response. Preserve the decoded status so
+		// Client.ValidateRAKP2 can return it as a typed RmcpStatusError.
+		return nil
 	}
 
 	if len(msg) < 40 {

--- a/pkg/rmcpplus/rakp_message_3_4.go
+++ b/pkg/rmcpplus/rakp_message_3_4.go
@@ -60,15 +60,26 @@ func (req *RAKPMessage3) Unpack(msg []byte, authAlg types.AuthAlg) error {
 }
 
 func (res *RAKPMessage4) Unpack(msg []byte) error {
-	authCodeLen := crypto.RAKP4ICVLen(res.AuthAlg)
-	if len(msg) < 8+authCodeLen {
-		return types.ErrUnpackedDataTooShortWith(len(msg), 8+authCodeLen)
+	// Error responses contain only the eight-byte fixed portion. Validate and decode it first.
+	// Only successful responses are required to include an integrity check value.
+	if len(msg) < 8 {
+		return types.ErrUnpackedDataTooShortWith(len(msg), 8)
 	}
 
 	res.MessageTag, _, _ = types.UnpackUint8(msg, 0)
 	b1, _, _ := types.UnpackUint8(msg, 1)
 	res.RmcpStatusCode = types.RmcpStatusCode(b1)
 	res.MgmtConsoleSessionID, _, _ = types.UnpackUint32L(msg, 4)
+	if res.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		// A non-zero status is a valid short RAKP4 response. Preserve the decoded status so
+		// Client.ValidateRAKP4 can return it as a typed RmcpStatusError.
+		return nil
+	}
+
+	authCodeLen := crypto.RAKP4ICVLen(res.AuthAlg)
+	if len(msg) < 8+authCodeLen {
+		return types.ErrUnpackedDataTooShortWith(len(msg), 8+authCodeLen)
+	}
 	res.IntegrityCheckValue, _, _ = types.UnpackBytes(msg, 8, authCodeLen)
 	return nil
 }

--- a/pkg/types/errors.go
+++ b/pkg/types/errors.go
@@ -10,6 +10,25 @@ var (
 	ErrDCMIGroupExtensionIDMismatch = errors.New("DCMI group extension ID mismatch")
 )
 
+// RmcpStatusError reports a non-zero RMCP+ Open Session or RAKP status code.
+type RmcpStatusError struct {
+	statusCode RmcpStatusCode
+}
+
+func (e *RmcpStatusError) Error() string {
+	return fmt.Sprintf("RMCP+ status %#02x: %s", uint8(e.statusCode), e.statusCode)
+}
+
+// StatusCode returns the RMCP+ status code reported by the BMC.
+func (e *RmcpStatusError) StatusCode() RmcpStatusCode {
+	return e.statusCode
+}
+
+// NewRmcpStatusError creates an error for a non-zero RMCP+ status code.
+func NewRmcpStatusError(statusCode RmcpStatusCode) *RmcpStatusError {
+	return &RmcpStatusError{statusCode: statusCode}
+}
+
 func ErrUnpackedDataTooShortWith(actual int, expected int) error {
 	return fmt.Errorf("%w (%d/%d)", ErrUnpackedDataTooShort, actual, expected)
 }


### PR DESCRIPTION
Expose RMCP+/RAKP status codes and authentication failures through typed errors so callers can use errors.As and errors.Is instead of matching rendered error strings. Preserve valid short error responses and keep authentication-code values out of normal errors.