### PR TITLE
fix(client): detach keepalive from connect context

### DIFF
--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -319,9 +319,8 @@ func (c *Client) Connect15(ctx context.Context) error {
 		return fmt.Errorf("SetSessionPrivilegeLevel to (%s) failed, err: %w", c.maxPrivilegeLevel, err)
 	}
 
-	go func() {
-		c.keepSessionAlive(ctx, DefaultKeepAliveIntervalSec)
-	}()
+	// The Connect context bounds setup. Client.Close owns the established session lifetime.
+	go c.keepSessionAlive(context.WithoutCancel(ctx), DefaultKeepAliveIntervalSec)
 
 	return nil
 
@@ -407,9 +406,8 @@ func (c *Client) Connect20(ctx context.Context) error {
 		return fmt.Errorf("SetSessionPrivilegeLevel to (%s) failed, err: %w", c.maxPrivilegeLevel, err)
 	}
 
-	go func() {
-		c.keepSessionAlive(ctx, DefaultKeepAliveIntervalSec)
-	}()
+	// The Connect context bounds setup. Client.Close owns the established session lifetime.
+	go c.keepSessionAlive(context.WithoutCancel(ctx), DefaultKeepAliveIntervalSec)
 
 	return nil
 }


### PR DESCRIPTION
`Client.Connect` retained its setup context for the keepalive goroutine, causing keepalive requests to fail after that context was cancelled or expired. Detach the keepalive context for both LAN and LANplus so the connection context only bounds session setup, while `Client.Close` owns the established session lifetime.