### PR TITLE
feat(server): implement Serial over LAN (SOL) with payload management, console reconnect, and client data-plane fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ dependencies:
 #   make test-e2e-self           — goipmi → goipmi-server
 #   make test-e2e-chassis-codec  — typed chassis codec / boot options
 #   make test-e2e-cipher         — RMCP+ cipher suite coverage
+#   make test-e2e-sol            — ipmitool sol activate → PTY console
 #   make test-e2e                — run all suites (CI uses this)
 
 test-e2e-client: build
@@ -79,4 +80,7 @@ test-e2e-chassis-codec: build
 test-e2e-cipher: build
 	./test/e2e/cipher_suite_test.sh
 
-test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec test-e2e-cipher
+test-e2e-sol: build
+	./test/e2e/sol_test.sh
+
+test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec test-e2e-cipher test-e2e-sol

--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -37,6 +37,12 @@ func loadRuntimeConfig() (runtimeConfig, error) {
 		Password: envOr("GOIPMI_SERVER_PASS", "ADMIN"),
 		Console:  envOr("GOIPMI_SERVER_CONSOLE", ""),
 	}
+	// "none" is the documented spelling of "no console" (see Console); the
+	// HAL layer only understands the empty string, and a raw "none" would
+	// otherwise be opened as a device path and fail startup.
+	if cfg.Console == "none" {
+		cfg.Console = ""
+	}
 
 	if v := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_SOL_RECONNECT")); v != "" {
 		enabled, err := parseBoolEnv(v)

--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -24,6 +24,10 @@ type runtimeConfig struct {
 	// Console selects the SOL console backend: ""/none = no console (SOL
 	// unadvertised), "pty" = allocate a PTY pair, otherwise a device path.
 	Console string
+	// Reconnect enables SOL console reconnection (default policy): after a
+	// console failure the server retries the HAL Open on an exponential
+	// backoff, keeping the SOL payload alive across the outage.
+	Reconnect bool
 }
 
 func loadRuntimeConfig() (runtimeConfig, error) {
@@ -32,6 +36,14 @@ func loadRuntimeConfig() (runtimeConfig, error) {
 		User:     envOr("GOIPMI_SERVER_USER", "ADMIN"),
 		Password: envOr("GOIPMI_SERVER_PASS", "ADMIN"),
 		Console:  envOr("GOIPMI_SERVER_CONSOLE", ""),
+	}
+
+	if v := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_SOL_RECONNECT")); v != "" {
+		enabled, err := parseBoolEnv(v)
+		if err != nil {
+			return cfg, fmt.Errorf("GOIPMI_SERVER_SOL_RECONNECT: %w", err)
+		}
+		cfg.Reconnect = enabled
 	}
 
 	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_CIPHER_SUITES")); raw != "" {
@@ -78,6 +90,9 @@ func applyRuntimeConfig(b *bmc.BMC, cfg runtimeConfig) {
 		bmc.WithV15Disabled()(b)
 	} else if len(cfg.V15AuthTypes) > 0 {
 		bmc.WithV15AuthTypes(cfg.V15AuthTypes)(b)
+	}
+	if cfg.Reconnect {
+		b.SOL.SetReconnectPolicy(&bmc.DefaultReconnectPolicy)
 	}
 }
 

--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -20,6 +20,10 @@ type runtimeConfig struct {
 	V15AuthTypes []bmc.V15AuthType // nil = default (md5)
 	V15Disabled  bool
 	Trace        bool
+
+	// Console selects the SOL console backend: ""/none = no console (SOL
+	// unadvertised), "pty" = allocate a PTY pair, otherwise a device path.
+	Console string
 }
 
 func loadRuntimeConfig() (runtimeConfig, error) {
@@ -27,6 +31,7 @@ func loadRuntimeConfig() (runtimeConfig, error) {
 		Port:     envOr("GOIPMI_SERVER_PORT", "623"),
 		User:     envOr("GOIPMI_SERVER_USER", "ADMIN"),
 		Password: envOr("GOIPMI_SERVER_PASS", "ADMIN"),
+		Console:  envOr("GOIPMI_SERVER_CONSOLE", ""),
 	}
 
 	if raw := strings.TrimSpace(os.Getenv("GOIPMI_SERVER_CIPHER_SUITES")); raw != "" {
@@ -76,13 +81,16 @@ func applyRuntimeConfig(b *bmc.BMC, cfg runtimeConfig) {
 	}
 }
 
-func printRuntimeBanner(cfg runtimeConfig, b *bmc.BMC) {
+func printRuntimeBanner(cfg runtimeConfig, b *bmc.BMC, consoleDesc string) {
 	fmt.Printf("goipmi-server: listening on :%s (user=%s)\n", cfg.Port, cfg.User)
 	fmt.Printf("goipmi-server: IPMI v2.0 (lanplus) cipher suites: %v\n", b.ResolvedCipherSuites())
 	if b.V15LANEnabled() {
 		fmt.Printf("goipmi-server: IPMI v1.5 (lan) auth types: %s\n", bmc.FormatV15AuthTypes(b.ResolvedV15AuthTypes()))
 	} else {
 		fmt.Println("goipmi-server: IPMI v1.5 (lan) disabled")
+	}
+	if consoleDesc != "" {
+		fmt.Printf("goipmi-server: console %s\n", consoleDesc)
 	}
 	if cfg.Trace {
 		fmt.Println("goipmi-server: per-command trace enabled (stderr)")

--- a/cmd/goipmi-server/config_test.go
+++ b/cmd/goipmi-server/config_test.go
@@ -118,3 +118,17 @@ func TestLoadRuntimeConfigDisableV15(t *testing.T) {
 		t.Fatal("expected v1.5 disabled after apply")
 	}
 }
+
+// TestLoadRuntimeConfigConsoleNone verifies the documented "none" spelling
+// of "no console" normalizes to the empty string instead of being opened as
+// a device path (which would fail startup with ENOENT).
+func TestLoadRuntimeConfigConsoleNone(t *testing.T) {
+	t.Setenv("GOIPMI_SERVER_CONSOLE", "none")
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig: %v", err)
+	}
+	if cfg.Console != "" {
+		t.Fatalf("console %q, want empty after none normalization", cfg.Console)
+	}
+}

--- a/cmd/goipmi-server/console_linux.go
+++ b/cmd/goipmi-server/console_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -67,6 +68,12 @@ type fileConsoleConn struct {
 }
 
 func (c *fileConsoleConn) ReadAvailable(p []byte) (int, error) {
+	// Fault injection sits in front of the fd: it must make reads fail
+	// even when the underlying tty still has data, so the reconnect engine
+	// sees the same "console gone" it would with a dead link.
+	if consoleFaultInject.Load() {
+		return 0, errors.New("console fault injected (SIGUSR1)")
+	}
 	// poll(2) with a zero timeout, then a raw read. SetReadDeadline on
 	// *os.File cannot express this: the runtime poller reports an already
 	// elapsed deadline before attempting the syscall, so a "now" deadline

--- a/cmd/goipmi-server/console_linux.go
+++ b/cmd/goipmi-server/console_linux.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"golang.org/x/sys/unix"
+)
+
+// consoleOpener adapts an open function to [hal.ConsoleHAL].
+type consoleOpener func(context.Context) (hal.ConsoleConn, error)
+
+func (f consoleOpener) Open(ctx context.Context) (hal.ConsoleConn, error) { return f(ctx) }
+
+// openConsoleHAL builds the console HAL for GOIPMI_SERVER_CONSOLE:
+//
+//	"pty"      – allocate a PTY pair; the BMC holds the master, the slave
+//	             path is reported for tests to play the system side
+//	<path>     – open an existing character device (e.g. /dev/ttyS0)
+//
+// The returned string describes the console for the startup banner.
+func openConsoleHAL(spec string) (hal.ConsoleHAL, string, error) {
+	if spec == "pty" {
+		master, slavePath, err := openPTY()
+		if err != nil {
+			return nil, "", err
+		}
+		return consoleOpener(dupConsoleOpener(master)), "pty slave: " + slavePath, nil
+	}
+
+	f, err := os.OpenFile(spec, os.O_RDWR, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open console device: %w", err)
+	}
+	return consoleOpener(dupConsoleOpener(f)), spec, nil
+}
+
+// dupConsoleOpener hands each activation a dup(2) of the master fd so that
+// payload deactivation (conn close) does not prevent later re-activation.
+func dupConsoleOpener(f *os.File) func(context.Context) (hal.ConsoleConn, error) {
+	return func(context.Context) (hal.ConsoleConn, error) {
+		fd, err := unix.Dup(int(f.Fd()))
+		if err != nil {
+			return nil, fmt.Errorf("dup console fd: %w", err)
+		}
+		return &fileConsoleConn{
+			f:  os.NewFile(uintptr(fd), f.Name()+"#dup"),
+			fd: fd,
+			sendBreak: func() error {
+				return unix.IoctlSetInt(fd, unix.TCSBRK, 0)
+			},
+		}, nil
+	}
+}
+
+// fileConsoleConn adapts a character device fd (PTY master, serial port) to
+// [hal.ConsoleConn].
+type fileConsoleConn struct {
+	f  *os.File // owns fd: Write/Close go through it
+	fd int
+
+	sendBreak func() error
+}
+
+func (c *fileConsoleConn) ReadAvailable(p []byte) (int, error) {
+	// poll(2) with a zero timeout, then a raw read. SetReadDeadline on
+	// *os.File cannot express this: the runtime poller reports an already
+	// elapsed deadline before attempting the syscall, so a "now" deadline
+	// loses data that is sitting in the tty buffer.
+	fds := []unix.PollFd{{Fd: int32(c.fd), Events: unix.POLLIN}}
+	n, err := unix.Poll(fds, 0)
+	if err != nil {
+		return 0, err
+	}
+	if n == 0 || fds[0].Revents&unix.POLLIN == 0 {
+		return 0, nil
+	}
+	rn, err := unix.Read(c.fd, p)
+	if err != nil {
+		if err == unix.EAGAIN { // drained by a concurrent reader between poll and read
+			return 0, nil
+		}
+		return rn, err
+	}
+	return rn, nil
+}
+
+func (c *fileConsoleConn) Write(p []byte) (int, error) { return c.f.Write(p) }
+
+func (c *fileConsoleConn) Close() error { return c.f.Close() }
+
+func (c *fileConsoleConn) SendBreak(context.Context) error {
+	if c.sendBreak == nil {
+		return hal.ErrNotSupported
+	}
+	return c.sendBreak()
+}
+
+// openPTY allocates a PTY pair via /dev/ptmx and returns the master side
+// plus the slave path (grantpt/unlockpt equivalents via TIOCGPTN/TIOCSPTLCK).
+func openPTY() (*os.File, string, error) {
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open /dev/ptmx: %w", err)
+	}
+	n, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		_ = master.Close()
+		return nil, "", fmt.Errorf("TIOCGPTN: %w", err)
+	}
+	// TIOCSPTLCK takes a pointer to int (unlock = 0), unlike the value-arg
+	// ioctls above.
+	if err := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		_ = master.Close()
+		return nil, "", fmt.Errorf("unlockpt: %w", err)
+	}
+	return master, fmt.Sprintf("/dev/pts/%d", n), nil
+}

--- a/cmd/goipmi-server/console_linux.go
+++ b/cmd/goipmi-server/console_linux.go
@@ -48,9 +48,17 @@ func dupConsoleOpener(f *os.File) func(context.Context) (hal.ConsoleConn, error)
 		if err != nil {
 			return nil, fmt.Errorf("dup console fd: %w", err)
 		}
+		if err := unix.SetNonblock(fd, true); err != nil {
+			_ = unix.Close(fd)
+			return nil, fmt.Errorf("set console fd non-blocking: %w", err)
+		}
 		return &fileConsoleConn{
 			f:  os.NewFile(uintptr(fd), f.Name()+"#dup"),
 			fd: fd,
+			// A PTY master polls POLLHUP whenever no slave is open — a
+			// transient, normal state for a shared console whose peer is
+			// opened per write — so hangup detection must not apply to it.
+			pty: isPty(fd),
 			sendBreak: func() error {
 				return unix.IoctlSetInt(fd, unix.TCSBRK, 0)
 			},
@@ -58,11 +66,24 @@ func dupConsoleOpener(f *os.File) func(context.Context) (hal.ConsoleConn, error)
 	}
 }
 
+// isPty reports whether fd is a pseudo-terminal: TIOCGPTN succeeds only on
+// pty masters and slaves.
+func isPty(fd int) bool {
+	_, err := unix.IoctlGetInt(fd, unix.TIOCGPTN)
+	return err == nil
+}
+
 // fileConsoleConn adapts a character device fd (PTY master, serial port) to
 // [hal.ConsoleConn].
 type fileConsoleConn struct {
-	f  *os.File // owns fd: Write/Close go through it
+	f  *os.File // owns fd: Close goes through it
 	fd int
+
+	// pty marks a pseudo-terminal master: poll(2) reports POLLHUP on it
+	// whenever no slave is open, which is transient and normal, so HUP/ERR
+	// read as idle instead of a dead link. Only character devices get real
+	// hangup detection.
+	pty bool
 
 	sendBreak func() error
 }
@@ -79,24 +100,76 @@ func (c *fileConsoleConn) ReadAvailable(p []byte) (int, error) {
 	// elapsed deadline before attempting the syscall, so a "now" deadline
 	// loses data that is sitting in the tty buffer.
 	fds := []unix.PollFd{{Fd: int32(c.fd), Events: unix.POLLIN}}
-	n, err := unix.Poll(fds, 0)
-	if err != nil {
-		return 0, err
-	}
-	if n == 0 || fds[0].Revents&unix.POLLIN == 0 {
-		return 0, nil
-	}
-	rn, err := unix.Read(c.fd, p)
-	if err != nil {
-		if err == unix.EAGAIN { // drained by a concurrent reader between poll and read
+	for {
+		n, err := unix.Poll(fds, 0)
+		if err == unix.EINTR {
+			// Interrupted by a signal — Go handles signals without
+			// SA_RESTART, so raw syscalls see EINTR (e.g. the runtime's
+			// SIGURG async preemption); the console is fine, retry.
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if n > 0 && fds[0].Revents&unix.POLLNVAL != 0 {
+			// The fd itself is gone (device unplugged): a hard error for
+			// any console.
+			return 0, errors.New("console fd invalid")
+		}
+		if n == 0 || fds[0].Revents&unix.POLLIN == 0 {
+			// Nothing readable: HUP/ERR mean the link is dead for character
+			// devices — a PTY master polls POLLHUP whenever no slave is
+			// open, which is transient and normal (see
+			// fileConsoleConn.pty). Reporting the failure lets the
+			// reconnect engine take over; ignoring it would leave the
+			// payload active but silent, with status bit [5] never
+			// reported. POLLIN is checked first: poll reports POLLIN and
+			// POLLHUP together when the peer closed with data still
+			// buffered, and that output must be drained, not thrown away.
+			if n > 0 && !c.pty && fds[0].Revents&(unix.POLLERR|unix.POLLHUP) != 0 {
+				return 0, errors.New("console fd hung up")
+			}
 			return 0, nil
 		}
-		return rn, err
+		break
 	}
-	return rn, nil
+	for {
+		rn, err := unix.Read(c.fd, p)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			if err == unix.EAGAIN { // drained by a concurrent reader between poll and read
+				return 0, nil
+			}
+			// unix.Read returns -1 alongside the error; a negative count
+			// violates the Reader contract, so it never escapes.
+			return 0, err
+		}
+		return rn, nil
+	}
 }
 
-func (c *fileConsoleConn) Write(p []byte) (int, error) { return c.f.Write(p) }
+func (c *fileConsoleConn) Write(p []byte) (int, error) {
+	// The fd is non-blocking: a console that stops consuming (pty slave not
+	// reading, serial flow control asserting stop) must not freeze the SOL
+	// instance — ProcessPacket holds inst.mu during the write, and
+	// teardown waits on the pump. A full buffer reads as "nothing
+	// accepted": the SOL protocol models the backpressure via
+	// AcceptedCharacterCount + NACK, so the remote console retries.
+	n, err := unix.Write(c.fd, p)
+	if err == unix.EAGAIN {
+		return 0, nil
+	}
+	if err != nil {
+		// unix.Write returns -1 alongside the error; the SOL data plane
+		// casts the count to uint8 (AcceptedCharacterCount, pkg/bmc
+		// ProcessPacket), and -1 would report 255 characters accepted that
+		// never reached the console — silently discarding the keystrokes.
+		return 0, err
+	}
+	return n, nil
+}
 
 func (c *fileConsoleConn) Close() error { return c.f.Close() }
 

--- a/cmd/goipmi-server/console_linux_test.go
+++ b/cmd/goipmi-server/console_linux_test.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestReadAvailableHangup verifies a hung-up character device (PTY slave
+// closed) is reported as a failure instead of an idle read: without it the
+// reconnect engine never notices the dead link and the session stays
+// silently mute instead of reporting status bit [5]. A PTY master, whose
+// POLLHUP is a transient normal state (no slave open), must keep reading as
+// idle. Output buffered before the hangup is drained first — poll reports
+// POLLIN and POLLHUP together, and the data must not be thrown away.
+func TestReadAvailableHangup(t *testing.T) {
+	master, slavePath, err := openPTY()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	t.Cleanup(func() { _ = master.Close() })
+	if !isPty(int(master.Fd())) {
+		t.Fatal("isPty(master) = false, want true")
+	}
+
+	slave, err := os.OpenFile(slavePath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open slave: %v", err)
+	}
+
+	// Buffered output + hangup: write to the slave, then close it — the
+	// master polls POLLIN|POLLHUP.
+	if _, err := slave.WriteString("E2E"); err != nil {
+		t.Fatalf("write to slave: %v", err)
+	}
+	if err := slave.Close(); err != nil {
+		t.Fatalf("close slave: %v", err)
+	}
+
+	serial := &fileConsoleConn{f: master, fd: int(master.Fd())}
+	buf := make([]byte, 64)
+	n, err := serial.ReadAvailable(buf)
+	if err != nil || string(buf[:n]) != "E2E" {
+		t.Fatalf("ReadAvailable with buffered data + hangup: n=%d data=%q err=%v, want 3/E2E/nil", n, buf[:n], err)
+	}
+	if _, err := serial.ReadAvailable(buf); err == nil {
+		t.Fatal("ReadAvailable on hung-up console: nil error, want failure")
+	}
+
+	// PTY-master semantics: the same fd state on a fresh pair is a
+	// transient idle, not a dead link.
+	master2, slavePath2, err := openPTY()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	t.Cleanup(func() { _ = master2.Close() })
+	slave2, err := os.OpenFile(slavePath2, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open slave: %v", err)
+	}
+	if _, err := slave2.WriteString("E2E"); err != nil {
+		t.Fatalf("write to slave: %v", err)
+	}
+	if err := slave2.Close(); err != nil {
+		t.Fatalf("close slave: %v", err)
+	}
+	pty := &fileConsoleConn{f: master2, fd: int(master2.Fd()), pty: true}
+	n, err = pty.ReadAvailable(buf)
+	if err != nil || string(buf[:n]) != "E2E" {
+		t.Fatalf("pty ReadAvailable with buffered data: n=%d data=%q err=%v, want 3/E2E/nil", n, buf[:n], err)
+	}
+	if _, err := pty.ReadAvailable(buf); err != nil {
+		t.Fatalf("pty ReadAvailable with no slave: %v, want idle", err)
+	}
+
+	// A live console with no data reads as idle, not broken.
+	fresh, freshPath, err := openPTY()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	t.Cleanup(func() { _ = fresh.Close() })
+	alive := &fileConsoleConn{f: fresh, fd: int(fresh.Fd()), pty: true}
+	if _, err := alive.ReadAvailable(buf); err != nil {
+		t.Fatalf("ReadAvailable on live console: %v, want nil", err)
+	}
+	_ = os.Remove(freshPath)
+}
+
+// TestWriteBackpressure verifies a full output buffer reads as "nothing
+// accepted" (0, nil) instead of an error: ProcessPacket holds the instance
+// lock during the write, so a blocking fd would freeze the whole SOL
+// instance and its teardown. A socketpair stands in for the tty — a pty
+// master accepts gigabytes without EAGAIN, while the socket's ~200KB send
+// buffer fills deterministically; the write path (unix.Write + EAGAIN
+// mapping) is fd-agnostic.
+func TestWriteBackpressure(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
+	})
+	if err := unix.SetNonblock(fds[0], true); err != nil {
+		t.Fatalf("set nonblock: %v", err) // like dupConsoleOpener, so a full buffer returns EAGAIN
+	}
+	conn := &fileConsoleConn{fd: fds[0]} // peer fds[1] open, never read
+
+	buf := make([]byte, 65536)
+	var total int
+	for i := 0; i < 64; i++ {
+		n, err := conn.Write(buf)
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		total += n
+		if n == 0 {
+			break // buffer full: EAGAIN surfaced as backpressure, not an error
+		}
+	}
+	if total == 0 {
+		t.Fatal("wrote 0 bytes before backpressure")
+	}
+
+	// A failing write must report (0, err): unix.Write returns -1 alongside
+	// the error, and the SOL data plane casts the count to uint8 — a -1
+	// would report 255 characters accepted that never reached the console.
+	_ = unix.Close(fds[1])
+	n, err := conn.Write([]byte("k"))
+	if err == nil {
+		t.Fatalf("write after peer close: n=%d err=nil, want error", n)
+	}
+	if n != 0 {
+		t.Fatalf("write after peer close: n=%d, want 0 (negative counts must not leak)", n)
+	}
+}

--- a/cmd/goipmi-server/console_other.go
+++ b/cmd/goipmi-server/console_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/bougou/go-ipmi/pkg/hal"
+)
+
+// openConsoleHAL is only meaningful on Linux (PTY/serial devices); elsewhere
+// the reference server runs without a console and SOL stays unadvertised.
+func openConsoleHAL(spec string) (hal.ConsoleHAL, string, error) {
+	return nil, "", fmt.Errorf("console %q not supported on %s", spec, runtime.GOOS)
+}

--- a/cmd/goipmi-server/fault_linux.go
+++ b/cmd/goipmi-server/fault_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+)
+
+// consoleFaultInject simulates a broken console link: while set, every
+// console read fails, flipping the SOL instance broken so the reconnect
+// engine runs its real recovery path. Toggled by SIGUSR1 (break) and
+// SIGUSR2 (restore); e2e uses it to drive a full
+// outage → reconnect → recovery cycle against a real client.
+//
+// Linux-only like the console backend itself (openConsoleHAL); the
+// SIGUSR1/SIGUSR2 toggle in startConsoleFaultInjection is the only writer,
+// console_linux.go the only reader.
+var consoleFaultInject atomic.Bool
+
+// startConsoleFaultInjection wires the e2e console-fault toggle: SIGUSR1
+// breaks the console link, SIGUSR2 restores it (see consoleFaultInject
+// above). Linux-only — SIGUSR1/SIGUSR2 exist on Unix only, matching the
+// Linux-only console backend (openConsoleHAL).
+func startConsoleFaultInjection() {
+	faultCh := make(chan os.Signal, 2)
+	signal.Notify(faultCh, syscall.SIGUSR1, syscall.SIGUSR2)
+	go func() {
+		for sig := range faultCh {
+			switch sig {
+			case syscall.SIGUSR1:
+				consoleFaultInject.Store(true)
+				fmt.Fprintln(os.Stderr, "console fault injected: reads now fail")
+			case syscall.SIGUSR2:
+				consoleFaultInject.Store(false)
+				fmt.Fprintln(os.Stderr, "console fault cleared: reads restored")
+			}
+		}
+	}()
+}

--- a/cmd/goipmi-server/fault_other.go
+++ b/cmd/goipmi-server/fault_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package main
+
+// startConsoleFaultInjection is a no-op off Linux: SIGUSR1/SIGUSR2 are Unix
+// signals, and the console backend itself is Linux-only (see openConsoleHAL),
+// so the fault toggle can never be exercised here.
+func startConsoleFaultInjection() {}

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -15,6 +15,9 @@
 //	GOIPMI_SERVER_TRACE           – set to 1/true to log every dispatched command to stderr (default: 0)
 //	GOIPMI_SERVER_CONSOLE         – SOL console backend: "pty" allocates a PTY pair (linux),
 //	                                a path opens that device (e.g. /dev/ttyS0); unset = no SOL
+//	GOIPMI_SERVER_SOL_RECONNECT   – set to 1/true to reconnect a failed SOL console
+//	                                automatically (default policy; default: 0/off)
+//	                                SIGUSR1/SIGUSR2 inject/clear a console fault (e2e, linux)
 package main
 
 import (
@@ -71,6 +74,11 @@ func run() error {
 		}
 		halImpl.SetConsole(consoleHAL)
 		consoleDesc = desc
+	}
+
+	if cfg.Console != "" {
+		// Console fault injection for e2e (see consoleFaultInject in fault_linux.go).
+		startConsoleFaultInjection()
 	}
 
 	b := bmc.New(info, guid, halImpl, bmc.WithClock(clock.Real))

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -13,6 +13,8 @@
 //	GOIPMI_SERVER_V15_AUTH_TYPES  – v1.5 auth types: none,md2,md5,password,oem (default: md5)
 //	GOIPMI_SERVER_V15             – set to 0/false to disable v1.5 while keeping lanplus (default: 1)
 //	GOIPMI_SERVER_TRACE           – set to 1/true to log every dispatched command to stderr (default: 0)
+//	GOIPMI_SERVER_CONSOLE         – SOL console backend: "pty" allocates a PTY pair (linux),
+//	                                a path opens that device (e.g. /dev/ttyS0); unset = no SOL
 package main
 
 import (
@@ -61,6 +63,16 @@ func run() error {
 	halImpl := mock.New()
 	seedReferenceStorage(context.Background(), halImpl)
 
+	consoleDesc := ""
+	if cfg.Console != "" {
+		consoleHAL, desc, err := openConsoleHAL(cfg.Console)
+		if err != nil {
+			return fmt.Errorf("console: %w", err)
+		}
+		halImpl.SetConsole(consoleHAL)
+		consoleDesc = desc
+	}
+
 	b := bmc.New(info, guid, halImpl, bmc.WithClock(clock.Real))
 	applyRuntimeConfig(b, cfg)
 
@@ -84,7 +96,7 @@ func run() error {
 
 	var opts []server.ServerOption
 	if cfg.Trace {
-		opts = append(opts, server.WithHandlerRegistry(tracingRegistry()))
+		opts = append(opts, server.WithHandlerRegistry(tracingRegistry()), server.WithSOLDebug())
 	}
 	srv := server.NewServer(b, conn, opts...)
 
@@ -96,7 +108,7 @@ func run() error {
 		srv.Close()
 	}()
 
-	printRuntimeBanner(cfg, b)
+	printRuntimeBanner(cfg, b, consoleDesc)
 
 	if err := srv.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("serve: %w", err)

--- a/cmd/goipmi-server/trace.go
+++ b/cmd/goipmi-server/trace.go
@@ -17,10 +17,7 @@ import (
 func tracingRegistry() *handlers.Registry {
 	reg := handlers.NewRegistry()
 	reg.Use(traceCommands)
-	handlers.RegisterAppHandlers(reg)
-	handlers.RegisterSessionHandlers(reg)
-	handlers.RegisterChassisHandlers(reg)
-	handlers.RegisterStorageHandlers(reg)
+	handlers.RegisterAllHandlers(reg)
 	return reg
 }
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -30,6 +30,7 @@ make build
 | `GOIPMI_SERVER_V15_AUTH_TYPES` | `md5`   | v1.5 auth types: `none`, `md2`, `md5`, `password`, `oem` |
 | `GOIPMI_SERVER_V15`            | `1`     | `0` / `false` disables v1.5; lanplus stays up            |
 | `GOIPMI_SERVER_TRACE`          | `0`     | Log dispatched commands to stderr                        |
+| `GOIPMI_SERVER_CONSOLE`        | unset   | SOL console backend: `pty` allocates a PTY pair, a path opens that device (e.g. `/dev/ttyS0`); unset = no SOL |
 
 ```bash
 ./_output/goipmi -I lanplus -H 127.0.0.1 -p 623 -U ADMIN -P ADMIN mc info

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/olekukonko/tablewriter v1.0.9
 	github.com/spf13/cobra v1.3.0
 	golang.org/x/net v0.43.0
+	golang.org/x/sys v0.35.0
 	golang.org/x/term v0.34.0
 )
 
@@ -24,5 +25,4 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.35.0 // indirect
 )

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -58,6 +58,9 @@ type BMC struct {
 
 	// SDRRepo tracks SDR repository reservation state (v2.0§33.11).
 	SDRRepo *SDRRepoStore
+	// SOL holds the SOL payload configuration (v2.0 Table 26-5) and the
+	// active SOL instance state machine (v2.0 §15).
+	SOL *SOLStore
 	// sdrRepo is the lazily-initialised SDR record repository (v2.0§33).
 	sdrRepo     *SDRRepository
 	sdrRepoOnce sync.Once
@@ -188,6 +191,9 @@ func New(info DeviceInfo, guid [16]byte, h hal.HAL, opts ...Option) *BMC {
 	}
 	b.Sessions = NewSessionStore(b.clock)
 	b.V15Sessions = NewV15SessionStore(b.clock)
+	b.SOL = NewSOLStore(h, b.clock)
+	// Session termination automatically deactivates its payloads (v2.0§24.2).
+	b.Sessions.SetOnRemove(b.SOL.DeactivateBySession)
 	return b
 }
 

--- a/pkg/bmc/session.go
+++ b/pkg/bmc/session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -66,6 +67,21 @@ type Session struct {
 	InboundSeq  uint32
 	OutboundSeq uint32
 
+	// Addr is the remote console's transport address, refreshed on every
+	// inbound packet. Asynchronous traffic (SOL data push, §15.3) targets it.
+	Addr net.Addr
+
+	// seqMu serializes outbound sequence assignment: command responses and
+	// asynchronous SOL packets share one space (§15.5) and are sent from
+	// different goroutines.
+	seqMu sync.Mutex
+
+	// ProcMu serializes per-session packet processing. The server spawns a
+	// goroutine per inbound packet; without this lock, a burst of packets
+	// from one session is processed in scheduler order — scrambling SOL
+	// keystroke bytes and racing the inbound-seq check-then-set.
+	ProcMu sync.Mutex
+
 	// Session keys derived during RAKP.
 	SIK []byte
 	K1  []byte
@@ -96,6 +112,13 @@ type SessionStore struct {
 	max      int
 	timeout  time.Duration
 	clock    clock.Clock
+
+	// onRemove fires whenever a session leaves the store (Close or
+	// eviction). The BMC wires this to payload deactivation: when a session
+	// terminates, payloads active under it are automatically deactivated
+	// (spec v2.0 §24.2). It is invoked with the store lock held and must not
+	// call back into the store.
+	onRemove func(bmcID uint32)
 }
 
 // NewSessionStore creates a SessionStore limited to [MaxSessions] concurrent sessions
@@ -195,7 +218,21 @@ func (s *SessionStore) Close(bmcID uint32) error {
 		return fmt.Errorf("session 0x%08x: %w", bmcID, ErrNoSession)
 	}
 	delete(s.sessions, bmcID)
+	s.fireRemoveLocked(bmcID)
 	return nil
+}
+
+// SetOnRemove registers the hook fired when a session leaves the store.
+func (s *SessionStore) SetOnRemove(fn func(bmcID uint32)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onRemove = fn
+}
+
+func (s *SessionStore) fireRemoveLocked(bmcID uint32) {
+	if s.onRemove != nil {
+		s.onRemove(bmcID)
+	}
 }
 
 // EvictExpired removes all sessions that have been inactive beyond the timeout.
@@ -212,6 +249,7 @@ func (s *SessionStore) evictExpiredLocked() int {
 	for id, sess := range s.sessions {
 		if now.Sub(sess.LastActivity) > s.timeout+DefaultInactivityTimeoutTolerance {
 			delete(s.sessions, id)
+			s.fireRemoveLocked(id)
 			n++
 		}
 	}
@@ -233,6 +271,7 @@ func (s *SessionStore) evictOldestPendingLocked() bool {
 		return false
 	}
 	delete(s.sessions, oldest.BMCID)
+	s.fireRemoveLocked(oldest.BMCID)
 	return true
 }
 
@@ -252,6 +291,16 @@ func InboundSeqValid(last, seq uint32) bool {
 	}
 	diff := int64(seq) - int64(last)
 	return diff >= -16 && diff <= 15
+}
+
+// NextOutboundSeq returns the session sequence number for the next outbound
+// packet, advancing the counter shared by command responses and async SOL
+// packets (§15.5).
+func (sess *Session) NextOutboundSeq() uint32 {
+	sess.seqMu.Lock()
+	defer sess.seqMu.Unlock()
+	sess.OutboundSeq++
+	return sess.OutboundSeq
 }
 
 func randomUint32() (uint32, error) {

--- a/pkg/bmc/session.go
+++ b/pkg/bmc/session.go
@@ -69,7 +69,13 @@ type Session struct {
 
 	// Addr is the remote console's transport address, refreshed on every
 	// inbound packet. Asynchronous traffic (SOL data push, §15.3) targets it.
-	Addr net.Addr
+	// Guarded by addrMu; use [Session.SetAddr] / [Session.GetAddr] rather
+	// than touching the field directly. The SOL pump reads it from a
+	// goroutine that must not take ProcMu (a packet handler holding ProcMu
+	// can wait on the pump during deactivation — the reverse order would
+	// deadlock), while packet handling writes it under ProcMu.
+	addrMu sync.Mutex
+	Addr   net.Addr
 
 	// seqMu serializes outbound sequence assignment: command responses and
 	// asynchronous SOL packets share one space (§15.5) and are sent from
@@ -116,8 +122,10 @@ type SessionStore struct {
 	// onRemove fires whenever a session leaves the store (Close or
 	// eviction). The BMC wires this to payload deactivation: when a session
 	// terminates, payloads active under it are automatically deactivated
-	// (spec v2.0 §24.2). It is invoked with the store lock held and must not
-	// call back into the store.
+	// (spec v2.0 §24.2). It is invoked without the store lock: payload
+	// teardown can block (an SOL instance close waits for its pump
+	// goroutine, which may be mid reconnect dial), and holding the lock
+	// across that would freeze every session lookup and allocation.
 	onRemove func(bmcID uint32)
 }
 
@@ -159,13 +167,21 @@ func NewSessionStoreWithOptions(clk clock.Clock, opts ...SessionStoreOption) *Se
 // Returns [ErrSessionFull] only when all slots are occupied by active sessions.
 func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integrityAlg types.IntegrityAlg, cryptAlg types.CryptAlg) (*Session, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
-	s.evictExpiredLocked()
+	// Collect the evicted IDs so their removal hooks (payload deactivation,
+	// which can block) run after the lock is released — even on the error
+	// paths below, the evicted sessions are gone and must be cleaned up.
+	removed := s.evictExpiredLocked()
+	defer func() {
+		s.mu.Unlock()
+		s.fireRemoveAll(removed)
+	}()
 
 	if len(s.sessions) >= s.max {
 		// Evict oldest pending session if any exist.
-		if !s.evictOldestPendingLocked() {
+		if id, ok := s.evictOldestPendingLocked(); ok {
+			removed = append(removed, id)
+		} else {
 			return nil, ErrSessionFull
 		}
 	}
@@ -213,12 +229,13 @@ func (s *SessionStore) Get(bmcID uint32) (*Session, error) {
 // Close marks a session as closed and removes it from the store.
 func (s *SessionStore) Close(bmcID uint32) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if _, ok := s.sessions[bmcID]; !ok {
+		s.mu.Unlock()
 		return fmt.Errorf("session 0x%08x: %w", bmcID, ErrNoSession)
 	}
 	delete(s.sessions, bmcID)
-	s.fireRemoveLocked(bmcID)
+	s.mu.Unlock()
+	s.fireRemove(bmcID)
 	return nil
 }
 
@@ -229,9 +246,20 @@ func (s *SessionStore) SetOnRemove(fn func(bmcID uint32)) {
 	s.onRemove = fn
 }
 
-func (s *SessionStore) fireRemoveLocked(bmcID uint32) {
+// fireRemove invokes the removal hook for one session ID outside the store
+// lock; the hook may block (SOL teardown waits on the pump), so it must never
+// run under s.mu.
+func (s *SessionStore) fireRemove(bmcID uint32) {
 	if s.onRemove != nil {
 		s.onRemove(bmcID)
+	}
+}
+
+// fireRemoveAll invokes the removal hook for every ID collected by a locked
+// eviction pass.
+func (s *SessionStore) fireRemoveAll(ids []uint32) {
+	for _, id := range ids {
+		s.fireRemove(id)
 	}
 }
 
@@ -239,26 +267,29 @@ func (s *SessionStore) fireRemoveLocked(bmcID uint32) {
 // Called periodically by the server.
 func (s *SessionStore) EvictExpired() int {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.evictExpiredLocked()
+	removed := s.evictExpiredLocked()
+	s.mu.Unlock()
+	s.fireRemoveAll(removed)
+	return len(removed)
 }
 
-func (s *SessionStore) evictExpiredLocked() int {
+// evictExpiredLocked removes sessions inactive beyond the timeout and returns
+// their IDs. s.mu must be held.
+func (s *SessionStore) evictExpiredLocked() []uint32 {
 	now := s.clock.Now()
-	n := 0
+	var removed []uint32
 	for id, sess := range s.sessions {
 		if now.Sub(sess.LastActivity) > s.timeout+DefaultInactivityTimeoutTolerance {
 			delete(s.sessions, id)
-			s.fireRemoveLocked(id)
-			n++
+			removed = append(removed, id)
 		}
 	}
-	return n
+	return removed
 }
 
-// evictOldestPendingLocked removes the oldest pending session.
-// Returns false if no pending sessions exist.
-func (s *SessionStore) evictOldestPendingLocked() bool {
+// evictOldestPendingLocked removes the oldest pending session and returns its
+// ID. ok=false when no pending sessions exist. s.mu must be held.
+func (s *SessionStore) evictOldestPendingLocked() (uint32, bool) {
 	var oldest *Session
 	for _, sess := range s.sessions {
 		if sess.State == SessionStatePending {
@@ -268,11 +299,10 @@ func (s *SessionStore) evictOldestPendingLocked() bool {
 		}
 	}
 	if oldest == nil {
-		return false
+		return 0, false
 	}
 	delete(s.sessions, oldest.BMCID)
-	s.fireRemoveLocked(oldest.BMCID)
-	return true
+	return oldest.BMCID, true
 }
 
 // Count returns the number of sessions currently in the store.
@@ -291,6 +321,22 @@ func InboundSeqValid(last, seq uint32) bool {
 	}
 	diff := int64(seq) - int64(last)
 	return diff >= -16 && diff <= 15
+}
+
+// SetAddr records the console's transport address under the guard. The
+// server calls it on every accepted inbound packet.
+func (sess *Session) SetAddr(addr net.Addr) {
+	sess.addrMu.Lock()
+	sess.Addr = addr
+	sess.addrMu.Unlock()
+}
+
+// GetAddr returns the console's transport address, safe to call from any
+// goroutine (the SOL pump targets asynchronous data at it).
+func (sess *Session) GetAddr() net.Addr {
+	sess.addrMu.Lock()
+	defer sess.addrMu.Unlock()
+	return sess.Addr
 }
 
 // NextOutboundSeq returns the session sequence number for the next outbound

--- a/pkg/bmc/sol.go
+++ b/pkg/bmc/sol.go
@@ -7,6 +7,8 @@ package bmc
 import (
 	"context"
 	"errors"
+	"math"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -280,6 +282,75 @@ func (c *SOLConfig) resetVolatile() {
 	c.vBitRate = c.nvBitRate
 }
 
+// consoleReconnectOpenTimeout bounds each reconnect dial attempt. The pump
+// is the only driver of recovery, so a hung dial must not stall console
+// output indefinitely — deactivation waits on this tick via stopCh/stopped.
+const consoleReconnectOpenTimeout = 5 * time.Second
+
+// ReconnectPolicy controls when the pump retries attaching to a failed
+// console, after reconnection has been enabled via [SOLStore.SetReconnectPolicy].
+// By default reconnection is disabled: the payload stays active, reports
+// status bit [5] (Table 15-2), and recovers only via deactivate/reactivate —
+// the spec's own behavior.
+//
+// Field semantics follow k8s.io/apimachinery/pkg/util/wait.Backoff. The
+// delay for attempt n (n ≥ 1, counting from the first failure) is
+//
+//	Initial * Factor^(n-1), capped at Cap, plus a jitter of up to
+//	Jitter × the capped value.
+//
+// Console failures and reconnection are invisible to the remote console:
+// ipmitool keeps its SOL session alive with a Get Device ID keepalive every
+// 15s (ipmi_sol.c, SOL_KEEPALIVE_TIMEOUT) and only exits after 6 missed
+// keepalives (~90s), so the server may back off as long as its RMCP+ path
+// stays up. Keystrokes typed during the outage are lost either way:
+// ipmitool treats a NACK as delivered and never retransmits.
+type ReconnectPolicy struct {
+	// Initial is the delay after the first failure; 0 retries immediately.
+	Initial time.Duration
+	// Factor multiplies the delay on each failure (>= 1).
+	Factor float64
+	// Jitter adds a random delay of up to Jitter × the computed delay
+	// (0..1) to desynchronize concurrent reconnection attempts; 0 = none.
+	Jitter float64
+	// Cap bounds the delay; <= 0 means unbounded.
+	Cap time.Duration
+	// Steps bounds the number of reconnect attempts (1-based); once
+	// exhausted the instance gives up and behaves as if reconnection were
+	// disabled. 0 means retry forever.
+	Steps int
+}
+
+// DefaultReconnectPolicy is the built-in strategy: retry after 1s, then
+// double to a 30s cap, forever. VM-migration-scale outages (minutes) are
+// covered by the cap holding: attempts keep coming, just no more often
+// than every 30s.
+var DefaultReconnectPolicy = ReconnectPolicy{Initial: time.Second, Factor: 2, Cap: 30 * time.Second}
+
+// Delay returns the wait before attempt failures+1 after failures
+// consecutive failed attempts (failures ≥ 1), and whether reconnection
+// should be given up (Steps exhausted).
+func (p *ReconnectPolicy) Delay(failures int) (wait time.Duration, giveUp bool) {
+	if p == nil {
+		return 0, true
+	}
+	if p.Steps > 0 && failures >= p.Steps {
+		return 0, true
+	}
+	f := 1.0
+	if p.Factor > 1 {
+		f = math.Pow(p.Factor, float64(failures-1))
+	}
+	wait = p.Initial * time.Duration(f)
+	if p.Cap > 0 && wait > p.Cap {
+		wait = p.Cap
+	}
+	if p.Jitter > 0 {
+		wait += time.Duration(p.Jitter * float64(wait) * rand.Float64())
+	}
+	return wait, false
+}
+
 // SOLInstance is one activated SOL payload: the binding between an RMCP+
 // session and the system console, plus the payload-level sequence state of
 // Table 15-2. All methods are safe for concurrent use.
@@ -296,6 +367,9 @@ type SOLInstance struct {
 	encryptOutbound atomic.Bool
 
 	conn hal.ConsoleConn
+	// open re-attaches to the console after a failure; the HAL Open call that
+	// created the initial conn. The reconnect state machine is the only user.
+	open func(context.Context) (hal.ConsoleConn, error)
 	send SOLSendFunc // nil when the server injected no sender (unit tests)
 
 	clock   clock.Clock
@@ -317,6 +391,17 @@ type SOLInstance struct {
 	rx           []byte    // drained console output awaiting transmission
 	rxSince      time.Time // when the oldest rx byte arrived (accumulate interval)
 	broken       bool      // console conn failed; reported via status bit [5]
+
+	// Reconnect state, driven by the pump (the only goroutine that touches
+	// conn while broken). policy is the activation-time snapshot of the
+	// store's ReconnectPolicy (nil disables reconnection); failures counts
+	// consecutive failed attempts; reconnectAt is when the next attempt may
+	// run, zero until the first failure starts a cycle; giveUp latches once
+	// the policy's Steps are exhausted.
+	policy      *ReconnectPolicy
+	failures    int
+	reconnectAt time.Time
+	giveUp      bool
 }
 
 // nextSOLSeq advances a payload sequence number in 1..0x0f; 0h is reserved
@@ -343,18 +428,36 @@ type SOLStore struct {
 
 	senderFactory SOLSenderFactory // set by the server at construction
 
+	// policy decides console reconnect timing; nil (the default) disables
+	// reconnection. Snapshot per activation (see Activate), so the store's
+	// value may be changed between activations without locking the data
+	// plane.
+	policy *ReconnectPolicy
+
 	mu   sync.Mutex
 	inst *SOLInstance // nil when deactivated (SOLMaxInstances == 1)
 }
 
 // NewSOLStore creates a SOLStore. h may be nil or return a nil ConsoleHAL,
-// in which case SOL stays inactive and unadvertised.
+// in which case SOL stays inactive and unadvertised. Console reconnection
+// is disabled by default; enable it with [SOLStore.SetReconnectPolicy].
 func NewSOLStore(h hal.HAL, clk clock.Clock) *SOLStore {
 	s := &SOLStore{config: NewSOLConfig(), clock: clk}
 	if h != nil {
 		s.console = h.Console()
 	}
 	return s
+}
+
+// SetReconnectPolicy enables and configures console reconnection: after a
+// console failure the pump retries the HAL Open on the policy's schedule
+// (see [ReconnectPolicy]). A nil policy (the default) disables reconnection:
+// the payload reports status bit [5] and recovers only via
+// deactivate/reactivate. Takes effect on the next activation.
+func (s *SOLStore) SetReconnectPolicy(p *ReconnectPolicy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.policy = p
 }
 
 // SetSenderFactory installs the factory used to build per-activation senders.
@@ -435,6 +538,7 @@ func (s *SOLStore) Activate(ctx context.Context, sess *Session, wantEnc, wantAut
 	inst := &SOLInstance{
 		SessionID: sess.BMCID,
 		conn:      conn,
+		open:      s.console.Open,
 		clock:     s.clock,
 		config:    s.config,
 		stopCh:    make(chan struct{}),
@@ -452,6 +556,10 @@ func (s *SOLStore) Activate(ctx context.Context, sess *Session, wantEnc, wantAut
 		_ = conn.Close()
 		return nil, ErrSOLAlreadyActive
 	}
+	// Snapshot the reconnect policy under the store lock; the pump reads it
+	// on this instance only, so later SetReconnectPolicy calls do not need
+	// to synchronize with the data plane.
+	inst.policy = s.policy
 	s.inst = inst
 	s.mu.Unlock()
 
@@ -659,11 +767,22 @@ func (inst *SOLInstance) pumpTick() {
 	accumulate, threshold, retryCount, retryInterval := inst.config.timing()
 
 	inst.mu.Lock()
+	now := inst.clock.Now()
+
+	// A failed console conn enters the reconnect state machine before any
+	// other pump work: recovery is the pump's job alone (ProcessPacket never
+	// touches conn while broken), so the data plane must not skip it behind
+	// a nil-conn check. reconnectLocked temporarily drops the lock while the
+	// HAL dials (a dial may block), then re-acquires it to install state.
+	if inst.broken {
+		inst.reconnectLocked(now)
+		inst.mu.Unlock()
+		return
+	}
 	defer inst.mu.Unlock()
 	if inst.conn == nil || inst.send == nil {
 		return
 	}
-	now := inst.clock.Now()
 
 	if inst.pending != nil {
 		if inst.suspended {
@@ -697,6 +816,73 @@ func (inst *SOLInstance) pumpTick() {
 		inst.makeOutboundLocked()
 		inst.sendLocked()
 	}
+}
+
+// reconnectLocked drives the console recovery state machine. Called by the
+// pump on every tick while broken, entered with inst.mu held:
+//
+//   - first entry: release the dead conn. ProcessPacket never touches conn
+//     while broken (it answers with NACK + status bit [5] instead), so
+//     replacing the conn here cannot race a keystroke write.
+//   - on each policy-determined expiry: ask the console HAL for a fresh
+//     conn. A successful attach clears broken and drops the pre-failure RX
+//     residue — bytes read before the failure belong to the old console
+//     session (e.g. a rebooted system) and must not reach the remote
+//     console. Pending outbound data is kept: the remote console still owns
+//     its ACK (Table 15-3), and the retry engine already decides its fate.
+//
+// A nil policy (reconnection disabled) releases the dead conn once and then
+// does nothing: the payload stays active with status bit [5] until the
+// remote console deactivates it.
+//
+// The HAL dial happens with the lock dropped: it may block for up to
+// consoleReconnectOpenTimeout, and holding inst.mu across it would stall
+// keystroke processing and status responses. State is only ever mutated
+// under the lock, so the unlock window is safe — broken stays true (only
+// this goroutine clears it) and ProcessPacket only inspects it.
+func (inst *SOLInstance) reconnectLocked(now time.Time) {
+	if inst.conn != nil {
+		_ = inst.conn.Close()
+		inst.conn = nil
+	}
+	if inst.policy == nil || inst.giveUp {
+		return // reconnection disabled, or Steps exhausted
+	}
+	if inst.reconnectAt.IsZero() {
+		// First failure: the policy decides the first retry delay.
+		inst.failures = 1
+		inst.reconnectAt = now.Add(inst.policyDelay())
+	}
+	if now.Before(inst.reconnectAt) {
+		return // still backing off
+	}
+	inst.mu.Unlock() // dial without the lock; re-acquire to install state
+	ctx, cancel := context.WithTimeout(context.Background(), consoleReconnectOpenTimeout)
+	conn, err := inst.open(ctx)
+	cancel()
+	inst.mu.Lock()
+	if err != nil {
+		inst.failures++
+		inst.reconnectAt = now.Add(inst.policyDelay())
+		return
+	}
+	inst.conn = conn
+	inst.broken = false
+	inst.failures = 0
+	inst.reconnectAt = time.Time{}
+	inst.giveUp = false
+	inst.rx = nil
+	inst.rxSince = time.Time{}
+}
+
+// policyDelay asks the policy for the wait before the next attempt,
+// latching giveUp once its Steps are exhausted. inst.mu must be held.
+func (inst *SOLInstance) policyDelay() time.Duration {
+	wait, giveUp := inst.policy.Delay(inst.failures)
+	if giveUp {
+		inst.giveUp = true
+	}
+	return wait
 }
 
 // sendLocked transmits the pending packet. inst.mu must be held.
@@ -771,7 +957,7 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 
 	inst.mu.Lock()
 	defer inst.mu.Unlock()
-	if inst.conn == nil {
+	if inst.conn == nil && !inst.broken {
 		return nil
 	}
 
@@ -822,12 +1008,12 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 			accepted = inst.lastAccepted
 			nack = inst.lastNACK
 		} else {
-			if in.ControlByte&0x10 != 0 { // bit [4]: generate BREAK
-				_ = inst.conn.SendBreak(ctx) // best effort; BREAK is advisory
-			}
 			if inst.broken {
 				nack = true
 			} else {
+				if in.ControlByte&0x10 != 0 { // bit [4]: generate BREAK
+					_ = inst.conn.SendBreak(ctx) // best effort; BREAK is advisory
+				}
 				n, err := inst.conn.Write(in.CharacterData)
 				accepted = uint8(n)
 				if err != nil {

--- a/pkg/bmc/sol.go
+++ b/pkg/bmc/sol.go
@@ -347,17 +347,29 @@ func (p *ReconnectPolicy) Delay(failures int) (wait time.Duration, giveUp bool) 
 	if p == nil {
 		return 0, true
 	}
-	if p.Steps > 0 && failures >= p.Steps {
+	// failures counts the console failure that started the cycle plus every
+	// failed dial (reconnectLocked seeds it at 1 on first entry), so a dial
+	// is allowed while failures <= Steps — Steps bounds the number of dials,
+	// not the seed.
+	if p.Steps > 0 && failures > p.Steps {
 		return 0, true
 	}
 	f := 1.0
 	if p.Factor > 1 {
 		f = math.Pow(p.Factor, float64(failures-1))
 	}
-	wait = p.Initial * time.Duration(f)
-	if p.Cap > 0 && wait > p.Cap {
-		wait = p.Cap
+	// Compute in float seconds and clamp to Cap before converting to
+	// Duration: the raw Initial * Factor^(n-1) multiply overflows int64
+	// nanoseconds once the factor passes ~2^34, and a wrapped (negative)
+	// wait is already in the past — the Cap clamp never applies, turning
+	// the backoff into a busy retry loop. Float math also avoids the
+	// integer truncation that freezes non-integer Factor values (e.g. 1.5)
+	// on the first doubling steps.
+	secs := p.Initial.Seconds() * f
+	if p.Cap > 0 && secs > p.Cap.Seconds() {
+		secs = p.Cap.Seconds()
 	}
+	wait = time.Duration(secs * float64(time.Second))
 	if p.Jitter > 0 {
 		wait += time.Duration(p.Jitter * float64(wait) * rand.Float64())
 	}
@@ -562,7 +574,7 @@ func (s *SOLStore) Activate(ctx context.Context, sess *Session, wantEnc, wantAut
 		stopped:   make(chan struct{}),
 	}
 	inst.encryptOutbound.Store(encrypted)
-	if s.senderFactory != nil && sess.Addr != nil {
+	if s.senderFactory != nil && sess.GetAddr() != nil {
 		inst.send = s.senderFactory(sess, inst)
 	}
 
@@ -879,7 +891,11 @@ func (inst *SOLInstance) reconnectLocked(now time.Time) {
 	inst.mu.Lock()
 	if err != nil {
 		inst.failures++
-		inst.reconnectAt = now.Add(inst.policyDelay())
+		// Re-arm from when the attempt finished, not the tick's pre-dial
+		// time: a dial that burned most of the wait would otherwise leave
+		// reconnectAt already in the past, collapsing the backoff into
+		// back-to-back attempts no matter how large the delay has grown.
+		inst.reconnectAt = inst.clock.Now().Add(inst.policyDelay())
 		return
 	}
 	inst.conn = conn
@@ -1073,6 +1089,12 @@ func (inst *SOLInstance) ProcessPacket(ctx context.Context, in *types.SOLPayload
 			inst.lastAccepted = accepted
 			inst.lastNACK = nack
 		}
+	} else {
+		// ACK-only packet (seq 0h, §15.11): the acked echo names the last
+		// accepted data packet, so replay its accepted count — reporting 0
+		// would read as "packet N accepted nothing" (Table 15-3) and make
+		// a strict console resend packet N's already-delivered keystrokes.
+		accepted = inst.lastAccepted
 	}
 
 	// Outbound character data rides the response: polling-style consoles

--- a/pkg/bmc/sol.go
+++ b/pkg/bmc/sol.go
@@ -1,0 +1,876 @@
+package bmc
+
+// SOL (Serial over LAN) state: per-channel configuration parameters
+// (spec v2.0 Table 26-5) and the payload instance state machine
+// (spec v2.0 §15.9 payload data format, §15.11 acknowledge and retries).
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+const (
+	// SOLMaxInstances is the number of simultaneously activatable SOL payload
+	// instances (spec v2.0 Table 24-6, 1-based). One instance matches the
+	// single shared serial port of the reference hardware model (§15.3).
+	SOLMaxInstances = 1
+
+	// SOLMaxPayloadChars bounds character data per SOL packet. The Accepted
+	// Character Count field is one byte (Table 15-2) and the 4-byte SOL
+	// packet header shares the 255-byte reported payload size.
+	SOLMaxPayloadChars = 251
+
+	// SOLRXBufferCap bounds console output buffered between remote-console
+	// polls. A full buffer applies backpressure (draining pauses until the
+	// console catches up) — the in-tree equivalent of the BMC deasserting
+	// CTS (§15.6) — so buffered data is never silently dropped.
+	SOLRXBufferCap = 4096
+
+	// SOLPayloadUDPPortDefault is the primary RMCP port reported when the
+	// server transport does not expose its bound address.
+	SOLPayloadUDPPortDefault = 623
+)
+
+// SOL activation failure reasons, mapped by the Activate Payload handler to
+// the command-specific completion codes named in pkg/types (spec v2.0
+// Table 24-2 / Table 24-3 / Table 24-5).
+var (
+	// ErrSOLAlreadyActive → CodeActivatePayloadAlreadyActive (Table 24-2).
+	ErrSOLAlreadyActive = errors.New("SOL payload already active")
+	// ErrSOLDisabled → CodeActivatePayloadTypeDisabled (Table 24-2).
+	ErrSOLDisabled = errors.New("SOL payload type is disabled")
+	// ErrSOLPrivilege → CodeInsufficientPrivilege: session privilege below the
+	// configured SOL level.
+	ErrSOLPrivilege = errors.New("insufficient privilege to activate SOL")
+	// ErrSOLEncryptionUnavailable → CodeActivatePayloadCannotActivateWithEncryption
+	// (Table 24-2): the session negotiated no encryption algorithm.
+	ErrSOLEncryptionUnavailable = errors.New("cannot activate SOL with encryption")
+	// ErrSOLEncryptionRequired → CodeActivatePayloadCannotActivateWithoutEncryption
+	// (Table 24-2): policy forces encryption the console declined.
+	ErrSOLEncryptionRequired = errors.New("cannot activate SOL without encryption")
+	// ErrSOLAuthenticationUnavailable → CodeRequestDataFieldInvalid: Table 24-2
+	// defines no authentication-specific completion code, so an unsatisfiable
+	// authentication request/policy falls back to the generic invalid-data-field
+	// code.
+	ErrSOLAuthenticationUnavailable = errors.New("cannot activate SOL with authentication")
+
+	// ErrSOLInstanceNotActive → CodeSuspendResumePayloadEncryptionNotActive
+	// (Table 24-5): the session owns no active SOL payload instance.
+	ErrSOLInstanceNotActive = errors.New("SOL payload instance not active")
+	// ErrSOLEncryptionForced → CodeSuspendResumePayloadEncryptionNotAllowed
+	// (Table 24-5): SOL configuration parameter #2 forces encryption, so
+	// suspending it is not allowed.
+	ErrSOLEncryptionForced = errors.New("SOL encryption forced by configuration")
+	// ErrSOLEncryptionUnavailableForSession →
+	// CodeSuspendResumePayloadEncryptionNotAvailable (Table 24-5): the session
+	// negotiated no encryption algorithm at open time.
+	ErrSOLEncryptionUnavailableForSession = errors.New("encryption not available for session")
+	// ErrSOLOperationUnsupported → CodeSuspendResumePayloadEncryptionNotSupported
+	// (Table 24-5): IV regeneration is xRC4-specific; AES-CBC payloads draw a
+	// fresh IV per packet already.
+	ErrSOLOperationUnsupported = errors.New("operation not supported for SOL payload")
+	// ErrSOLNotActive → CodeDeactivatePayloadAlreadyDeactivated (Table 24-3).
+	ErrSOLNotActive = errors.New("SOL payload not active")
+	// ErrSOLNotOwner → CodeInsufficientPrivilege (Deactivate): session owns no
+	// instance and lacks the privilege to force-deactivate another session's
+	// payload.
+	ErrSOLNotOwner = errors.New("SOL payload owned by another session")
+)
+
+// SOLConfig holds the SOL configuration parameters of spec v2.0 Table 26-5.
+// Only Set In Progress (#0) and the volatile bit rate (#6) are volatile; the
+// volatile bit rate is reloaded from the non-volatile one on every payload
+// activation (§15.8). Defaults are manufacturer choices (the spec leaves them
+// open): SOL enabled, ADMINISTRATOR privilege, 115.2 kbps.
+type SOLConfig struct {
+	mu sync.Mutex
+
+	setInProgress uint8 // #0: 0 = set complete, 1 = set in progress (rollback not implemented)
+
+	enabled             bool           // #1
+	forceEncryption     bool           // #2 [7]
+	forceAuthentication bool           // #2 [6]
+	privilegeLevel      PrivilegeLevel // #2 [3:0]
+
+	accumulateInterval5ms uint8 // #3 byte 1, 5 ms units
+	sendThreshold         uint8 // #3 byte 2
+
+	retryCount        uint8 // #4 byte 1 [2:0]
+	retryInterval10ms uint8 // #4 byte 2
+
+	nvBitRate uint8 // #5
+	vBitRate  uint8 // #6 (volatile copy)
+
+	payloadChannel uint8 // #7: channel the activation arrived on (1 until first activation)
+
+	// PayloadPort is the RMCP port carrying the SOL payload (Table 26-5 #8).
+	// Server-internal, written once at construction and never settable via
+	// IPMI (#7/#8 are read-only per SetParam), so a plain field suffices.
+	PayloadPort uint16
+}
+
+// NewSOLConfig returns a SOLConfig with manufacturer defaults.
+func NewSOLConfig() *SOLConfig {
+	return &SOLConfig{
+		enabled:               true,
+		privilegeLevel:        PrivilegeLevelAdministrator,
+		accumulateInterval5ms: 10, // 50 ms
+		sendThreshold:         SOLMaxPayloadChars,
+		retryCount:            3,
+		retryInterval10ms:     5, // 50 ms
+		nvBitRate:             0x0a,
+		vBitRate:              0x0a,
+		payloadChannel:        1,
+		PayloadPort:           SOLPayloadUDPPortDefault,
+	}
+}
+
+// solBitRateSupported reports whether rate is a settable bit rate value
+// (Table 26-5 #5: 6h-Ah; 0h selects the serial-channel setting and is
+// reserved here because there is no IPMI-over-serial channel).
+func solBitRateSupported(rate uint8) bool {
+	return rate >= 0x06 && rate <= 0x0a
+}
+
+// GetParam returns the parameter data bytes for selector (Table 26-5),
+// or false when the selector is not a supported parameter.
+func (c *SOLConfig) GetParam(selector uint8) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch selector {
+	case 0:
+		return []byte{c.setInProgress}, true
+	case 1:
+		var b uint8
+		if c.enabled {
+			b = 0x01
+		}
+		return []byte{b}, true
+	case 2:
+		var b uint8
+		if c.forceEncryption {
+			b |= 0x80
+		}
+		if c.forceAuthentication {
+			b |= 0x40
+		}
+		return []byte{b | uint8(c.privilegeLevel)}, true
+	case 3:
+		return []byte{c.accumulateInterval5ms, c.sendThreshold}, true
+	case 4:
+		return []byte{c.retryCount & 0x07, c.retryInterval10ms}, true
+	case 5:
+		return []byte{c.nvBitRate}, true
+	case 6:
+		return []byte{c.vBitRate}, true
+	case 7:
+		return []byte{c.payloadChannel}, true
+	case 8:
+		return []byte{uint8(c.PayloadPort), uint8(c.PayloadPort >> 8)}, true
+	default:
+		return nil, false
+	}
+}
+
+// SetParam validates and applies one parameter write (Table 26-3/26-5),
+// returning the command-specific completion code on failure.
+func (c *SOLConfig) SetParam(selector uint8, data []byte) types.CompletionCode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if selector == 7 || selector == 8 {
+		// Read-only here: the payload channel is derived from the activation,
+		// and the port is fixed by the transport the server listens on.
+		return types.CodeParamConfigSetReadOnly
+	}
+	if selector > 8 {
+		return types.CodeParameterNotSupported // 80h
+	}
+	if len(data) == 0 {
+		return types.CodeRequestDataLengthInvalid
+	}
+
+	switch selector {
+	case 0:
+		// Commit write (10b) requires rollback support, which is not
+		// implemented; 11b is reserved (Table 26-5 #0).
+		if data[0] > 1 {
+			return types.CodeRequestDataFieldInvalid
+		}
+		if data[0] == 1 && c.setInProgress != 0 {
+			// Table 26-3: 81h recognizes that another party has already
+			// 'claimed' the parameters (set in progress is a notification
+			// flag, not a lock — later writers see this code).
+			return types.CodeParamConfigSetInProgressConflict
+		}
+		c.setInProgress = data[0]
+	case 1:
+		c.enabled = data[0]&0x01 != 0
+	case 2:
+		priv := PrivilegeLevel(data[0] & 0x0f)
+		switch priv {
+		case PrivilegeLevelUser, PrivilegeLevelOperator, PrivilegeLevelAdministrator, PrivilegeLevelOEM:
+		default:
+			return types.CodeRequestDataFieldInvalid
+		}
+		c.forceEncryption = data[0]&0x80 != 0
+		c.forceAuthentication = data[0]&0x40 != 0
+		c.privilegeLevel = priv
+	case 3:
+		if len(data) < 2 {
+			return types.CodeRequestDataLengthInvalid
+		}
+		if data[0] == 0 || data[1] == 0 {
+			return types.CodeRequestDataFieldInvalid // both fields are 1-based
+		}
+		if data[1] > SOLMaxPayloadChars {
+			return types.CodeParameterOutOfRange
+		}
+		c.accumulateInterval5ms = data[0]
+		c.sendThreshold = data[1]
+	case 4:
+		if len(data) < 2 {
+			return types.CodeRequestDataLengthInvalid
+		}
+		c.retryCount = data[0] & 0x07
+		c.retryInterval10ms = data[1]
+	case 5, 6:
+		if !solBitRateSupported(data[0]) {
+			return types.CodeParameterOutOfRange // C9h, per Table 26-5 #5 note
+		}
+		if selector == 5 {
+			c.nvBitRate = data[0]
+		} else {
+			c.vBitRate = data[0]
+		}
+	}
+	return types.CodeOK
+}
+
+// snapshot returns the activation-relevant settings under one lock.
+func (c *SOLConfig) snapshot() (enabled, forceEnc, forceAuth bool, priv PrivilegeLevel) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.enabled, c.forceEncryption, c.forceAuthentication, c.privilegeLevel
+}
+
+// timing returns the data-plane tuning of Table 26-5 #3/#4 as durations.
+// The SOL payload format has no room for a zero retry interval: 00h means
+// back-to-back retries, clamped here to a 10 ms floor.
+func (c *SOLConfig) timing() (accumulate time.Duration, threshold int, retryCount int, retryInterval time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	accumulate = time.Duration(c.accumulateInterval5ms) * 5 * time.Millisecond
+	retryInterval = max(time.Duration(c.retryInterval10ms)*10*time.Millisecond, 10*time.Millisecond)
+	return accumulate, int(c.sendThreshold), int(c.retryCount), retryInterval
+}
+
+// resetVolatile implements §15.8: volatile settings are copied from the
+// non-volatile settings when the payload is first activated.
+func (c *SOLConfig) resetVolatile() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vBitRate = c.nvBitRate
+}
+
+// SOLInstance is one activated SOL payload: the binding between an RMCP+
+// session and the system console, plus the payload-level sequence state of
+// Table 15-2. All methods are safe for concurrent use.
+type SOLInstance struct {
+	SessionID uint32 // BMC session ID owning the activation
+
+	// encryptOutbound records the outbound protection negotiated at activation
+	// (Table 24-2 auxiliary data + Table 26-5 #2 forcing bits) — the spec
+	// constrains BMC→console data only, so outbound SOL packets are protected
+	// per this setting, never per inbound packet flags (Table 24-4) — unless
+	// the console toggles BMC→console encryption at run time via
+	// Suspend/Resume Payload Encryption (Table 24-5). The send path reads it
+	// from the pump goroutine without inst.mu, hence the atomic.
+	encryptOutbound atomic.Bool
+
+	conn hal.ConsoleConn
+	send SOLSendFunc // nil when the server injected no sender (unit tests)
+
+	clock   clock.Clock
+	config  *SOLConfig
+	stopCh  chan struct{}
+	stopped chan struct{}
+
+	mu sync.Mutex
+
+	inSeq        uint8     // last accepted console→BMC packet sequence number (0 = none yet)
+	lastAccepted uint8     // accepted count reported for that packet (replayed on console retries)
+	lastNACK     bool      // NACK state reported for that packet (replayed with lastAccepted)
+	outSeq       uint8     // last assigned BMC→console packet sequence number (advances 1..0x0f)
+	pending      []byte    // outbound character data awaiting acknowledge (§15.11)
+	pendingSince time.Time // when pending was last (re)sent, for retry timing
+	retries      int       // resend count for the pending packet
+	suspended    bool      // Suspend NACK received; pending is withheld until resumed (Table 15-3)
+	overrun      bool      // characters were dropped since the last outbound packet (status [3])
+	rx           []byte    // drained console output awaiting transmission
+	rxSince      time.Time // when the oldest rx byte arrived (accumulate interval)
+	broken       bool      // console conn failed; reported via status bit [5]
+}
+
+// nextSOLSeq advances a payload sequence number in 1..0x0f; 0h is reserved
+// for ACK-only packets and never assigned to data packets (Table 15-2).
+func nextSOLSeq(seq uint8) uint8 {
+	return (seq % 0x0f) + 1
+}
+
+// SOLSendFunc transmits one BMC→console SOL payload packet. The server
+// supplies it; it owns session-level encryption, sequencing, and transport.
+type SOLSendFunc func(pkt *types.SOLPayloadPacket) error
+
+// SOLSenderFactory builds the send function for an activation. sess.Addr
+// must already hold the console's transport address.
+type SOLSenderFactory func(sess *Session, inst *SOLInstance) SOLSendFunc
+
+// SOLStore owns the SOL configuration and active instances. Packet
+// sequencing lives in [SOLInstance]; asynchronous output is pushed by the
+// instance pump (spec v2.0 §15.3: the BMC sends SOL data unrequested).
+type SOLStore struct {
+	console hal.ConsoleHAL // nil when the target has no redirectable console
+	config  *SOLConfig
+	clock   clock.Clock
+
+	senderFactory SOLSenderFactory // set by the server at construction
+
+	mu   sync.Mutex
+	inst *SOLInstance // nil when deactivated (SOLMaxInstances == 1)
+}
+
+// NewSOLStore creates a SOLStore. h may be nil or return a nil ConsoleHAL,
+// in which case SOL stays inactive and unadvertised.
+func NewSOLStore(h hal.HAL, clk clock.Clock) *SOLStore {
+	s := &SOLStore{config: NewSOLConfig(), clock: clk}
+	if h != nil {
+		s.console = h.Console()
+	}
+	return s
+}
+
+// SetSenderFactory installs the factory used to build per-activation senders.
+// Called by the server once the transport exists.
+func (s *SOLStore) SetSenderFactory(f SOLSenderFactory) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.senderFactory = f
+}
+
+// Config returns the SOL configuration parameter store.
+func (s *SOLStore) Config() *SOLConfig { return s.config }
+
+// Supported reports whether the SOL payload type can be activated at all,
+// i.e. a console exists and the type is enabled (Table 26-5 #1).
+func (s *SOLStore) Supported() bool {
+	if s.console == nil {
+		return false
+	}
+	enabled, _, _, _ := s.config.snapshot()
+	return enabled
+}
+
+// Activate attaches the system console to sess (spec v2.0 §24.1). wantEnc /
+// wantAuth are the remote console's Encryption/Authentication Activation
+// bits from the Activate Payload auxiliary request data. The returned error
+// maps to a Table 24-2 completion code in the handler.
+func (s *SOLStore) Activate(ctx context.Context, sess *Session, wantEnc, wantAuth bool) (*SOLInstance, error) {
+	if s.console == nil {
+		return nil, ErrSOLDisabled
+	}
+	enabled, forceEnc, forceAuth, solPriv := s.config.snapshot()
+	if !enabled {
+		return nil, ErrSOLDisabled
+	}
+
+	s.mu.Lock()
+	if s.inst != nil {
+		s.mu.Unlock()
+		return nil, ErrSOLAlreadyActive
+	}
+	s.mu.Unlock()
+
+	if sess.PrivilegeLevel < solPriv {
+		return nil, ErrSOLPrivilege
+	}
+	if sess.User != nil && !sess.User.PayloadAccessFor(sess.Channel).SOLEnabled() {
+		return nil, ErrSOLPrivilege
+	}
+
+	// Encryption requires authentication: the spec algorithms have no
+	// encrypt-only mode (Table 24-2 aux data note).
+	if wantEnc && !wantAuth {
+		return nil, ErrSOLEncryptionUnavailable
+	}
+	sessionCanCrypt := sess.CryptAlg != types.CryptAlg_None && len(sess.K2) >= 16
+	sessionCanAuth := sess.IntegrityAlg != types.IntegrityAlg_None
+	switch {
+	case forceEnc && !wantEnc:
+		// The console declined encryption while policy mandates it
+		// (Table 24-2: 84h "BMC requires encryption for all payloads").
+		return nil, ErrSOLEncryptionRequired
+	case wantEnc && !sessionCanCrypt:
+		// The console asked for encryption the session never negotiated.
+		return nil, ErrSOLEncryptionUnavailable
+	case (wantAuth || forceAuth) && !sessionCanAuth:
+		return nil, ErrSOLAuthenticationUnavailable
+	}
+
+	conn, err := s.console.Open(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Outbound SOL packets are protected per the activation-negotiated
+	// setting; inbound packets keep their own packet flags (Table 24-4).
+	encrypted := sessionCanCrypt && (wantEnc || forceEnc)
+	inst := &SOLInstance{
+		SessionID: sess.BMCID,
+		conn:      conn,
+		clock:     s.clock,
+		config:    s.config,
+		stopCh:    make(chan struct{}),
+		stopped:   make(chan struct{}),
+	}
+	inst.encryptOutbound.Store(encrypted)
+	if s.senderFactory != nil && sess.Addr != nil {
+		inst.send = s.senderFactory(sess, inst)
+	}
+
+	s.mu.Lock()
+	if s.inst != nil {
+		// Lost the race against a concurrent activation on another session.
+		s.mu.Unlock()
+		_ = conn.Close()
+		return nil, ErrSOLAlreadyActive
+	}
+	s.inst = inst
+	s.mu.Unlock()
+
+	s.config.resetVolatile()
+	if inst.send != nil {
+		go inst.pump()
+	} else {
+		close(inst.stopped)
+	}
+	return inst, nil
+}
+
+// Deactivate detaches the console (spec v2.0 §24.2). The owning session may
+// always deactivate; another session may force-deactivate when its privilege
+// meets the configured SOL level (Table 26-5 #2) — this is the recovery path
+// for payloads orphaned by a crashed console.
+func (s *SOLStore) Deactivate(sess *Session) error {
+	_, _, _, solPriv := s.config.snapshot()
+
+	s.mu.Lock()
+	inst := s.inst
+	switch {
+	case inst == nil:
+		s.mu.Unlock()
+		return ErrSOLNotActive
+	case inst.SessionID != sess.BMCID && sess.PrivilegeLevel < solPriv:
+		s.mu.Unlock()
+		return ErrSOLNotOwner
+	}
+	s.inst = nil
+	s.mu.Unlock()
+
+	return s.teardownInst(inst)
+}
+
+// DeactivateBySession drops the instance owned by bmcID, if any. Wired to
+// SessionStore removals: session termination automatically deactivates its
+// payloads (spec v2.0 §24.2 note).
+func (s *SOLStore) DeactivateBySession(bmcID uint32) {
+	s.mu.Lock()
+	inst := s.inst
+	if inst == nil || inst.SessionID != bmcID {
+		s.mu.Unlock()
+		return
+	}
+	s.inst = nil
+	s.mu.Unlock()
+
+	_ = s.teardownInst(inst)
+}
+
+// CloseAll deactivates every instance; called when the server shuts down.
+func (s *SOLStore) CloseAll() {
+	s.mu.Lock()
+	inst := s.inst
+	s.inst = nil
+	s.mu.Unlock()
+	if inst != nil {
+		_ = s.teardownInst(inst)
+	}
+}
+
+// teardownInst notifies the remote console and releases an instance that has
+// already been unregistered from the store. The notify packet must go out
+// before close, which stops the pump.
+func (s *SOLStore) teardownInst(inst *SOLInstance) error {
+	inst.sendDeactivating()
+	return inst.close()
+}
+
+// ActivationStatus reports the Table 24-6 instance bitmask: bit (n-1) set
+// when instance n is active.
+func (s *SOLStore) ActivationStatus() (capacity uint8, active1to8, active9to16 uint8) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inst != nil {
+		active1to8 = 0x01
+	}
+	return SOLMaxInstances, active1to8, 0
+}
+
+// ActiveSessionID returns the owning session ID for instance (1-based),
+// or 0 when not activated (Table 24-7).
+func (s *SOLStore) ActiveSessionID(instance uint8) uint32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inst == nil || instance != 1 {
+		return 0
+	}
+	return s.inst.SessionID
+}
+
+// InstanceBySession returns the instance owned by bmcID, or nil. The server
+// reads the negotiated protection flags from it before processing packets.
+func (s *SOLStore) InstanceBySession(bmcID uint32) *SOLInstance {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inst == nil || s.inst.SessionID != bmcID {
+		return nil
+	}
+	return s.inst
+}
+
+// OutboundEncrypted reports whether BMC→console SOL data is currently
+// encrypted: the activation-negotiated setting unless the console toggled it
+// via Suspend/Resume Payload Encryption (Table 24-5). The command only
+// governs data from the BMC ("encryption on all transfers of specified
+// payload data from the BMC"); inbound packets keep their own packet flags.
+func (inst *SOLInstance) OutboundEncrypted() bool {
+	return inst.encryptOutbound.Load()
+}
+
+// Table 24-5 operations for Suspend/Resume Payload Encryption.
+const (
+	SOLEncryptionOpSuspend = 0
+	SOLEncryptionOpResume  = 1
+	SOLEncryptionOpRegenIV = 2
+)
+
+// SuspendResumeEncryption applies a Table 24-5 operation to the instance
+// owned by sess. Only BMC→console encryption is affected; authentication is
+// untouched and inbound packets keep their activation-negotiated protection.
+func (s *SOLStore) SuspendResumeEncryption(sess *Session, op uint8) error {
+	s.mu.Lock()
+	inst := s.inst
+	s.mu.Unlock()
+	if inst == nil || inst.SessionID != sess.BMCID {
+		return ErrSOLInstanceNotActive
+	}
+	switch op {
+	case SOLEncryptionOpSuspend:
+		if _, forceEnc, _, _ := s.config.snapshot(); forceEnc {
+			return ErrSOLEncryptionForced
+		}
+		inst.encryptOutbound.Store(false)
+	case SOLEncryptionOpResume:
+		// "Resume/Start encryption": valid even when the payload was
+		// activated without encryption, provided the session can encrypt.
+		if sess.CryptAlg == types.CryptAlg_None || len(sess.K2) < 16 {
+			return ErrSOLEncryptionUnavailableForSession
+		}
+		inst.encryptOutbound.Store(true)
+	default:
+		return ErrSOLOperationUnsupported
+	}
+	return nil
+}
+
+// sendDeactivating issues the one-time packet with status bit [4] (SOL
+// deactivated/deactivating, Table 15-2 footnote 2) just before the payload
+// goes down, so the remote console can tell an administrative deactivation
+// (Deactivate Payload / Close Session, possibly from another session) apart
+// from a communication failure.
+func (inst *SOLInstance) sendDeactivating() {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.send == nil {
+		return
+	}
+	_ = inst.send(&types.SOLPayloadPacket{
+		AckedSequenceNumber:    inst.inSeq,
+		AcceptedCharacterCount: inst.lastAccepted,
+		NACK:                   true,
+		ControlByte:            0x10,
+	})
+}
+
+func (inst *SOLInstance) close() error {
+	if inst.stopCh != nil {
+		close(inst.stopCh)
+		<-inst.stopped // pump outlives conn use; wait before closing
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.conn != nil {
+		err := inst.conn.Close()
+		inst.conn = nil
+		return err
+	}
+	return nil
+}
+
+// pump asynchronously pushes console output to the remote console and drives
+// the §15.11 retry engine. Consoles such as ipmitool never poll with SOL
+// packets (their keepalive is Get Device ID), so response-piggybacking alone
+// would starve the BMC→console direction.
+//
+// Tick granularity is fixed at 10 ms; configured intervals (5 ms / 10 ms
+// units) are compared against timestamps, so the tick only bounds precision.
+func (inst *SOLInstance) pump() {
+	defer close(inst.stopped)
+	ticker := inst.clock.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-inst.stopCh:
+			return
+		case <-ticker.C():
+			inst.pumpTick()
+		}
+	}
+}
+
+func (inst *SOLInstance) pumpTick() {
+	accumulate, threshold, retryCount, retryInterval := inst.config.timing()
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.conn == nil || inst.send == nil {
+		return
+	}
+	now := inst.clock.Now()
+
+	if inst.pending != nil {
+		if inst.suspended {
+			// Suspend NACK (Table 15-3): stop sending/retrying the pending
+			// packet until a Partial/Completion ACK, Resume ACK, or Flush
+			// Outbound arrives. Console output keeps buffering meanwhile.
+			inst.drainConsoleLocked()
+			return
+		}
+		// Unacknowledged packet: resend on the retry interval, drop when
+		// retries are exhausted (§15.11: "the data will be lost") and flag
+		// the loss on the next outbound packet (Table 15-2 status [3]).
+		if now.Sub(inst.pendingSince) >= retryInterval {
+			if inst.retries >= retryCount {
+				inst.pending = nil
+				inst.retries = 0
+				inst.overrun = true
+			} else {
+				inst.sendLocked()
+				inst.retries++
+				inst.pendingSince = now
+			}
+		}
+		return
+	}
+
+	inst.drainConsoleLocked()
+	full := threshold > 0 && len(inst.rx) >= threshold
+	aged := len(inst.rx) > 0 && now.Sub(inst.rxSince) >= accumulate
+	if full || aged {
+		inst.makeOutboundLocked()
+		inst.sendLocked()
+	}
+}
+
+// sendLocked transmits the pending packet. inst.mu must be held.
+func (inst *SOLInstance) sendLocked() {
+	pkt := &types.SOLPayloadPacket{
+		SequenceNumber:         inst.outSeq,
+		AckedSequenceNumber:    inst.inSeq,
+		AcceptedCharacterCount: inst.lastAccepted,
+		CharacterData:          inst.pending,
+	}
+	if inst.broken {
+		pkt.ControlByte |= 0x20 // Table 15-2 status [5]: character transfer unavailable
+	}
+	if inst.overrun {
+		pkt.ControlByte |= 0x08 // Table 15-2 status [3]: characters dropped since the previous packet
+		inst.overrun = false
+	}
+	_ = inst.send(pkt) // send failure keeps pending; the retry path owns it
+}
+
+// drainConsoleLocked moves immediately-available console output into rx.
+// inst.mu must be held.
+func (inst *SOLInstance) drainConsoleLocked() {
+	if inst.broken || inst.conn == nil || len(inst.rx) >= SOLRXBufferCap {
+		return
+	}
+	chunk := make([]byte, SOLRXBufferCap-len(inst.rx))
+	n, err := inst.conn.ReadAvailable(chunk)
+	if err != nil {
+		inst.broken = true
+		return
+	}
+	if n > 0 {
+		if len(inst.rx) == 0 {
+			inst.rxSince = inst.clock.Now()
+		}
+		inst.rx = append(inst.rx, chunk[:n]...)
+	}
+}
+
+// makeOutboundLocked promotes buffered console output to the pending packet.
+// One outstanding packet at a time (Table 15-2): a new sequence number is
+// assigned only when nothing is unacknowledged. Returns the pending data
+// (nil when nothing may be sent). inst.mu must be held.
+func (inst *SOLInstance) makeOutboundLocked() []byte {
+	if inst.pending != nil {
+		return inst.pending
+	}
+	if len(inst.rx) == 0 {
+		return nil
+	}
+	take := min(len(inst.rx), SOLMaxPayloadChars)
+	inst.pending = append([]byte{}, inst.rx[:take]...)
+	inst.rx = inst.rx[take:]
+	inst.outSeq = nextSOLSeq(inst.outSeq)
+	inst.retries = 0
+	inst.pendingSince = inst.clock.Now()
+	return inst.pending
+}
+
+// ProcessPacket handles one inbound SOL payload packet from the owning
+// session and produces the response packet (spec v2.0 §15.9/§15.11,
+// Table 15-3). It returns nil when the session owns no active instance.
+func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *types.SOLPayloadPacket) *types.SOLPayloadPacket {
+	s.mu.Lock()
+	inst := s.inst
+	if inst == nil || inst.SessionID != sessionID {
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.conn == nil {
+		return nil
+	}
+
+	out := &types.SOLPayloadPacket{}
+
+	// The console is acknowledging our pending outbound packet (Table 15-3).
+	if in.AckedSequenceNumber != 0 && inst.pending != nil && in.AckedSequenceNumber == inst.outSeq {
+		switch {
+		case in.NACK:
+			// Suspend NACK: stop sending/retrying the pending packet until a
+			// Partial/Completion ACK, Resume ACK, or Flush Outbound arrives.
+			// (A console→BMC NACK with a non-zero count is not defined by
+			// Table 15-3; suspending is the lossless reading.)
+			inst.suspended = true
+		case in.AcceptedCharacterCount == 0:
+			inst.suspended = false // Resume ACK: pending rides this response
+		case int(in.AcceptedCharacterCount) >= len(inst.pending):
+			inst.pending = nil // Completion ACK
+			inst.suspended = false
+		default:
+			// Partial ACK: retransmit the unaccepted remainder (Table 15-3).
+			inst.pending = inst.pending[in.AcceptedCharacterCount:]
+			inst.suspended = false
+		}
+	}
+
+	// Console→BMC operations (Table 15-2) execute before character data.
+	// Flush Outbound doubles as the recovery path from a Suspend NACK
+	// (Table 15-3), so it is honored on any packet, including ACK-only ones.
+	if in.ControlByte&0x01 != 0 {
+		inst.pending = nil
+		inst.retries = 0
+		inst.rx = nil
+		inst.suspended = false
+	}
+	// Flush Inbound (bit [1]) needs no action: inbound keystrokes are written
+	// to the system console synchronously, so no BMC-side buffer exists.
+
+	// Inbound operations and character data. ACK-only packets (seq 0h) carry
+	// no data and are never acknowledged (§15.11).
+	var accepted uint8
+	var nack bool
+	if in.SequenceNumber != 0 {
+		if in.SequenceNumber == inst.inSeq {
+			// Console retry: content is unchanged (§15.9), so replay the
+			// response the original packet got — reporting len(CharacterData)
+			// here would ACK bytes a partial accept or NACK never wrote.
+			accepted = inst.lastAccepted
+			nack = inst.lastNACK
+		} else {
+			if in.ControlByte&0x10 != 0 { // bit [4]: generate BREAK
+				_ = inst.conn.SendBreak(ctx) // best effort; BREAK is advisory
+			}
+			if inst.broken {
+				nack = true
+			} else {
+				n, err := inst.conn.Write(in.CharacterData)
+				accepted = uint8(n)
+				if err != nil {
+					inst.broken = true
+					nack = true
+				} else if n < len(in.CharacterData) {
+					nack = true
+				}
+			}
+			inst.inSeq = in.SequenceNumber
+			inst.lastAccepted = accepted
+			inst.lastNACK = nack
+		}
+	}
+
+	// Outbound character data rides the response: polling-style consoles
+	// (which send empty SOL packets continuously) get output with the lowest
+	// latency this way; the pump covers consoles that never poll. A suspended
+	// packet (Suspend NACK, Table 15-3) is withheld from the response.
+	if !inst.broken {
+		inst.drainConsoleLocked()
+	}
+	if !inst.suspended {
+		inst.makeOutboundLocked()
+	}
+
+	out.SequenceNumber = 0 // ACK-only packet unless data is pending (Table 15-2)
+	if inst.pending != nil && !inst.suspended {
+		out.SequenceNumber = inst.outSeq
+		out.CharacterData = inst.pending
+		inst.pendingSince = inst.clock.Now() // the response is a (re)send
+	}
+	out.AckedSequenceNumber = inst.inSeq
+	out.AcceptedCharacterCount = accepted
+	out.NACK = nack
+	if inst.broken {
+		// Status bit [5]: character transfer is unavailable (Table 15-2,
+		// BMC→console status), e.g. system powered down or console gone.
+		out.ControlByte |= 0x20
+	}
+	if inst.overrun {
+		out.ControlByte |= 0x08 // status [3]: characters dropped since the previous packet
+		inst.overrun = false
+	}
+	return out
+}

--- a/pkg/bmc/sol.go
+++ b/pkg/bmc/sol.go
@@ -385,6 +385,10 @@ type SOLInstance struct {
 	open func(context.Context) (hal.ConsoleConn, error)
 	send SOLSendFunc // nil when the server injected no sender (unit tests)
 
+	// tracef is the optional diagnostic sink for console lifecycle events
+	// (reconnect); nil (the default) disables it. Written from the pump only.
+	tracef func(format string, args ...any)
+
 	clock   clock.Clock
 	config  *SOLConfig
 	stopCh  chan struct{}
@@ -880,11 +884,27 @@ func (inst *SOLInstance) reconnectLocked(now time.Time) {
 	}
 	inst.conn = conn
 	inst.broken = false
+	if inst.tracef != nil {
+		inst.tracef("sol! sess=%x console reconnected after %d failed attempt(s)\n", inst.SessionID, inst.failures)
+	}
 	inst.failures = 0
 	inst.reconnectAt = time.Time{}
 	inst.giveUp = false
 	inst.rx = nil
 	inst.rxSince = time.Time{}
+}
+
+// SetTracef installs the diagnostic sink for console lifecycle events. The
+// server wires it to its solDebug-gated SOL trace; a nil sink (the default)
+// keeps the library silent. Callable from any goroutine; events are emitted
+// from the pump.
+//
+// The sink is printf-shaped, so printf-style loggers plug in directly —
+// logrus.Printf and zap's SugaredLogger.Infof match this signature as-is.
+func (inst *SOLInstance) SetTracef(f func(format string, args ...any)) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	inst.tracef = f
 }
 
 // policyDelay asks the policy for the wait before the next attempt,

--- a/pkg/bmc/sol.go
+++ b/pkg/bmc/sol.go
@@ -229,8 +229,8 @@ func (c *SOLConfig) SetParam(selector uint8, data []byte) types.CompletionCode {
 		if len(data) < 2 {
 			return types.CodeRequestDataLengthInvalid
 		}
-		if data[0] == 0 || data[1] == 0 {
-			return types.CodeRequestDataFieldInvalid // both fields are 1-based
+		if data[0] == 0 {
+			return types.CodeRequestDataFieldInvalid // accumulate interval is 1-based (00h reserved)
 		}
 		if data[1] > SOLMaxPayloadChars {
 			return types.CodeParameterOutOfRange
@@ -274,11 +274,24 @@ func (c *SOLConfig) timing() (accumulate time.Duration, threshold int, retryCoun
 	return accumulate, int(c.sendThreshold), int(c.retryCount), retryInterval
 }
 
-// resetVolatile implements §15.8: volatile settings are copied from the
-// non-volatile settings when the payload is first activated.
-func (c *SOLConfig) resetVolatile() {
+// markActivated implements §15.8: on payload activation the volatile bit
+// rate is reloaded from the non-volatile one, and Table 26-5 #7 records the
+// channel the activation arrived on.
+func (c *SOLConfig) markActivated(ch uint8) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.vBitRate = c.nvBitRate
+	c.payloadChannel = ch
+}
+
+// ResetVolatile clears the volatile SOL configuration — only #0 set in
+// progress and #6 volatile bit rate are volatile (Table 26-5) — as after a
+// BMC cold reset / power cycle, which aborts any parameter set in progress
+// (Table 26-3 "set complete" rule).
+func (c *SOLConfig) ResetVolatile() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.setInProgress = 0
 	c.vBitRate = c.nvBitRate
 }
 
@@ -563,7 +576,7 @@ func (s *SOLStore) Activate(ctx context.Context, sess *Session, wantEnc, wantAut
 	s.inst = inst
 	s.mu.Unlock()
 
-	s.config.resetVolatile()
+	s.config.markActivated(sess.Channel)
 	if inst.send != nil {
 		go inst.pump()
 	} else {
@@ -722,7 +735,6 @@ func (inst *SOLInstance) sendDeactivating() {
 	_ = inst.send(&types.SOLPayloadPacket{
 		AckedSequenceNumber:    inst.inSeq,
 		AcceptedCharacterCount: inst.lastAccepted,
-		NACK:                   true,
 		ControlByte:            0x10,
 	})
 }
@@ -893,14 +905,20 @@ func (inst *SOLInstance) sendLocked() {
 		AcceptedCharacterCount: inst.lastAccepted,
 		CharacterData:          inst.pending,
 	}
+	inst.applyStatusLocked(pkt)
+	_ = inst.send(pkt) // send failure keeps pending; the retry path owns it
+}
+
+// applyStatusLocked stamps the BMC→console status bits on out and consumes
+// the overrun latch. inst.mu must be held.
+func (inst *SOLInstance) applyStatusLocked(out *types.SOLPayloadPacket) {
 	if inst.broken {
-		pkt.ControlByte |= 0x20 // Table 15-2 status [5]: character transfer unavailable
+		out.ControlByte |= 0x20 // Table 15-2 status [5]: character transfer unavailable
 	}
 	if inst.overrun {
-		pkt.ControlByte |= 0x08 // Table 15-2 status [3]: characters dropped since the previous packet
+		out.ControlByte |= 0x08 // Table 15-2 status [3]: characters dropped since the previous packet
 		inst.overrun = false
 	}
-	_ = inst.send(pkt) // send failure keeps pending; the retry path owns it
 }
 
 // drainConsoleLocked moves immediately-available console output into rx.
@@ -925,14 +943,10 @@ func (inst *SOLInstance) drainConsoleLocked() {
 
 // makeOutboundLocked promotes buffered console output to the pending packet.
 // One outstanding packet at a time (Table 15-2): a new sequence number is
-// assigned only when nothing is unacknowledged. Returns the pending data
-// (nil when nothing may be sent). inst.mu must be held.
-func (inst *SOLInstance) makeOutboundLocked() []byte {
-	if inst.pending != nil {
-		return inst.pending
-	}
-	if len(inst.rx) == 0 {
-		return nil
+// assigned only when nothing is unacknowledged. inst.mu must be held.
+func (inst *SOLInstance) makeOutboundLocked() {
+	if inst.pending != nil || len(inst.rx) == 0 {
+		return
 	}
 	take := min(len(inst.rx), SOLMaxPayloadChars)
 	inst.pending = append([]byte{}, inst.rx[:take]...)
@@ -940,7 +954,6 @@ func (inst *SOLInstance) makeOutboundLocked() []byte {
 	inst.outSeq = nextSOLSeq(inst.outSeq)
 	inst.retries = 0
 	inst.pendingSince = inst.clock.Now()
-	return inst.pending
 }
 
 // ProcessPacket handles one inbound SOL payload packet from the owning
@@ -949,12 +962,16 @@ func (inst *SOLInstance) makeOutboundLocked() []byte {
 func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *types.SOLPayloadPacket) *types.SOLPayloadPacket {
 	s.mu.Lock()
 	inst := s.inst
+	s.mu.Unlock()
 	if inst == nil || inst.SessionID != sessionID {
-		s.mu.Unlock()
 		return nil
 	}
-	s.mu.Unlock()
+	return inst.ProcessPacket(ctx, in)
+}
 
+// ProcessPacket handles one inbound SOL payload packet (spec v2.0
+// §15.9/§15.11, Table 15-3) and produces the response packet.
+func (inst *SOLInstance) ProcessPacket(ctx context.Context, in *types.SOLPayloadPacket) *types.SOLPayloadPacket {
 	inst.mu.Lock()
 	defer inst.mu.Unlock()
 	if inst.conn == nil && !inst.broken {
@@ -966,11 +983,10 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 	// The console is acknowledging our pending outbound packet (Table 15-3).
 	if in.AckedSequenceNumber != 0 && inst.pending != nil && in.AckedSequenceNumber == inst.outSeq {
 		switch {
-		case in.NACK:
-			// Suspend NACK: stop sending/retrying the pending packet until a
+		case in.NACK && in.AcceptedCharacterCount == 0:
+			// Suspend NACK (Table 15-3): the console cannot accept SOL data
+			// right now. Stop sending/retrying the pending packet until a
 			// Partial/Completion ACK, Resume ACK, or Flush Outbound arrives.
-			// (A console→BMC NACK with a non-zero count is not defined by
-			// Table 15-3; suspending is the lossless reading.)
 			inst.suspended = true
 		case in.AcceptedCharacterCount == 0:
 			inst.suspended = false // Resume ACK: pending rides this response
@@ -978,8 +994,17 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 			inst.pending = nil // Completion ACK
 			inst.suspended = false
 		default:
-			// Partial ACK: retransmit the unaccepted remainder (Table 15-3).
+			// Partial ACK — a NACK with a non-zero count reads the same
+			// (rev 1.1: NACK means "some or all data could not be accepted",
+			// count meaningful): retransmit the unaccepted remainder as a
+			// fresh packet. A same-sequence resend would look like the
+			// original packet to consoles deduping by sequence number, and
+			// ipmitool's character-offset logic would see zero new bytes in
+			// a shorter retransmission (§15.11), so the remainder advances
+			// the sequence number.
 			inst.pending = inst.pending[in.AcceptedCharacterCount:]
+			inst.outSeq = nextSOLSeq(inst.outSeq)
+			inst.retries = 0
 			inst.suspended = false
 		}
 	}
@@ -993,8 +1018,9 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 		inst.rx = nil
 		inst.suspended = false
 	}
-	// Flush Inbound (bit [1]) needs no action: inbound keystrokes are written
-	// to the system console synchronously, so no BMC-side buffer exists.
+	// Flush Inbound (bit [1]) needs no instance-side action: keystrokes are
+	// written to the system console synchronously, and the server layer
+	// drops the session's not-yet-processed queued packets on flush.
 
 	// Inbound operations and character data. ACK-only packets (seq 0h) carry
 	// no data and are never acknowledged (§15.11).
@@ -1049,14 +1075,6 @@ func (s *SOLStore) ProcessPacket(ctx context.Context, sessionID uint32, in *type
 	out.AckedSequenceNumber = inst.inSeq
 	out.AcceptedCharacterCount = accepted
 	out.NACK = nack
-	if inst.broken {
-		// Status bit [5]: character transfer is unavailable (Table 15-2,
-		// BMC→console status), e.g. system powered down or console gone.
-		out.ControlByte |= 0x20
-	}
-	if inst.overrun {
-		out.ControlByte |= 0x08 // status [3]: characters dropped since the previous packet
-		inst.overrun = false
-	}
+	inst.applyStatusLocked(out)
 	return out
 }

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -146,7 +146,7 @@ func TestSOLActivateRules(t *testing.T) {
 	t.Run("user payload access revoked", func(t *testing.T) {
 		b, _ := newConsoleBMC(t)
 		sess := newSOLTestSession(t, b)
-		sess.User.PayloadAccessFor(1).Standard1 = 0 // SOL bit cleared
+		sess.User.SetPayloadAccess(1, false, 2, 0) // SOL bit cleared
 		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLPrivilege) {
 			t.Fatalf("got %v, want ErrSOLPrivilege", err)
 		}
@@ -827,10 +827,11 @@ func TestSOLReconnectKeepsPending(t *testing.T) {
 
 	// Keep the unacknowledged packet alive across the outage: the retry
 	// engine would drop it after its retries are exhausted (§15.11), which
-	// is unrelated to the reconnect — widen the window (200 × 10ms) and
-	// retry immediately so only the reconnect could be responsible for
-	// losing it.
-	if cc := b.SOL.Config().SetParam(4, []byte{200, 1}); cc != types.CodeOK {
+	// is unrelated to the reconnect — widen the window so only the
+	// reconnect could be responsible for losing it. The retry count is a
+	// 3-bit field (Table 26-5 #4), so the maximum is 7 retries × a 2.55 s
+	// interval ≈ 18 s, far beyond the test's duration.
+	if cc := b.SOL.Config().SetParam(4, []byte{7, 255}); cc != types.CodeOK {
 		t.Fatalf("set retry: CC %#02x", cc)
 	}
 	b.SOL.SetReconnectPolicy(&ReconnectPolicy{}) // Initial 0: reconnect immediately
@@ -901,54 +902,86 @@ func TestSOLReconnectWriteErrorTriggers(t *testing.T) {
 	}
 }
 
-// TestSOLReconnectBackoff verifies the exponential backoff between failed
-// reconnect attempts: the first fires immediately, later failures double
-// the delay (bounded by consoleReconnectMax), and no attempt fires early.
+// TestSOLReconnectBackoff verifies the exponential backoff of the reconnect
+// state machine: the first failure arms Delay(1), no attempt fires before
+// the armed time, and each failed attempt doubles the wait. reconnectLocked
+// takes the current time as a parameter, so the sequence is driven directly
+// with explicit times — no wall-clock measurement, which is what made the
+// pump-driven version flaky under load.
 func TestSOLReconnectBackoff(t *testing.T) {
 	fake1 := &mock.FakeConsoleConn{}
-	var opens atomic.Int32
-	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
-		opens.Add(1)
-		if opens.Load() == 1 {
+	opens := 0
+	m := mock.New()
+	m.SetConsole(&mock.Console{OpenHook: func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
 			return fake1, nil
 		}
 		return nil, errors.New("console unreachable")
-	})
+	}})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	// No sender factory: the pump never starts, so reconnectLocked below is
+	// the only driver of the state machine.
+	b.SOL.SetReconnectPolicy(&DefaultReconnectPolicy)
+	sess := newSOLTestSession(t, b)
 	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
 	if err != nil {
 		t.Fatalf("activate: %v", err)
 	}
 	t.Cleanup(b.SOL.CloseAll)
 
-	fake1.SetReadErr(errors.New("console died"))
-
-	// First attempt is immediate; its failure arms the 1s backoff.
-	waitForCondition(t, func() bool { return opens.Load() >= 2 })
+	// Mark the console broken as the pump would after a read failure.
 	inst.mu.Lock()
-	armed := inst.reconnectAt.Sub(inst.clock.Now())
+	inst.broken = true
 	inst.mu.Unlock()
-	if armed < 900*time.Millisecond || armed > 2*time.Second {
-		t.Fatalf("first backoff armed at %v, want ~1s", armed)
-	}
 
-	// No early retry while backing off.
-	time.Sleep(300 * time.Millisecond)
-	if opens.Load() > 2 {
-		t.Fatalf("reconnect fired early (opens=%d)", opens.Load())
-	}
+	t0 := b.Clock().Now()
 
-	// After the 1s backoff the second attempt fires, and its failure arms
-	// the next delay from the policy (1s, 2s, 4s, ... sequence).
-	waitForCondition(t, func() bool { return opens.Load() >= 3 })
+	// First failure: releases the dead conn and arms Delay(1) = 1s.
 	inst.mu.Lock()
-	failures := inst.failures
-	armed = inst.reconnectAt.Sub(inst.clock.Now())
+	inst.reconnectLocked(t0)
 	inst.mu.Unlock()
-	if failures != 3 {
-		t.Fatalf("failures after 2nd failure: %d, want 3", failures)
+	if opens != 1 || inst.failures != 1 {
+		t.Fatalf("after first failure: opens=%d failures=%d, want 1/1", opens, inst.failures)
 	}
-	if armed < 1900*time.Millisecond {
-		t.Fatalf("second backoff armed at %v, want ~2s", armed)
+	if !inst.reconnectAt.Equal(t0.Add(time.Second)) {
+		t.Fatalf("first backoff armed at %v, want 1s", inst.reconnectAt.Sub(t0))
+	}
+	if !fake1.IsClosed() {
+		t.Fatal("dead console conn not closed")
+	}
+
+	// No attempt fires before reconnectAt.
+	inst.mu.Lock()
+	inst.reconnectLocked(t0.Add(100 * time.Millisecond))
+	inst.mu.Unlock()
+	if opens != 1 {
+		t.Fatalf("reconnect fired early (opens=%d)", opens)
+	}
+
+	// The attempt at reconnectAt fails and doubles the wait: Delay(2) = 2s.
+	// The re-arm is computed from the post-dial clock (the dial is instant
+	// here), so the armed time is t0 + 1s + ε + 2s — assert the range
+	// rather than exact equality.
+	inst.mu.Lock()
+	inst.reconnectLocked(t0.Add(time.Second))
+	inst.mu.Unlock()
+	if opens != 2 || inst.failures != 2 {
+		t.Fatalf("after 2nd failure: opens=%d failures=%d, want 2/2", opens, inst.failures)
+	}
+	if !inst.reconnectAt.After(t0.Add(2*time.Second)) || inst.reconnectAt.After(t0.Add(2*time.Second+100*time.Millisecond)) {
+		t.Fatalf("second backoff armed at %v, want ~2s after the failed attempt", inst.reconnectAt.Sub(t0))
+	}
+
+	// Next failure quadruples: Delay(3) = 4s.
+	inst.mu.Lock()
+	inst.reconnectLocked(t0.Add(3 * time.Second))
+	inst.mu.Unlock()
+	if opens != 3 || inst.failures != 3 {
+		t.Fatalf("after 3rd failure: opens=%d failures=%d, want 3/3", opens, inst.failures)
+	}
+	if !inst.reconnectAt.After(t0.Add(4*time.Second)) || inst.reconnectAt.After(t0.Add(4*time.Second+100*time.Millisecond)) {
+		t.Fatalf("third backoff armed at %v, want ~4s after the failed attempt", inst.reconnectAt.Sub(t0))
 	}
 }
 
@@ -1042,23 +1075,31 @@ func TestDefaultReconnectPolicy(t *testing.T) {
 			t.Fatalf("Delay(%d): got %v giveUp=%v, want %v/false", i+1, got, giveUp, w)
 		}
 	}
+	// Far past the int64-nanosecond overflow point of the raw
+	// Initial*Factor^(n-1) multiply (~35 failures), the delay must stay
+	// clamped at the cap — a wrapped value would be negative, i.e. already
+	// in the past, turning the backoff into a busy retry loop.
+	if got, giveUp := DefaultReconnectPolicy.Delay(100); got != 30*time.Second || giveUp {
+		t.Fatalf("Delay(100): got %v giveUp=%v, want 30s/false", got, giveUp)
+	}
 }
 
 // TestReconnectPolicySteps verifies Steps bounds the attempts and Jitter
 // stays within the declared range.
 func TestReconnectPolicySteps(t *testing.T) {
 	p := ReconnectPolicy{Initial: 100 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: time.Second, Steps: 3}
-	// 3 reconnect attempts: failures 1..2 keep going, failure 3 gives up.
-	for i := 1; i <= 2; i++ {
+	// 3 reconnect attempts: failures 1..3 keep going, failure 4 gives up
+	// (failures includes the console failure that started the cycle).
+	for i := 1; i <= 3; i++ {
 		if _, giveUp := p.Delay(i); giveUp {
 			t.Fatalf("Delay(%d): gave up early", i)
 		}
 	}
-	if _, giveUp := p.Delay(3); !giveUp {
-		t.Fatal("Delay(3): want give-up past Steps")
+	if _, giveUp := p.Delay(4); !giveUp {
+		t.Fatal("Delay(4): want give-up past Steps")
 	}
 	// Jitter keeps the wait within [base, base*(1+Jitter)).
-	for i := 1; i <= 2; i++ {
+	for i := 1; i <= 3; i++ {
 		base := p.Initial * time.Duration(1<<(i-1))
 		got, _ := p.Delay(i)
 		if got < base || got >= base+time.Duration(float64(base)*p.Jitter) {
@@ -1178,5 +1219,74 @@ func TestSOLReconnectGiveUpAfterSteps(t *testing.T) {
 	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
 	if out.ControlByte&0x20 == 0 {
 		t.Fatalf("after give-up: control %#02x missing status bit [5]", out.ControlByte)
+	}
+}
+
+// TestSOLReconnectSlowDialReArms verifies the next attempt is re-armed from
+// when a slow dial finished, not from the pre-dial tick time: a dial that
+// burns most of the wait must not leave reconnectAt in the past and
+// collapse the backoff into back-to-back attempts.
+func TestSOLReconnectSlowDialReArms(t *testing.T) {
+	opens := 0
+	m := mock.New()
+	m.SetConsole(&mock.Console{OpenHook: func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return &mock.FakeConsoleConn{}, nil
+		}
+		time.Sleep(300 * time.Millisecond) // slow dial: burns 300ms of Delay(1)
+		return nil, errors.New("console unreachable")
+	}})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	b.SOL.SetReconnectPolicy(&DefaultReconnectPolicy)
+	sess := newSOLTestSession(t, b)
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	inst.mu.Lock()
+	inst.broken = true
+	inst.mu.Unlock()
+
+	t0 := b.Clock().Now()
+
+	inst.mu.Lock()
+	inst.reconnectLocked(t0) // first failure: arms Delay(1) = 1s
+	inst.mu.Unlock()
+
+	// Dial at the forged now = t0 + 1s; the hook blocks 300ms then fails.
+	// The re-arm must be Delay(2) from the post-dial time, so the gap to
+	// wall time right after the call is still ~2s — re-arming from the
+	// pre-dial now would leave ~1s of the wait already consumed (the forged
+	// 1s gap), measured here as a gap well under 2s.
+	inst.mu.Lock()
+	inst.reconnectLocked(t0.Add(time.Second))
+	inst.mu.Unlock()
+	if gap := time.Until(inst.reconnectAt); gap < 2*time.Second-50*time.Millisecond {
+		t.Fatalf("reconnectAt %v (gap %v), want ~2s from the post-dial time", inst.reconnectAt, gap)
+	}
+}
+
+// TestSOLAckOnlyReplaysAcceptedCount verifies the response to an ACK-only
+// packet echoes the accepted count of the data packet it acknowledges
+// (Table 15-3): reporting 0 for a non-empty packet would make a strict
+// console resend already-delivered keystrokes.
+func TestSOLAckOnlyReplaysAcceptedCount(t *testing.T) {
+	b, _ := newConsoleBMC(t)
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 3, CharacterData: []byte("abc")})
+	if out.AckedSequenceNumber != 3 || out.AcceptedCharacterCount != 3 {
+		t.Fatalf("data response: acked=%d accept=%d, want 3/3", out.AckedSequenceNumber, out.AcceptedCharacterCount)
+	}
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.AckedSequenceNumber != 3 || out.AcceptedCharacterCount != 3 {
+		t.Fatalf("ack-only response: acked=%d accept=%d, want 3/3", out.AckedSequenceNumber, out.AcceptedCharacterCount)
 	}
 }

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -313,17 +313,19 @@ func TestSOLProcessOutboundData(t *testing.T) {
 		t.Fatalf("resume: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "hello")
 	}
 
-	// Partial ACK of 2 chars (Table 15-3): retransmit only the remainder.
+	// Partial ACK of 2 chars (Table 15-3): retransmit the remainder as a
+	// fresh packet — a same-sequence resend would yield zero new bytes to
+	// consoles computing new data by character offset (§15.11).
 	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, AcceptedCharacterCount: 2})
-	if out.SequenceNumber != 1 || string(out.CharacterData) != "llo" {
-		t.Fatalf("partial resend: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "llo")
+	if out.SequenceNumber != 2 || string(out.CharacterData) != "llo" {
+		t.Fatalf("partial resend: seq=%d data=%q, want 2/%q", out.SequenceNumber, out.CharacterData, "llo")
 	}
 
 	// Completion ACK frees the sequence; fresh output gets the next number.
 	fake.RX = []byte("world")
-	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, AcceptedCharacterCount: 3})
-	if out.SequenceNumber != 2 || string(out.CharacterData) != "world" {
-		t.Fatalf("next: seq=%d data=%q, want 2/%q", out.SequenceNumber, out.CharacterData, "world")
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 2, AcceptedCharacterCount: 3})
+	if out.SequenceNumber != 3 || string(out.CharacterData) != "world" {
+		t.Fatalf("next: seq=%d data=%q, want 3/%q", out.SequenceNumber, out.CharacterData, "world")
 	}
 }
 
@@ -546,7 +548,7 @@ func TestSOLPumpAsyncPush(t *testing.T) {
 	}
 }
 
-// TestSOLDeactivateSendsStatus verifies the one-time NACK packet with
+// TestSOLDeactivateSendsStatus verifies the one-time status packet with
 // status bit [4] (Table 15-2 footnote 2) issued on deactivation paths.
 func TestSOLDeactivateSendsStatus(t *testing.T) {
 	fake := &mock.FakeConsoleConn{}
@@ -560,8 +562,8 @@ func TestSOLDeactivateSendsStatus(t *testing.T) {
 		t.Fatalf("deactivate: %v", err)
 	}
 	pkts := cap.all()
-	if len(pkts) != 1 || !pkts[0].NACK || pkts[0].ControlByte&0x10 == 0 || pkts[0].SequenceNumber != 0 {
-		t.Fatalf("deactivation packet: %+v, want ACK-only NACK with status [4]", pkts)
+	if len(pkts) != 1 || pkts[0].NACK || pkts[0].ControlByte&0x10 == 0 || pkts[0].SequenceNumber != 0 {
+		t.Fatalf("deactivation packet: %+v, want ACK-only with status [4]", pkts)
 	}
 
 	// Session termination (Close Session path, §24.2) issues the same status.
@@ -572,8 +574,8 @@ func TestSOLDeactivateSendsStatus(t *testing.T) {
 		t.Fatalf("close session: %v", err)
 	}
 	pkts = cap.all()
-	if len(pkts) != 2 || !pkts[1].NACK || pkts[1].ControlByte&0x10 == 0 {
-		t.Fatalf("session-close packet: %+v, want NACK with status [4]", pkts[1:])
+	if len(pkts) != 2 || pkts[1].NACK || pkts[1].ControlByte&0x10 == 0 {
+		t.Fatalf("session-close packet: %+v, want status [4]", pkts[1:])
 	}
 }
 

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -676,5 +677,456 @@ func TestSOLPumpRetryAndDrop(t *testing.T) {
 	}
 	if pkts[3].ControlByte&0x08 == 0 {
 		t.Fatalf("after drop: control %#02x missing transmit-overrun bit", pkts[3].ControlByte)
+	}
+}
+
+// --- console reconnect (recovery from a failed console conn) ---
+
+// newReconnectBMC builds a pump BMC whose console Open is driven by hook,
+// returning the BMC, an active session, and the async send capture.
+func newReconnectBMC(t *testing.T, hook func(context.Context) (hal.ConsoleConn, error)) (*BMC, *Session, *pumpCapture) {
+	t.Helper()
+	m := mock.New()
+	m.SetConsole(&mock.Console{OpenHook: hook})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	// Reconnection is opt-in; the helper enables the default policy so the
+	// reconnect tests exercise the feature rather than the disabled default.
+	b.SOL.SetReconnectPolicy(&DefaultReconnectPolicy)
+	cap := &pumpCapture{}
+	b.SOL.SetSenderFactory(func(sess *Session, inst *SOLInstance) SOLSendFunc { return cap.send })
+	sess := newSOLTestSession(t, b)
+	sess.Addr = &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5000}
+	return b, sess, cap
+}
+
+func waitForCondition(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}
+
+func instBroken(inst *SOLInstance) bool {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	return inst.broken
+}
+
+// TestSOLReconnectRecovers verifies the full recovery cycle: a failing
+// console conn flips the instance broken (NACK + status bit [5]), the pump
+// re-attaches via the HAL Open, and the data plane resumes — with the
+// pre-failure RX residue dropped (it belongs to the dead console session).
+func TestSOLReconnectRecovers(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	opens := 0
+	// release gates the first reconnect: the outage window is only one pump
+	// tick wide, so the test holds the reconnect until the broken-state
+	// behavior (NACK + status bit [5]) has been observed.
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReconnect := func() { releaseOnce.Do(func() { close(release) }) }
+	// Any failed assertion must not strand the pump (which CloseAll waits
+	// for), so the gate is always released before cleanup runs.
+	t.Cleanup(releaseReconnect)
+	b, sess, cap := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return fake1, nil // activation
+		}
+		<-release // hold the reconnect while the outage is verified
+		return fake2, nil
+	})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	// One normal output round, acknowledged, so pending is non-empty when
+	// the console dies: the reconnect must keep that pending state.
+	fake1.FeedRX([]byte("hello"))
+	pkts := waitForPkt(t, cap, 1)
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: pkts[0].SequenceNumber, AcceptedCharacterCount: 5})
+
+	// Console dies; anything queued on it afterwards is stale residue.
+	fake1.SetReadErr(errors.New("console died"))
+	fake1.FeedRX([]byte("stale"))
+
+	waitForCondition(t, func() bool { return instBroken(inst) })
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 2, CharacterData: []byte("k")})
+	if !out.NACK {
+		t.Fatalf("keystroke during outage: NACK=%v, want true", out.NACK)
+	}
+	if out.ControlByte&0x20 == 0 {
+		t.Fatalf("keystroke during outage: control %#02x missing status bit [5]", out.ControlByte)
+	}
+
+	// Release the reconnect: it fires immediately, releasing the dead conn.
+	releaseReconnect()
+	waitForCondition(t, func() bool { return !instBroken(inst) })
+	if !fake1.IsClosed() {
+		t.Fatalf("dead console conn not closed")
+	}
+
+	// Keystrokes reach the fresh console, and its output flows on — the
+	// stale residue from the dead console is not forwarded.
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 3, CharacterData: []byte("x")})
+	if got := fake2.TXString(); got != "x" {
+		t.Fatalf("keystroke after reconnect: TX %q, want %q", got, "x")
+	}
+	fake2.FeedRX([]byte("fresh"))
+	pkts = waitForPkt(t, cap, 2)
+	if string(pkts[1].CharacterData) != "fresh" {
+		t.Fatalf("after reconnect: data %q, want %q (stale residue must be dropped)", pkts[1].CharacterData, "fresh")
+	}
+
+	// Output continues after the reconnect. ACK the "fresh" packet first so
+	// the retry engine does not re-send it while the next chunk accumulates.
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: pkts[1].SequenceNumber, AcceptedCharacterCount: 5})
+	fake2.FeedRX([]byte("second"))
+	waitForCondition(t, func() bool {
+		for _, p := range cap.all() {
+			if string(p.CharacterData) == "second" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// TestSOLReconnectKeepsPending verifies the unacknowledged outbound packet
+// survives the reconnect: the remote console still owes its ACK
+// (Table 15-3), so the pump must keep it rather than treat the new console
+// as a fresh start.
+func TestSOLReconnectKeepsPending(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	opens := 0
+	b, sess, cap := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return fake1, nil
+		}
+		return fake2, nil
+	})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	// Keep the unacknowledged packet alive across the outage: the retry
+	// engine would drop it after its retries are exhausted (§15.11), which
+	// is unrelated to the reconnect — widen the window (200 × 10ms) and
+	// retry immediately so only the reconnect could be responsible for
+	// losing it.
+	if cc := b.SOL.Config().SetParam(4, []byte{200, 1}); cc != types.CodeOK {
+		t.Fatalf("set retry: CC %#02x", cc)
+	}
+	b.SOL.SetReconnectPolicy(&ReconnectPolicy{}) // Initial 0: reconnect immediately
+
+	fake1.FeedRX([]byte("abc"))
+	pkts := waitForPkt(t, cap, 1) // seq 1, unacknowledged
+	// Break the console via the keystroke path: while pending != nil the
+	// pump never reads the console, so a read failure could not flip broken
+	// before the retry engine dropped the pending packet — a write failure
+	// in ProcessPacket can, leaving pending untouched.
+	fake1.SetWriteErr(errors.New("console died"))
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 2, CharacterData: []byte("k")})
+	if !out.NACK {
+		t.Fatalf("keystroke on failing console: NACK=%v, want true", out.NACK)
+	}
+	waitForCondition(t, func() bool { return instBroken(inst) })
+	waitForCondition(t, func() bool { return !instBroken(inst) })
+
+	inst.mu.Lock()
+	pending := inst.pending != nil
+	inst.mu.Unlock()
+	if !pending {
+		t.Fatalf("reconnect dropped the unacknowledged pending packet")
+	}
+
+	// The pre-outage ACK is still honored after the reconnect.
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: pkts[0].SequenceNumber, AcceptedCharacterCount: 3})
+	inst.mu.Lock()
+	pending = inst.pending != nil
+	inst.mu.Unlock()
+	if pending {
+		t.Fatalf("pending not cleared by ACK after reconnect")
+	}
+}
+
+// TestSOLReconnectWriteErrorTriggers verifies that a failing console Write
+// (keystroke path) also starts the reconnect cycle.
+func TestSOLReconnectWriteErrorTriggers(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	opens := 0
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return fake1, nil
+		}
+		return fake2, nil
+	})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake1.SetWriteErr(errors.New("console write failed"))
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 5, CharacterData: []byte("k")})
+	if !out.NACK {
+		t.Fatalf("keystroke on failing console: NACK=%v, want true", out.NACK)
+	}
+
+	waitForCondition(t, func() bool { return !instBroken(inst) })
+	if !fake1.IsClosed() {
+		t.Fatalf("dead console conn not closed")
+	}
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 6, CharacterData: []byte("y")})
+	if got := fake2.TXString(); got != "y" {
+		t.Fatalf("keystroke after reconnect: TX %q, want %q", got, "y")
+	}
+}
+
+// TestSOLReconnectBackoff verifies the exponential backoff between failed
+// reconnect attempts: the first fires immediately, later failures double
+// the delay (bounded by consoleReconnectMax), and no attempt fires early.
+func TestSOLReconnectBackoff(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	var opens atomic.Int32
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens.Add(1)
+		if opens.Load() == 1 {
+			return fake1, nil
+		}
+		return nil, errors.New("console unreachable")
+	})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake1.SetReadErr(errors.New("console died"))
+
+	// First attempt is immediate; its failure arms the 1s backoff.
+	waitForCondition(t, func() bool { return opens.Load() >= 2 })
+	inst.mu.Lock()
+	armed := inst.reconnectAt.Sub(inst.clock.Now())
+	inst.mu.Unlock()
+	if armed < 900*time.Millisecond || armed > 2*time.Second {
+		t.Fatalf("first backoff armed at %v, want ~1s", armed)
+	}
+
+	// No early retry while backing off.
+	time.Sleep(300 * time.Millisecond)
+	if opens.Load() > 2 {
+		t.Fatalf("reconnect fired early (opens=%d)", opens.Load())
+	}
+
+	// After the 1s backoff the second attempt fires, and its failure arms
+	// the next delay from the policy (1s, 2s, 4s, ... sequence).
+	waitForCondition(t, func() bool { return opens.Load() >= 3 })
+	inst.mu.Lock()
+	failures := inst.failures
+	armed = inst.reconnectAt.Sub(inst.clock.Now())
+	inst.mu.Unlock()
+	if failures != 3 {
+		t.Fatalf("failures after 2nd failure: %d, want 3", failures)
+	}
+	if armed < 1900*time.Millisecond {
+		t.Fatalf("second backoff armed at %v, want ~2s", armed)
+	}
+}
+
+// TestSOLReconnectDeactivateWhileBroken verifies deactivation completes
+// while the reconnect cycle is backing off (no hang, conn released).
+func TestSOLReconnectDeactivateWhileBroken(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	var opens atomic.Int32
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens.Add(1)
+		if opens.Load() == 1 {
+			return fake1, nil
+		}
+		return nil, errors.New("console unreachable")
+	})
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	fake1.SetReadErr(errors.New("console died"))
+	waitForCondition(t, func() bool { return opens.Load() >= 2 }) // backing off
+
+	done := make(chan error, 1)
+	go func() { done <- b.SOL.Deactivate(sess) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("deactivate: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("deactivate hung during reconnect backoff")
+	}
+	if !fake1.IsClosed() {
+		t.Fatalf("dead console conn not closed on deactivate")
+	}
+}
+
+func TestDefaultReconnectPolicy(t *testing.T) {
+	// Interval sequence: 1s initial, doubling capped at 30s; retries
+	// forever (Steps 0).
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, 30 * time.Second, 30 * time.Second}
+	for i, w := range want {
+		got, giveUp := DefaultReconnectPolicy.Delay(i + 1)
+		if got != w || giveUp {
+			t.Fatalf("Delay(%d): got %v giveUp=%v, want %v/false", i+1, got, giveUp, w)
+		}
+	}
+}
+
+// TestReconnectPolicySteps verifies Steps bounds the attempts and Jitter
+// stays within the declared range.
+func TestReconnectPolicySteps(t *testing.T) {
+	p := ReconnectPolicy{Initial: 100 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: time.Second, Steps: 3}
+	// 3 reconnect attempts: failures 1..2 keep going, failure 3 gives up.
+	for i := 1; i <= 2; i++ {
+		if _, giveUp := p.Delay(i); giveUp {
+			t.Fatalf("Delay(%d): gave up early", i)
+		}
+	}
+	if _, giveUp := p.Delay(3); !giveUp {
+		t.Fatal("Delay(3): want give-up past Steps")
+	}
+	// Jitter keeps the wait within [base, base*(1+Jitter)).
+	for i := 1; i <= 2; i++ {
+		base := p.Initial * time.Duration(1<<(i-1))
+		got, _ := p.Delay(i)
+		if got < base || got >= base+time.Duration(float64(base)*p.Jitter) {
+			t.Fatalf("Delay(%d) jittered to %v, want within [%v, %v)", i, got, base, base+time.Duration(float64(base)*p.Jitter))
+		}
+	}
+}
+
+// TestSOLReconnectDisabled verifies the opt-out (nil ReconnectPolicy):
+// the dead conn is released once, no further Open attempts happen, and the
+// payload keeps reporting status bit [5] until deactivation — the
+// spec-defined behavior without the reconnect enhancement.
+func TestSOLReconnectDisabled(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	var opens atomic.Int32
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens.Add(1)
+		return fake1, nil
+	})
+	b.SOL.SetReconnectPolicy(nil)
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake1.SetReadErr(errors.New("console died"))
+	waitForCondition(t, func() bool { return instBroken(inst) })
+
+	time.Sleep(300 * time.Millisecond)
+	if opens.Load() != 1 {
+		t.Fatalf("reconnect attempted despite disabled policy (opens=%d)", opens.Load())
+	}
+	if !fake1.IsClosed() {
+		t.Fatalf("dead console conn not released")
+	}
+
+	// The payload keeps answering with status bit [5] so the remote console
+	// can tell the outage apart from a dead BMC.
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.ControlByte&0x20 == 0 {
+		t.Fatalf("disabled reconnect: control %#02x missing status bit [5]", out.ControlByte)
+	}
+}
+
+// TestSOLReconnectCustomPolicy verifies a caller-supplied ReconnectPolicy
+// drives both the first-retry decision and the later backoff, receiving the
+// consecutive failure count (1-based).
+func TestSOLReconnectCustomPolicy(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	var opens atomic.Int32
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens.Add(1)
+		switch opens.Load() {
+		case 1:
+			return fake1, nil // activation
+		case 2:
+			return nil, errors.New("still down") // first retry fails
+		}
+		return fake2, nil // second retry succeeds
+	})
+	// Fixed 100ms retry schedule: the first retry waits 100ms (Initial),
+	// the second (which succeeds) another 100ms (Factor 1).
+	b.SOL.SetReconnectPolicy(&ReconnectPolicy{Initial: 100 * time.Millisecond, Factor: 1, Cap: 100 * time.Millisecond})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake1.SetReadErr(errors.New("console died"))
+	// opens reaching 3 anchors both retries: the first failed, the second
+	// (100ms later) succeeded.
+	waitForCondition(t, func() bool { return opens.Load() >= 3 })
+	waitForCondition(t, func() bool { return !instBroken(inst) })
+	if !fake1.IsClosed() {
+		t.Fatalf("dead console conn not closed")
+	}
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 7, CharacterData: []byte("z")})
+	if got := fake2.TXString(); got != "z" {
+		t.Fatalf("keystroke after custom-policy reconnect: TX %q, want %q", got, "z")
+	}
+}
+
+// TestSOLReconnectGiveUpAfterSteps verifies a policy with bounded Steps:
+// once the attempts are exhausted the instance stops reconnecting and
+// behaves like the disabled default (status bit [5], no further Opens).
+func TestSOLReconnectGiveUpAfterSteps(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	var opens atomic.Int32
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens.Add(1)
+		if opens.Load() == 1 {
+			return fake1, nil
+		}
+		return nil, errors.New("console unreachable")
+	})
+	// One immediate retry (Steps 1), then give up.
+	b.SOL.SetReconnectPolicy(&ReconnectPolicy{Steps: 1})
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake1.SetReadErr(errors.New("console died"))
+	// First retry fires immediately and fails; after that, no more.
+	waitForCondition(t, func() bool { return opens.Load() >= 2 })
+	time.Sleep(300 * time.Millisecond)
+	if opens.Load() > 2 {
+		t.Fatalf("reconnect continued past Steps (opens=%d)", opens.Load())
+	}
+	if !instBroken(inst) {
+		t.Fatal("instance recovered despite Steps exhaustion")
+	}
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.ControlByte&0x20 == 0 {
+		t.Fatalf("after give-up: control %#02x missing status bit [5]", out.ControlByte)
 	}
 }

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -3,7 +3,9 @@ package bmc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -952,6 +954,52 @@ func TestSOLReconnectBackoff(t *testing.T) {
 
 // TestSOLReconnectDeactivateWhileBroken verifies deactivation completes
 // while the reconnect cycle is backing off (no hang, conn released).
+// TestSOLReconnectTrace verifies the reconnect emits a trace line naming the
+// failed-attempt count, so an operator watching the trace can see the console
+// came back after an outage.
+func TestSOLReconnectTrace(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	opens := 0
+	b, sess, _ := newReconnectBMC(t, func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return fake1, nil
+		}
+		return fake2, nil
+	})
+	// Fast policy so the test does not wait out the 1s default backoff.
+	b.SOL.SetReconnectPolicy(&ReconnectPolicy{Initial: 10 * time.Millisecond})
+
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	inst, err := b.SOL.Activate(context.Background(), sess, false, false)
+	if err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+	inst.SetTracef(func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, fmt.Sprintf(format, args...))
+	})
+
+	fake1.SetReadErr(errors.New("console died"))
+	waitForCondition(t, func() bool { return instBroken(inst) })
+	waitForCondition(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(lines) > 0
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(lines[0], "console reconnected after 1 failed attempt") {
+		t.Fatalf("reconnect trace = %q, want failure count 1", lines[0])
+	}
+}
+
 func TestSOLReconnectDeactivateWhileBroken(t *testing.T) {
 	fake1 := &mock.FakeConsoleConn{}
 	var opens atomic.Int32

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -1,0 +1,680 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// newSOLTestSession returns an active-looking session for SOL activation
+// tests: admin privilege, AES + HMAC-SHA1 negotiated, user with default
+// payload access on channel 1.
+func newSOLTestSession(t *testing.T, b *BMC) *Session {
+	t.Helper()
+	sess, err := b.Sessions.Allocate(0xA5A5A5A5, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	sess.State = SessionStateActive
+	sess.Channel = 1
+	sess.PrivilegeLevel = PrivilegeLevelAdministrator
+	sess.K2 = make([]byte, 16)
+	user, err := b.Users.GetByName("sol")
+	if err != nil {
+		user, err = b.Users.Add(2, "sol")
+		if err != nil {
+			t.Fatalf("add user: %v", err)
+		}
+	}
+	sess.User = user
+	return sess
+}
+
+func TestSOLConfigDefaults(t *testing.T) {
+	c := NewSOLConfig()
+	cases := []struct {
+		selector uint8
+		want     []byte
+	}{
+		{0, []byte{0x00}}, // set complete
+		{1, []byte{0x01}}, // enabled
+		{2, []byte{0x04}}, // no forcing, ADMINISTRATOR privilege
+		{3, []byte{10, SOLMaxPayloadChars}},
+		{4, []byte{3, 5}},
+		{5, []byte{0x0a}},       // 115.2k non-volatile
+		{6, []byte{0x0a}},       // 115.2k volatile
+		{7, []byte{0x01}},       // channel 1
+		{8, []byte{0x6f, 0x02}}, // 623 LE
+	}
+	for _, tc := range cases {
+		got, ok := c.GetParam(tc.selector)
+		if !ok {
+			t.Fatalf("param %d: not supported", tc.selector)
+		}
+		if string(got) != string(tc.want) {
+			t.Errorf("param %d: got %x, want %x", tc.selector, got, tc.want)
+		}
+	}
+	if _, ok := c.GetParam(9); ok {
+		t.Errorf("param 9 must not be supported")
+	}
+}
+
+func TestSOLConfigSetValidation(t *testing.T) {
+	c := NewSOLConfig()
+	cases := []struct {
+		name     string
+		selector uint8
+		data     []byte
+		wantCC   types.CompletionCode
+	}{
+		{"read-only channel", 7, []byte{2}, 0x82},
+		{"read-only port", 8, []byte{0, 0}, 0x82},
+		{"unknown param", 9, []byte{0}, types.CodeParameterNotSupported},
+		{"commit write unsupported", 0, []byte{2}, types.CodeRequestDataFieldInvalid},
+		{"set in progress", 0, []byte{1}, types.CodeOK},
+		// The table runs in order on one config: a second claim while the
+		// first is outstanding gets 81h (Table 26-3); set complete releases.
+		{"set in progress already claimed", 0, []byte{1}, 0x81},
+		{"set complete", 0, []byte{0}, types.CodeOK},
+		{"set in progress after complete", 0, []byte{1}, types.CodeOK},
+		{"set complete again", 0, []byte{0}, types.CodeOK},
+		{"privilege reserved value", 2, []byte{0x01}, types.CodeRequestDataFieldInvalid},
+		{"privilege operator", 2, []byte{0x03}, types.CodeOK},
+		{"zero accumulate interval", 3, []byte{0, 10}, types.CodeRequestDataFieldInvalid},
+		{"threshold too large", 3, []byte{10, 0xff}, types.CodeParameterOutOfRange},
+		{"char params ok", 3, []byte{5, 100}, types.CodeOK},
+		{"retry masks reserved bits", 4, []byte{0xff, 7}, types.CodeOK},
+		{"bit rate too low", 5, []byte{0x05}, types.CodeParameterOutOfRange},
+		{"bit rate serial-channel reserved", 5, []byte{0x00}, types.CodeParameterOutOfRange},
+		{"bit rate ok", 6, []byte{0x07}, types.CodeOK},
+	}
+	for _, tc := range cases {
+		if cc := c.SetParam(tc.selector, tc.data); cc != tc.wantCC {
+			t.Errorf("%s: got CC %#02x, want %#02x", tc.name, cc, tc.wantCC)
+		}
+	}
+	// retry count reserved bits [7:3] must not leak into the stored value
+	if got, _ := c.GetParam(4); got[0] != 0x07 {
+		t.Errorf("retry count: got %#02x, want 0x07 (reserved bits masked)", got[0])
+	}
+}
+
+func TestSOLActivateRules(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no console hardware", func(t *testing.T) {
+		m := mock.New() // Console.Conn nil → no console
+		b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLDisabled) {
+			t.Fatalf("got %v, want ErrSOLDisabled", err)
+		}
+	})
+
+	t.Run("config disabled", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		if cc := b.SOL.Config().SetParam(1, []byte{0}); cc != types.CodeOK {
+			t.Fatalf("disable SOL: CC %#02x", cc)
+		}
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLDisabled) {
+			t.Fatalf("got %v, want ErrSOLDisabled", err)
+		}
+	})
+
+	t.Run("privilege below configured level", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		sess.PrivilegeLevel = PrivilegeLevelOperator // config default is ADMINISTRATOR
+		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLPrivilege) {
+			t.Fatalf("got %v, want ErrSOLPrivilege", err)
+		}
+	})
+
+	t.Run("user payload access revoked", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		sess.User.PayloadAccessFor(1).Standard1 = 0 // SOL bit cleared
+		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLPrivilege) {
+			t.Fatalf("got %v, want ErrSOLPrivilege", err)
+		}
+	})
+
+	t.Run("encryption without authentication rejected", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, true, false); !errors.Is(err, ErrSOLEncryptionUnavailable) {
+			t.Fatalf("got %v, want ErrSOLEncryptionUnavailable", err)
+		}
+	})
+
+	t.Run("forced encryption refused when console declines", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		if cc := b.SOL.Config().SetParam(2, []byte{0x80 | 0x04}); cc != types.CodeOK {
+			t.Fatalf("force encryption: CC %#02x", cc)
+		}
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, false, false); !errors.Is(err, ErrSOLEncryptionRequired) {
+			t.Fatalf("got %v, want ErrSOLEncryptionRequired", err)
+		}
+	})
+
+	t.Run("second activation conflicts", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess1 := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess1, false, false); err != nil {
+			t.Fatalf("first activate: %v", err)
+		}
+		sess2 := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess2, false, false); !errors.Is(err, ErrSOLAlreadyActive) {
+			t.Fatalf("got %v, want ErrSOLAlreadyActive", err)
+		}
+		if cap, a1, _ := b.SOL.ActivationStatus(); cap != 1 || a1 != 0x01 {
+			t.Fatalf("activation status: cap=%d active=%#02x, want 1/0x01", cap, a1)
+		}
+	})
+
+	t.Run("volatile bit rate reloaded on activation", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		if cc := b.SOL.Config().SetParam(6, []byte{0x07}); cc != types.CodeOK {
+			t.Fatalf("set volatile bit rate: CC %#02x", cc)
+		}
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, false, false); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+		got, _ := b.SOL.Config().GetParam(6)
+		if got[0] != 0x0a { // §15.8: volatile copied from non-volatile at activation
+			t.Fatalf("volatile bit rate after activate: %#02x, want 0x0a", got[0])
+		}
+	})
+}
+
+// feed is a test shorthand for processing one inbound packet.
+func feed(t *testing.T, s *SOLStore, sess *Session, in *types.SOLPayloadPacket) *types.SOLPayloadPacket {
+	t.Helper()
+	out := s.ProcessPacket(context.Background(), sess.BMCID, in)
+	if out == nil {
+		t.Fatalf("ProcessPacket returned nil")
+	}
+	return out
+}
+
+func TestSOLProcessInboundData(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	// seq 1 carries "ab": fully accepted.
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("ab")})
+	if out.AcceptedCharacterCount != 2 || out.AckedSequenceNumber != 1 || out.NACK {
+		t.Fatalf("ack: %+v, want accepted=2 ackedSeq=1 ACK", out)
+	}
+	if string(fake.TX) != "ab" {
+		t.Fatalf("console TX %q, want %q", fake.TX, "ab")
+	}
+
+	// Retried seq 1 (same content per §15.9): re-ACK, no double write.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("ab")})
+	if out.AcceptedCharacterCount != 2 || string(fake.TX) != "ab" {
+		t.Fatalf("dup: accepted=%d TX=%q, want 2/%q", out.AcceptedCharacterCount, fake.TX, "ab")
+	}
+
+	// seq 2 with the BREAK operation bit set (Table 15-2 bit [4]).
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 2, ControlByte: 0x10, CharacterData: []byte("c")})
+	if fake.Breaks != 1 {
+		t.Fatalf("breaks=%d, want 1", fake.Breaks)
+	}
+	if out.AcceptedCharacterCount != 1 {
+		t.Fatalf("accepted=%d, want 1", out.AcceptedCharacterCount)
+	}
+
+	// A stranger session owns nothing.
+	if other := newSOLTestSession(t, b); b.SOL.ProcessPacket(context.Background(), other.BMCID, &types.SOLPayloadPacket{SequenceNumber: 9}) != nil {
+		t.Fatalf("packet from non-owner session must be ignored")
+	}
+}
+
+func TestSOLProcessInboundWriteFailure(t *testing.T) {
+	fake := &mock.FakeConsoleConn{WriteErr: errors.New("console gone")}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("x")})
+	if !out.NACK || out.AcceptedCharacterCount != 0 {
+		t.Fatalf("got NACK=%v accepted=%d, want NACK accepted=0", out.NACK, out.AcceptedCharacterCount)
+	}
+	// Table 15-2 status bit [5]: character transfer unavailable.
+	if out.ControlByte&0x20 == 0 {
+		t.Fatalf("status byte %#02x missing transfer-unavailable bit", out.ControlByte)
+	}
+}
+
+func TestSOLProcessOutboundData(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	fake.RX = []byte("hello")
+
+	// An empty poll (ACK-only, seq 0h) collects the pending console output.
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.SequenceNumber != 1 || string(out.CharacterData) != "hello" {
+		t.Fatalf("outbound: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "hello")
+	}
+
+	// A poll that does not acknowledge seq 1 gets the same packet again
+	// (§15.11 retry semantics; the BMC resends with the same sequence number).
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.SequenceNumber != 1 || string(out.CharacterData) != "hello" {
+		t.Fatalf("resend: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "hello")
+	}
+
+	// Suspend NACK for seq 1 (Table 15-3): the BMC stops sending the pending
+	// packet — the response is ACK-only — until the console resumes.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, NACK: true})
+	if out.SequenceNumber != 0 || len(out.CharacterData) != 0 {
+		t.Fatalf("suspend: seq=%d data=%q, want ACK-only response", out.SequenceNumber, out.CharacterData)
+	}
+
+	// While suspended even a plain poll must not resurrect the packet.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.SequenceNumber != 0 || len(out.CharacterData) != 0 {
+		t.Fatalf("suspended poll: seq=%d data=%q, want ACK-only response", out.SequenceNumber, out.CharacterData)
+	}
+
+	// Resume ACK (ACK with count 0, Table 15-3): retransmit immediately.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1})
+	if out.SequenceNumber != 1 || string(out.CharacterData) != "hello" {
+		t.Fatalf("resume: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "hello")
+	}
+
+	// Partial ACK of 2 chars (Table 15-3): retransmit only the remainder.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, AcceptedCharacterCount: 2})
+	if out.SequenceNumber != 1 || string(out.CharacterData) != "llo" {
+		t.Fatalf("partial resend: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "llo")
+	}
+
+	// Completion ACK frees the sequence; fresh output gets the next number.
+	fake.RX = []byte("world")
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, AcceptedCharacterCount: 3})
+	if out.SequenceNumber != 2 || string(out.CharacterData) != "world" {
+		t.Fatalf("next: seq=%d data=%q, want 2/%q", out.SequenceNumber, out.CharacterData, "world")
+	}
+}
+
+func TestSOLDeactivateLifecycle(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	// Deactivate by a non-owner session without the SOL privilege level
+	// (default ADMINISTRATOR) is refused.
+	other := newSOLTestSession(t, b)
+	other.PrivilegeLevel = PrivilegeLevelOperator
+	if err := b.SOL.Deactivate(other); !errors.Is(err, ErrSOLNotOwner) {
+		t.Fatalf("non-owner deactivate: got %v, want ErrSOLNotOwner", err)
+	}
+
+	// A non-owner session at the SOL privilege level may force-deactivate:
+	// the recovery path for consoles that crashed without deactivating.
+	other.PrivilegeLevel = PrivilegeLevelAdministrator
+	if err := b.SOL.Deactivate(other); err != nil {
+		t.Fatalf("admin force-deactivate: %v", err)
+	}
+	if _, a1, _ := b.SOL.ActivationStatus(); a1 != 0 {
+		t.Fatalf("instance still active after force-deactivate")
+	}
+	if !fake.Closed {
+		t.Fatalf("console conn not closed on force-deactivate")
+	}
+
+	// Re-activate, then §24.2: terminating the session auto-deactivates its
+	// payloads.
+	fake2 := &mock.FakeConsoleConn{}
+	m.Console().(*mock.Console).Conn = fake2
+	sess = newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("re-activate: %v", err)
+	}
+	if err := b.Sessions.Close(sess.BMCID); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+	if _, a1, _ := b.SOL.ActivationStatus(); a1 != 0 {
+		t.Fatalf("instance still active after session close")
+	}
+	if !fake2.Closed {
+		t.Fatalf("console conn not closed on session termination")
+	}
+
+	// Double deactivate reports "already deactivated" (Table 24-3, 80h).
+	if err := b.SOL.Deactivate(sess); !errors.Is(err, ErrSOLNotActive) {
+		t.Fatalf("double deactivate: got %v, want ErrSOLNotActive", err)
+	}
+}
+
+func TestSOLProcessRetryReplaysOriginalAccept(t *testing.T) {
+	fake := &mock.FakeConsoleConn{WriteLimit: 1}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	// seq 1 carries "ab" but the console only takes 1 byte: NACK + accepted=1.
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("ab")})
+	if !out.NACK || out.AcceptedCharacterCount != 1 {
+		t.Fatalf("partial: NACK=%v accepted=%d, want NACK/1", out.NACK, out.AcceptedCharacterCount)
+	}
+
+	// A lost response makes the console retry the packet unchanged (§15.9).
+	// The replay must report the original partial accept — ACKing both bytes
+	// here would lose "b", which was never written to the console.
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("ab")})
+	if !out.NACK || out.AcceptedCharacterCount != 1 {
+		t.Fatalf("retry: NACK=%v accepted=%d, want NACK/1 (replayed)", out.NACK, out.AcceptedCharacterCount)
+	}
+	if string(fake.TX) != "a" {
+		t.Fatalf("TX %q, want %q (no re-write on retry)", fake.TX, "a")
+	}
+
+	// The console resends the rejected remainder under a fresh sequence.
+	fake.WriteLimit = 0
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{SequenceNumber: 2, CharacterData: []byte("b")})
+	if out.NACK || out.AcceptedCharacterCount != 1 || string(fake.TX) != "ab" {
+		t.Fatalf("remainder: NACK=%v accepted=%d TX=%q", out.NACK, out.AcceptedCharacterCount, fake.TX)
+	}
+}
+
+func TestSOLFlushOutbound(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	fake.RX = []byte("hello")
+
+	out := feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.SequenceNumber != 1 || string(out.CharacterData) != "hello" {
+		t.Fatalf("outbound: seq=%d data=%q, want 1/%q", out.SequenceNumber, out.CharacterData, "hello")
+	}
+
+	// Suspend NACK, then Flush Outbound on an ACK-only packet (Table 15-3's
+	// recovery path): the pending packet is dropped, not resumed.
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, NACK: true})
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{ControlByte: 0x01})
+	if out.SequenceNumber != 0 || len(out.CharacterData) != 0 {
+		t.Fatalf("flush: seq=%d data=%q, want ACK-only response", out.SequenceNumber, out.CharacterData)
+	}
+
+	// Output produced after the flush flows under a fresh sequence number.
+	fake.RX = []byte("world")
+	out = feed(t, b.SOL, sess, &types.SOLPayloadPacket{})
+	if out.SequenceNumber != 2 || string(out.CharacterData) != "world" {
+		t.Fatalf("post-flush: seq=%d data=%q, want 2/%q", out.SequenceNumber, out.CharacterData, "world")
+	}
+}
+
+func TestSOLHALErrorPropagation(t *testing.T) {
+	m := mock.New()
+	m.SetConsole(&mock.Console{})
+	m.Console().(*mock.Console).OpenHook = func(context.Context) (hal.ConsoleConn, error) {
+		return nil, hal.ErrNotSupported
+	}
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	sess := newSOLTestSession(t, b)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); !errors.Is(err, hal.ErrNotSupported) {
+		t.Fatalf("got %v, want hal.ErrNotSupported", err)
+	}
+}
+
+// pumpCapture records asynchronously sent SOL packets.
+type pumpCapture struct {
+	mu  sync.Mutex
+	pkt []*types.SOLPayloadPacket
+}
+
+func (p *pumpCapture) send(pkt *types.SOLPayloadPacket) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := *pkt
+	cp.CharacterData = append([]byte{}, pkt.CharacterData...)
+	p.pkt = append(p.pkt, &cp)
+	return nil
+}
+
+func (p *pumpCapture) all() []*types.SOLPayloadPacket {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*types.SOLPayloadPacket{}, p.pkt...)
+}
+
+// newConsoleBMC builds a BMC with a fake console attached.
+func newConsoleBMC(t *testing.T) (*BMC, *mock.FakeConsoleConn) {
+	t.Helper()
+	fake := &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	return New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real)), fake
+}
+
+func newPumpBMC(t *testing.T, fake *mock.FakeConsoleConn, cap *pumpCapture) (*BMC, *Session) {
+	t.Helper()
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+	b := New(DeviceInfo{}, [16]byte{}, m, WithClock(clock.Real))
+	b.SOL.SetSenderFactory(func(sess *Session, inst *SOLInstance) SOLSendFunc {
+		return cap.send
+	})
+	sess := newSOLTestSession(t, b)
+	sess.Addr = &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5000} // non-nil Addr enables the sender
+	return b, sess
+}
+
+func waitForPkt(t *testing.T, cap *pumpCapture, n int) []*types.SOLPayloadPacket {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := cap.all(); len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d async SOL packets", n)
+	return nil
+}
+
+func TestSOLPumpAsyncPush(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	cap := &pumpCapture{}
+	b, sess := newPumpBMC(t, fake, cap)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	// Console output must be pushed without any inbound packet.
+	fake.FeedRX([]byte("async-output"))
+	pkts := waitForPkt(t, cap, 1)
+	if string(pkts[0].CharacterData) != "async-output" {
+		t.Fatalf("async data %q, want %q", pkts[0].CharacterData, "async-output")
+	}
+	if pkts[0].SequenceNumber != 1 {
+		t.Fatalf("async seq=%d, want 1", pkts[0].SequenceNumber)
+	}
+
+	// ACK it: the pump must then send the next chunk with a fresh sequence.
+	fake.FeedRX([]byte("second"))
+	feed(t, b.SOL, sess, &types.SOLPayloadPacket{AckedSequenceNumber: 1, AcceptedCharacterCount: 12})
+	pkts = waitForPkt(t, cap, 2)
+	if string(pkts[1].CharacterData) != "second" || pkts[1].SequenceNumber != 2 {
+		t.Fatalf("second: seq=%d data=%q, want 2/%q", pkts[1].SequenceNumber, pkts[1].CharacterData, "second")
+	}
+}
+
+// TestSOLDeactivateSendsStatus verifies the one-time NACK packet with
+// status bit [4] (Table 15-2 footnote 2) issued on deactivation paths.
+func TestSOLDeactivateSendsStatus(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	cap := &pumpCapture{}
+	b, sess := newPumpBMC(t, fake, cap)
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	if err := b.SOL.Deactivate(sess); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	pkts := cap.all()
+	if len(pkts) != 1 || !pkts[0].NACK || pkts[0].ControlByte&0x10 == 0 || pkts[0].SequenceNumber != 0 {
+		t.Fatalf("deactivation packet: %+v, want ACK-only NACK with status [4]", pkts)
+	}
+
+	// Session termination (Close Session path, §24.2) issues the same status.
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("re-activate: %v", err)
+	}
+	if err := b.Sessions.Close(sess.BMCID); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+	pkts = cap.all()
+	if len(pkts) != 2 || !pkts[1].NACK || pkts[1].ControlByte&0x10 == 0 {
+		t.Fatalf("session-close packet: %+v, want NACK with status [4]", pkts[1:])
+	}
+}
+
+func TestSOLSuspendResumeEncryption(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("toggle on encrypted activation", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		inst, err := b.SOL.Activate(ctx, sess, true, true)
+		if err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+		if !inst.OutboundEncrypted() {
+			t.Fatalf("activated with encryption but OutboundEncrypted is false")
+		}
+		if err := b.SOL.SuspendResumeEncryption(sess, SOLEncryptionOpSuspend); err != nil {
+			t.Fatalf("suspend: %v", err)
+		}
+		if inst.OutboundEncrypted() {
+			t.Fatalf("suspended but OutboundEncrypted is true")
+		}
+		if err := b.SOL.SuspendResumeEncryption(sess, SOLEncryptionOpResume); err != nil {
+			t.Fatalf("resume: %v", err)
+		}
+		if !inst.OutboundEncrypted() {
+			t.Fatalf("resumed but OutboundEncrypted is false")
+		}
+	})
+
+	t.Run("suspend refused when configuration forces encryption", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		if cc := b.SOL.Config().SetParam(2, []byte{0x80 | 0x04}); cc != types.CodeOK {
+			t.Fatalf("force encryption: CC %#02x", cc)
+		}
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, true, true); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+		if err := b.SOL.SuspendResumeEncryption(sess, SOLEncryptionOpSuspend); !errors.Is(err, ErrSOLEncryptionForced) {
+			t.Fatalf("suspend: got %v, want ErrSOLEncryptionForced", err)
+		}
+	})
+
+	t.Run("resume needs a session with encryption", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, false, false); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+		sess.CryptAlg = types.CryptAlg_None
+		sess.K2 = nil
+		if err := b.SOL.SuspendResumeEncryption(sess, SOLEncryptionOpResume); !errors.Is(err, ErrSOLEncryptionUnavailableForSession) {
+			t.Fatalf("resume: got %v, want ErrSOLEncryptionUnavailableForSession", err)
+		}
+	})
+
+	t.Run("regenerate IV unsupported and stranger session rejected", func(t *testing.T) {
+		b, _ := newConsoleBMC(t)
+		sess := newSOLTestSession(t, b)
+		if _, err := b.SOL.Activate(ctx, sess, true, true); err != nil {
+			t.Fatalf("activate: %v", err)
+		}
+		if err := b.SOL.SuspendResumeEncryption(sess, SOLEncryptionOpRegenIV); !errors.Is(err, ErrSOLOperationUnsupported) {
+			t.Fatalf("regen IV: got %v, want ErrSOLOperationUnsupported", err)
+		}
+		other := newSOLTestSession(t, b)
+		if err := b.SOL.SuspendResumeEncryption(other, SOLEncryptionOpSuspend); !errors.Is(err, ErrSOLInstanceNotActive) {
+			t.Fatalf("stranger: got %v, want ErrSOLInstanceNotActive", err)
+		}
+	})
+}
+
+func TestSOLPumpRetryAndDrop(t *testing.T) {
+	fake := &mock.FakeConsoleConn{}
+	cap := &pumpCapture{}
+	b, sess := newPumpBMC(t, fake, cap)
+	// Fast retries for the test: 2 retries at 10 ms (the floor).
+	if cc := b.SOL.Config().SetParam(4, []byte{2, 1}); cc != types.CodeOK {
+		t.Fatalf("set retry: CC %#02x", cc)
+	}
+	if _, err := b.SOL.Activate(context.Background(), sess, false, false); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(b.SOL.CloseAll)
+
+	fake.FeedRX([]byte("lost-cause"))
+	pkts := waitForPkt(t, cap, 3) // initial send + 2 retries, same seq
+	for i, p := range pkts {
+		if p.SequenceNumber != 1 || string(p.CharacterData) != "lost-cause" {
+			t.Fatalf("pkt %d: seq=%d data=%q, want 1/lost-cause", i, p.SequenceNumber, p.CharacterData)
+		}
+	}
+
+	// Retries exhausted: the packet is dropped (§15.11) and the pump moves on.
+	// The next packet reports the loss (Table 15-2 status [3], overrun).
+	fake.FeedRX([]byte("aftermath"))
+	pkts = waitForPkt(t, cap, 4)
+	if string(pkts[3].CharacterData) != "aftermath" || pkts[3].SequenceNumber != 2 {
+		t.Fatalf("after drop: seq=%d data=%q, want 2/%q", pkts[3].SequenceNumber, pkts[3].CharacterData, "aftermath")
+	}
+	if pkts[3].ControlByte&0x08 == 0 {
+		t.Fatalf("after drop: control %#02x missing transmit-overrun bit", pkts[3].ControlByte)
+	}
+}

--- a/pkg/bmc/user.go
+++ b/pkg/bmc/user.go
@@ -45,7 +45,13 @@ type User struct {
 	ChannelAccess map[uint8]UserChannelAccess
 
 	// PayloadAccess holds per-channel payload activation rights keyed by
-	// channel number (spec v2.0 §24.6/§24.7).
+	// channel number (spec v2.0 §24.6/§24.7). Guarded by payloadMu: entries
+	// are created and updated by the payload-access commands while SOL
+	// activation reads them, and two sessions authenticated as the same
+	// user (or a session plus the SOL activation path) can do so
+	// concurrently — an unlocked map write is a fatal "concurrent map
+	// writes" runtime error.
+	payloadMu     sync.Mutex
 	PayloadAccess map[uint8]*UserPayloadAccess
 }
 
@@ -65,9 +71,36 @@ const defaultStandardPayload1 = 0x02
 // SOLEnabled reports whether the user may activate the SOL payload.
 func (a *UserPayloadAccess) SOLEnabled() bool { return a.Standard1&0x02 != 0 }
 
-// PayloadAccessFor returns the user's payload access entry for channel,
-// creating it with default rights (SOL enabled) on first use.
+// PayloadAccessFor returns a snapshot of the user's payload access entry for
+// channel, creating it with default rights (SOL enabled) on first use. A copy
+// is returned so readers never race a concurrent Set Payload Access update on
+// the live entry.
 func (u *User) PayloadAccessFor(channel uint8) *UserPayloadAccess {
+	u.payloadMu.Lock()
+	defer u.payloadMu.Unlock()
+	a := *u.getOrCreatePayloadAccess(channel)
+	return &a
+}
+
+// SetPayloadAccess applies an enable/disable update to the user's payload
+// access entry for channel (spec v2.0 Table 24-8: on enable, 1-bits set and
+// 0-bits leave unchanged; on disable, 1-bits clear).
+func (u *User) SetPayloadAccess(channel uint8, enable bool, standard1, oem1 uint8) {
+	u.payloadMu.Lock()
+	defer u.payloadMu.Unlock()
+	a := u.getOrCreatePayloadAccess(channel)
+	if enable {
+		a.Standard1 |= standard1
+		a.OEM1 |= oem1
+	} else {
+		a.Standard1 &^= standard1
+		a.OEM1 &^= oem1
+	}
+}
+
+// getOrCreatePayloadAccess returns the user's live entry for channel, creating
+// it with default rights (SOL enabled) on first use. u.payloadMu must be held.
+func (u *User) getOrCreatePayloadAccess(channel uint8) *UserPayloadAccess {
 	if u.PayloadAccess == nil {
 		u.PayloadAccess = make(map[uint8]*UserPayloadAccess)
 	}

--- a/pkg/bmc/user.go
+++ b/pkg/bmc/user.go
@@ -43,6 +43,40 @@ type User struct {
 
 	// ChannelAccess holds per-channel access settings keyed by channel number.
 	ChannelAccess map[uint8]UserChannelAccess
+
+	// PayloadAccess holds per-channel payload activation rights keyed by
+	// channel number (spec v2.0 §24.6/§24.7).
+	PayloadAccess map[uint8]*UserPayloadAccess
+}
+
+// UserPayloadAccess records a user's payload activation rights on one
+// channel, mirroring the bitfields of spec v2.0 Table 24-8/24-9.
+type UserPayloadAccess struct {
+	// Standard1 mirrors "Standard Payload enables 1": bit [1] = SOL.
+	Standard1 uint8
+	// OEM1 mirrors "OEM Payload Enables 1".
+	OEM1 uint8
+}
+
+// defaultStandardPayload1 enables SOL for new entries: payload access
+// defaults to allowed, matching how ChannelAccess defaults to enabled.
+const defaultStandardPayload1 = 0x02
+
+// SOLEnabled reports whether the user may activate the SOL payload.
+func (a *UserPayloadAccess) SOLEnabled() bool { return a.Standard1&0x02 != 0 }
+
+// PayloadAccessFor returns the user's payload access entry for channel,
+// creating it with default rights (SOL enabled) on first use.
+func (u *User) PayloadAccessFor(channel uint8) *UserPayloadAccess {
+	if u.PayloadAccess == nil {
+		u.PayloadAccess = make(map[uint8]*UserPayloadAccess)
+	}
+	a, ok := u.PayloadAccess[channel]
+	if !ok {
+		a = &UserPayloadAccess{Standard1: defaultStandardPayload1}
+		u.PayloadAccess[channel] = a
+	}
+	return a
 }
 
 // SetPassword copies up to MaxPasswordLen bytes from raw into the User's password field.

--- a/pkg/bmc/user_test.go
+++ b/pkg/bmc/user_test.go
@@ -1,6 +1,9 @@
 package bmc
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestUserStore(t *testing.T) {
 	tests := []struct {
@@ -96,5 +99,34 @@ func TestUserVerifyPassword(t *testing.T) {
 				t.Errorf("want %v, got %v", tc.want, got)
 			}
 		})
+	}
+}
+
+// TestUserPayloadAccessConcurrent hammers one account's payload access table
+// from many goroutines: two sessions authenticated as the same user (or a
+// session plus the SOL activation path) can issue Set/Get Payload Access
+// concurrently, and the lazily-created per-channel map must survive — an
+// unlocked map write is a fatal "concurrent map writes" runtime error.
+func TestUserPayloadAccessConcurrent(t *testing.T) {
+	u := &User{}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				u.PayloadAccessFor(1).SOLEnabled()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				u.SetPayloadAccess(1, true, 2, 0)
+			}
+		}()
+	}
+	wg.Wait()
+	if !u.PayloadAccessFor(1).SOLEnabled() {
+		t.Fatal("SOL access bit lost under concurrency")
 	}
 }

--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -180,14 +180,19 @@ func (c *Client) tryMatchIPMILANResponse(recv []byte, wantSeq, wantCmd uint8) (b
 }
 
 // tryMatchSOLResponse returns true if recv is an RMCP+ SOL payload packet
-// acknowledging the pending request. Every SOL packet is acknowledged by
-// echoing the acknowledged packet's sequence number (spec v2.0 §15.9/§15.11),
-// so the response to the request with sequence number wantAck always carries
+// acknowledging the pending request. A data request is acknowledged by
+// echoing its sequence number (spec v2.0 §15.9/§15.11), so the response to
+// the request with sequence number wantAck always carries
 // AckedSequenceNumber == wantAck. Async retransmissions of earlier packets
 // (which reuse the original sequence number per §15.9 and are sent before the
 // request was processed) carry older acked sequence numbers and are discarded
 // here — consuming them as the response would re-display already-delivered
 // character data and lag the ACK bookkeeping.
+//
+// ACK-only requests (sequence 0h) carry no number for the BMC to echo: it
+// answers with the last accepted data sequence instead (which is non-zero
+// once any keystroke has flowed), so no acked-based filter exists and the
+// first SOL packet on the wire is taken as their response.
 func (c *Client) tryMatchSOLResponse(recv []byte, wantAck uint8) (bool, error) {
 	rmcp := &types.Rmcp{}
 	if err := rmcp.Unpack(recv); err != nil {
@@ -216,7 +221,7 @@ func (c *Client) tryMatchSOLResponse(recv []byte, wantAck uint8) (bool, error) {
 		c.DebugfYellow("drop recv: SOL payload unpack failed: %s\n", err)
 		return false, nil
 	}
-	if sol.AckedSequenceNumber != wantAck {
+	if wantAck != 0 && sol.AckedSequenceNumber != wantAck {
 		c.DebugfYellow("drop recv: SOL ack mismatch (got ack %d, want ack %d)\n", sol.AckedSequenceNumber, wantAck)
 		return false, nil
 	}
@@ -235,7 +240,9 @@ func (c *Client) exchangeLAN(ctx context.Context, request types.Request, respons
 		c.unlock()
 	}
 	// SOL responses are matched by the acked sequence number echoing the
-	// request's sequence number (§15.9/§15.11), not by rqSeq/cmd.
+	// request's sequence number (§15.9/§15.11), not by rqSeq/cmd. ACK-only
+	// requests (sequence 0h) get no echo and match the first SOL packet
+	// (see tryMatchSOLResponse).
 	var wantSOLAck uint8
 	solReq, isSOL := request.(*types.SOLPayloadRequest)
 	if isSOL {

--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -179,6 +179,50 @@ func (c *Client) tryMatchIPMILANResponse(recv []byte, wantSeq, wantCmd uint8) (b
 	return true, nil
 }
 
+// tryMatchSOLResponse returns true if recv is an RMCP+ SOL payload packet
+// acknowledging the pending request. Every SOL packet is acknowledged by
+// echoing the acknowledged packet's sequence number (spec v2.0 §15.9/§15.11),
+// so the response to the request with sequence number wantAck always carries
+// AckedSequenceNumber == wantAck. Async retransmissions of earlier packets
+// (which reuse the original sequence number per §15.9 and are sent before the
+// request was processed) carry older acked sequence numbers and are discarded
+// here — consuming them as the response would re-display already-delivered
+// character data and lag the ACK bookkeeping.
+func (c *Client) tryMatchSOLResponse(recv []byte, wantAck uint8) (bool, error) {
+	rmcp := &types.Rmcp{}
+	if err := rmcp.Unpack(recv); err != nil {
+		c.DebugfYellow("drop recv: rmcp unpack failed: %s\n", err)
+		c.DebugBytes("dropped recv (rmcp unpack failed)", recv, 16)
+		return false, nil
+	}
+	if rmcp.Session20 == nil {
+		return false, nil
+	}
+	hdr := rmcp.Session20.SessionHeader20
+	if hdr.PayloadType != types.PayloadTypeSOL {
+		return false, nil
+	}
+	payload := rmcp.Session20.SessionPayload
+	if hdr.PayloadEncrypted {
+		d, err := c.decryptPayload(payload)
+		if err != nil {
+			c.DebugfYellow("drop recv: decrypt SOL payload failed: %s\n", err)
+			return false, nil
+		}
+		payload = d
+	}
+	var sol types.SOLPayloadPacket
+	if err := sol.Unpack(payload); err != nil {
+		c.DebugfYellow("drop recv: SOL payload unpack failed: %s\n", err)
+		return false, nil
+	}
+	if sol.AckedSequenceNumber != wantAck {
+		c.DebugfYellow("drop recv: SOL ack mismatch (got ack %d, want ack %d)\n", sol.AckedSequenceNumber, wantAck)
+		return false, nil
+	}
+	return true, nil
+}
+
 func (c *Client) exchangeLAN(ctx context.Context, request types.Request, response types.Response) error {
 	c.Debug(">> Command Request", request)
 
@@ -189,6 +233,13 @@ func (c *Client) exchangeLAN(ctx context.Context, request types.Request, respons
 		wantSeq = c.session.ipmiSeq
 		wantCmd = request.Command().ID
 		c.unlock()
+	}
+	// SOL responses are matched by the acked sequence number echoing the
+	// request's sequence number (§15.9/§15.11), not by rqSeq/cmd.
+	var wantSOLAck uint8
+	solReq, isSOL := request.(*types.SOLPayloadRequest)
+	if isSOL {
+		wantSOLAck = solReq.SequenceNumber
 	}
 
 	rmcp, err := c.BuildRmcpRequest(ctx, request)
@@ -207,12 +258,21 @@ func (c *Client) exchangeLAN(ctx context.Context, request types.Request, respons
 	for attempt := 1; attempt <= attempts; attempt++ {
 		c.Debugf("attempt %d/%d, ", attempt, attempts)
 
-		if applyIPMIMatch {
+		switch {
+		case applyIPMIMatch:
 			matcher := func(p []byte) (bool, error) {
 				return c.tryMatchIPMILANResponse(p, wantSeq, wantCmd)
 			}
 			recv, err = c.udpClient.ExchangeUntilMatch(ctx, bytes.NewReader(sent), matcher)
-		} else {
+		case isSOL:
+			// The socket also carries the server's unsolicited SOL
+			// retransmissions; a bare Exchange would consume one of those as
+			// the response to this request.
+			matcher := func(p []byte) (bool, error) {
+				return c.tryMatchSOLResponse(p, wantSOLAck)
+			}
+			recv, err = c.udpClient.ExchangeUntilMatch(ctx, bytes.NewReader(sent), matcher)
+		default:
 			recv, err = c.udpClient.Exchange(ctx, bytes.NewReader(sent))
 		}
 		lastErr = err

--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/clock"
 	"github.com/bougou/go-ipmi/pkg/command/transport"
+	"github.com/bougou/go-ipmi/pkg/hal"
 	"github.com/bougou/go-ipmi/pkg/hal/mock"
 	"github.com/bougou/go-ipmi/pkg/server"
 	"github.com/bougou/go-ipmi/pkg/transport/udp"
@@ -41,12 +43,23 @@ func (b *lockedBuffer) String() string {
 // fake console attached, and connects a lanplus client to it.
 func newSOLTestServer(t *testing.T) (c *Client, b *bmc.BMC, fake *mock.FakeConsoleConn) {
 	t.Helper()
-
 	fake = &mock.FakeConsoleConn{}
+	c, b = newSOLTestServerWithConsole(t, &mock.Console{Conn: fake})
+	return c, b, fake
+}
+
+// newSOLTestServerWithConsole is newSOLTestServer with a caller-supplied
+// console HAL (e.g. one that swaps the attached console on reconnect).
+func newSOLTestServerWithConsole(t *testing.T, ch *mock.Console) (c *Client, b *bmc.BMC) {
+	t.Helper()
+
 	m := mock.New()
-	m.SetConsole(&mock.Console{Conn: fake})
+	m.SetConsole(ch)
 
 	b = bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, m, bmc.WithClock(clock.Real))
+	// Reconnection is opt-in (disabled by default); the loopback tests that
+	// go through this helper all exercise the reconnect path.
+	b.SOL.SetReconnectPolicy(&bmc.DefaultReconnectPolicy)
 	user, err := b.Users.Add(2, "ADMIN")
 	if err != nil {
 		t.Fatalf("add user: %v", err)
@@ -76,7 +89,7 @@ func newSOLTestServer(t *testing.T) (c *Client, b *bmc.BMC, fake *mock.FakeConso
 	if err := c.Connect(ctx); err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	return c, b, fake
+	return c, b
 }
 
 func waitForCondition(t *testing.T, what string, fn func() bool) {
@@ -196,4 +209,91 @@ func newSOLTestServerFromExisting(t *testing.T, c1 *Client) (c2 *Client, b *bmc.
 		t.Fatalf("client2 connect: %v", err)
 	}
 	return c2, nil, nil
+}
+
+// TestSOLReconnectLoopback verifies the remote console experiences a
+// transparent recovery: when the system console fails and the server
+// re-attaches to a fresh console, the SOL session keeps running with no
+// client action — output resumes, keystrokes flow, the payload stays active.
+func TestSOLReconnectLoopback(t *testing.T) {
+	fake1 := &mock.FakeConsoleConn{}
+	fake2 := &mock.FakeConsoleConn{}
+	opens := 0
+	ch := &mock.Console{OpenHook: func(context.Context) (hal.ConsoleConn, error) {
+		opens++
+		if opens == 1 {
+			return fake1, nil // activation
+		}
+		return fake2, nil // reconnects
+	}}
+	c, b := newSOLTestServerWithConsole(t, ch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inR, inW := io.Pipe()
+	out := &lockedBuffer{}
+
+	solErr := make(chan error, 1)
+	go func() {
+		solErr <- c.SOLActivate(ctx, inR, out, &SOLActivateOptions{PollInterval: 20 * time.Millisecond})
+	}()
+	waitForCondition(t, "SOL activation", func() bool {
+		return b.SOL.ActiveSessionID(1) != 0
+	})
+
+	// Normal round before the outage.
+	fake1.FeedRX([]byte("login: "))
+	waitForCondition(t, "console output at remote", func() bool {
+		return strings.Contains(out.String(), "login: ")
+	})
+	if _, err := inW.Write([]byte("root\r")); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	waitForCondition(t, "keystrokes at console", func() bool {
+		return strings.Contains(fake1.TXString(), "root\r")
+	})
+
+	// Console dies mid-session; anything queued on it afterwards is stale
+	// residue that must not reach the remote console.
+	fake1.SetReadErr(errors.New("console died"))
+	fake1.FeedRX([]byte("stale"))
+
+	// Recovery is server-driven: the dead conn is released, a fresh one
+	// attached, and output resumes — with no client-side action.
+	waitForCondition(t, "console reconnect", fake1.IsClosed)
+	fake2.FeedRX([]byte("recovered: "))
+	waitForCondition(t, "console output after reconnect", func() bool {
+		return strings.Contains(out.String(), "recovered: ")
+	})
+	if strings.Contains(out.String(), "stale") {
+		t.Fatalf("stale pre-outage residue leaked to the remote console: %q", out.String())
+	}
+
+	// Keystrokes now land on the fresh console; the session is untouched.
+	if _, err := inW.Write([]byte("who\r")); err != nil {
+		t.Fatalf("write input after reconnect: %v", err)
+	}
+	waitForCondition(t, "keystrokes at reconnected console", func() bool {
+		return strings.Contains(fake2.TXString(), "who\r")
+	})
+	if b.SOL.ActiveSessionID(1) == 0 {
+		t.Fatal("payload deactivated by the reconnect")
+	}
+	select {
+	case err := <-solErr:
+		t.Fatalf("SOLActivate returned during reconnect: %v", err)
+	default:
+	}
+
+	// Clean deactivation still works at the end.
+	_ = inW.Close()
+	select {
+	case err := <-solErr:
+		if err != nil {
+			t.Fatalf("SOLActivate: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("SOLActivate did not return after input EOF")
+	}
 }

--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -116,9 +116,12 @@ func TestSOLSessionLoopback(t *testing.T) {
 	inR, inW := io.Pipe()
 	out := &lockedBuffer{}
 
+	// Poll slower than the server's 50ms retry interval (§15.11): the retry
+	// engine must fire between polls so async retransmissions exist — a fast
+	// poller would ack every packet before a retry could be sent.
 	solErr := make(chan error, 1)
 	go func() {
-		solErr <- c.SOLActivate(ctx, inR, out, &SOLActivateOptions{PollInterval: 20 * time.Millisecond})
+		solErr <- c.SOLActivate(ctx, inR, out, &SOLActivateOptions{PollInterval: 100 * time.Millisecond})
 	}()
 
 	waitForCondition(t, "SOL activation", func() bool {
@@ -140,6 +143,16 @@ func TestSOLSessionLoopback(t *testing.T) {
 	waitForCondition(t, "keystrokes at console", func() bool {
 		return strings.Contains(fake.TXString(), "root\r")
 	})
+
+	// §15.9/§15.11: a retransmission reuses its sequence number, so the
+	// receiver must not re-deliver it. The server pushes console data both
+	// async and piggybacked on poll responses, and retries unacked packets;
+	// the client must consume only the response to its current poll and
+	// display the data exactly once. The keystroke round-trip above spans
+	// several poll cycles, so any duplicate delivery has settled by now.
+	if got := strings.Count(out.String(), "login: "); got != 1 {
+		t.Fatalf("console output delivered %d times, want exactly once: %q", got, out.String())
+	}
 
 	// Input EOF ends the session and deactivates the payload (client defer),
 	// which closes the console conn.

--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -310,3 +310,52 @@ func TestSOLReconnectLoopback(t *testing.T) {
 		t.Fatal("SOLActivate did not return after input EOF")
 	}
 }
+
+// TestSOLPayloadAckOnly verifies an ACK-only SOL packet (sequence 0h,
+// §15.11) still exchanges successfully after data has flowed: the BMC
+// echoes the last accepted data sequence number, which the response
+// matcher must not demand to equal the request's (zero) sequence number.
+func TestSOLPayloadAckOnly(t *testing.T) {
+	c, _, _ := newSOLTestServer(t)
+	ctx := context.Background()
+	if _, err := c.ActivatePayload(ctx, &transport.ActivatePayloadRequest{
+		PayloadType:     types.PayloadTypeSOL,
+		PayloadInstance: 1,
+	}); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = c.DeactivatePayload(ctx, &transport.DeactivatePayloadRequest{
+			PayloadType:     types.PayloadTypeSOL,
+			PayloadInstance: 1,
+		})
+	})
+
+	// Data packet first, so the server's acked echo becomes non-zero.
+	if _, err := c.SOLPayload(ctx, &types.SOLPayloadRequest{
+		SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("k")},
+	}); err != nil {
+		t.Fatalf("data exchange: %v", err)
+	}
+	// ACK-only (seq 0h) must still get a reply.
+	if _, err := c.SOLPayload(ctx, &types.SOLPayloadRequest{}); err != nil {
+		t.Fatalf("ack-only exchange: %v", err)
+	}
+}
+
+// TestGetChannelPayloadSupport verifies the §24.8 reply is spec-length (8
+// bytes): the client rejects shorter replies, so this is what keeps payload
+// discovery working.
+func TestGetChannelPayloadSupport(t *testing.T) {
+	c, _, _ := newSOLTestServer(t)
+	res, err := c.GetChannelPayloadSupport(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetChannelPayloadSupport: %v", err)
+	}
+	if !res.PayloadTypeIPMI || !res.PayloadTypeSOL {
+		t.Fatalf("standard payloads: IPMI=%v SOL=%v, want both supported", res.PayloadTypeIPMI, res.PayloadTypeSOL)
+	}
+	if !res.PayloadTypeRmcpOpenSessionRequest || !res.PayloadTypeRAKPMessage4 {
+		t.Fatalf("session-setup payloads not fully supported: %+v", res)
+	}
+}

--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -1,0 +1,199 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/command/transport"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/server"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// lockedBuffer is an io.Writer safe for concurrent reads from the test.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// newSOLTestServer starts the reference server on a UDP loopback port with a
+// fake console attached, and connects a lanplus client to it.
+func newSOLTestServer(t *testing.T) (c *Client, b *bmc.BMC, fake *mock.FakeConsoleConn) {
+	t.Helper()
+
+	fake = &mock.FakeConsoleConn{}
+	m := mock.New()
+	m.SetConsole(&mock.Console{Conn: fake})
+
+	b = bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, m, bmc.WithClock(clock.Real))
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{MaxPrivilege: bmc.PrivilegeLevelAdministrator, Enabled: true}
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	srv := server.NewServer(b, udp.Wrap(pc))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	t.Cleanup(func() { _ = srv.Close() })
+	go func() { _ = srv.Serve(ctx) }()
+
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	c, err = NewClient(addr.IP.String(), addr.Port, "ADMIN", "ADMIN")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLanplus)
+	if err := c.Connect(ctx); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	return c, b, fake
+}
+
+func waitForCondition(t *testing.T, what string, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestSOLSessionLoopback runs a full SOL session against the reference
+// server over UDP loopback: activation, console output to the remote side,
+// keystrokes to the console, and clean deactivation on input EOF.
+func TestSOLSessionLoopback(t *testing.T) {
+	c, b, fake := newSOLTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inR, inW := io.Pipe()
+	out := &lockedBuffer{}
+
+	solErr := make(chan error, 1)
+	go func() {
+		solErr <- c.SOLActivate(ctx, inR, out, &SOLActivateOptions{PollInterval: 20 * time.Millisecond})
+	}()
+
+	waitForCondition(t, "SOL activation", func() bool {
+		return b.SOL.ActiveSessionID(1) != 0
+	})
+
+	// BMC→console: bytes appearing on the system serial port must reach the
+	// remote console's output stream.
+	fake.FeedRX([]byte("login: "))
+	waitForCondition(t, "console output at remote", func() bool {
+		return strings.Contains(out.String(), "login: ")
+	})
+
+	// Console→BMC: keystrokes from the remote console must land on the
+	// system serial port.
+	if _, err := inW.Write([]byte("root\r")); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	waitForCondition(t, "keystrokes at console", func() bool {
+		return strings.Contains(fake.TXString(), "root\r")
+	})
+
+	// Input EOF ends the session and deactivates the payload (client defer),
+	// which closes the console conn.
+	_ = inW.Close()
+	select {
+	case err := <-solErr:
+		if err != nil {
+			t.Fatalf("SOLActivate: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("SOLActivate did not return after input EOF")
+	}
+	waitForCondition(t, "payload deactivation", func() bool {
+		return b.SOL.ActiveSessionID(1) == 0
+	})
+	waitForCondition(t, "console conn close", fake.IsClosed)
+}
+
+// TestSOLActivateConflict verifies that a second activation while SOL is
+// active fails with 80h (payload already active on another session,
+// Table 24-2).
+func TestSOLActivateConflict(t *testing.T) {
+	c1, _, _ := newSOLTestServer(t)
+	ctx := context.Background()
+
+	if _, err := c1.ActivatePayload(ctx, &transport.ActivatePayloadRequest{
+		PayloadType:     types.PayloadTypeSOL,
+		PayloadInstance: 1,
+	}); err != nil {
+		t.Fatalf("first activate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = c1.DeactivatePayload(ctx, &transport.DeactivatePayloadRequest{
+			PayloadType:     types.PayloadTypeSOL,
+			PayloadInstance: 1,
+		})
+	})
+
+	// Second client on the same server.
+	c2, _, _ := newSOLTestServerFromExisting(t, c1)
+	_, err := c2.ActivatePayload(ctx, &transport.ActivatePayloadRequest{
+		PayloadType:     types.PayloadTypeSOL,
+		PayloadInstance: 1,
+	})
+	if err == nil {
+		t.Fatal("second activate must fail")
+	}
+	respErr, ok := types.IsResponseError(err)
+	if !ok {
+		t.Fatalf("second activate error %v is not a ResponseError", err)
+	}
+	if respErr.CompletionCode() != types.CompletionCode(0x80) {
+		t.Fatalf("second activate CC = %#02x, want 0x80", respErr.CompletionCode())
+	}
+}
+
+// newSOLTestServerFromExisting connects a second client to the server an
+// existing client is already talking to.
+func newSOLTestServerFromExisting(t *testing.T, c1 *Client) (c2 *Client, b *bmc.BMC, fake *mock.FakeConsoleConn) {
+	t.Helper()
+	c2, err := NewClient(c1.Host, c1.Port, "ADMIN", "ADMIN")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c2.WithInterface(InterfaceLanplus)
+	if err := c2.Connect(context.Background()); err != nil {
+		t.Fatalf("client2 connect: %v", err)
+	}
+	return c2, nil, nil
+}

--- a/pkg/hal/hal.go
+++ b/pkg/hal/hal.go
@@ -19,6 +19,7 @@ package hal
 
 import (
 	"context"
+	"io"
 
 	"github.com/bougou/go-ipmi/pkg/types"
 )
@@ -38,6 +39,9 @@ type HAL interface {
 	GPIO() GPIOHAL
 	// I2C returns raw I2C bus access for sensors or EEPROMs, or nil.
 	I2C() I2CHAL
+	// Console returns the system serial console used by SOL payloads
+	// (spec v2.0 §15), or nil when the target has no redirectable console.
+	Console() ConsoleHAL
 	// Close releases all hardware resources.
 	Close() error
 }
@@ -131,6 +135,39 @@ type I2CHAL interface {
 	Read(ctx context.Context, bus int, addr uint8, reg uint8, length int) ([]byte, error)
 	// Write performs a register write to an I2C device.
 	Write(ctx context.Context, bus int, addr uint8, reg uint8, data []byte) error
+}
+
+// ConsoleHAL exposes the managed system's serial console for SOL
+// (Serial over LAN) payload redirection (spec v2.0 §15).
+type ConsoleHAL interface {
+	// Open attaches to the system serial console and returns its byte stream.
+	// It is called when a remote console activates the SOL payload
+	// (Activate Payload command, spec v2.0 §24.1) and the returned conn is
+	// closed when the payload is deactivated or the owning session ends.
+	//
+	// Opening an already-attached console must fail: a shared serial port
+	// cannot serve two activations (spec v2.0 §15.3 serial port sharing).
+	Open(ctx context.Context) (ConsoleConn, error)
+}
+
+// ConsoleConn is a bidirectional byte stream to the system serial console.
+//
+// ReadAvailable rather than io.Reader: the SOL data plane drains console
+// output synchronously while answering remote-console packets (spec v2.0
+// §15.9 character accumulation happens at the BMC), so reads must never
+// block. Implementations typically wrap a [net.Conn] or *os.File with an
+// immediate read deadline.
+type ConsoleConn interface {
+	io.WriteCloser
+
+	// ReadAvailable copies immediately-pending console output into p and
+	// returns (0, nil) when no data is waiting. It must not block.
+	ReadAvailable(p []byte) (int, error)
+
+	// SendBreak transmits a ~300 ms serial BREAK to the baseboard (spec
+	// v2.0 Table 15-2 operation bit [4]). Implementations whose transport
+	// has no BREAK concept (e.g. a websocket) return ErrNotSupported.
+	SendBreak(ctx context.Context) error
 }
 
 // ErrNotSupported is returned by HAL methods when the hardware does not

--- a/pkg/hal/mock/mock.go
+++ b/pkg/hal/mock/mock.go
@@ -52,12 +52,7 @@ func (h *HAL) I2C() hal.I2CHAL         { return h.i2c }
 
 // Console returns the console installed by [HAL.SetConsole], or nil when the
 // simulated target has no redirectable serial port.
-func (h *HAL) Console() hal.ConsoleHAL {
-	if h.console == nil {
-		return nil
-	}
-	return h.console
-}
+func (h *HAL) Console() hal.ConsoleHAL { return h.console }
 
 // SetConsole installs the console sub-interface returned by [HAL.Console].
 // Tests typically pass [*Console]; production wiring may pass any

--- a/pkg/hal/mock/mock.go
+++ b/pkg/hal/mock/mock.go
@@ -332,6 +332,22 @@ type FakeConsoleConn struct {
 	WriteLimit int
 }
 
+// SetReadErr arms a read failure for the next ReadAvailable, safe for
+// concurrent use with a running SOL session (unlike direct ReadErr writes).
+func (f *FakeConsoleConn) SetReadErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ReadErr = err
+}
+
+// SetWriteErr arms a write failure for the next Write, safe for concurrent
+// use with a running SOL session (unlike direct WriteErr writes).
+func (f *FakeConsoleConn) SetWriteErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.WriteErr = err
+}
+
 func (f *FakeConsoleConn) ReadAvailable(p []byte) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/hal/mock/mock.go
+++ b/pkg/hal/mock/mock.go
@@ -23,10 +23,15 @@ type HAL struct {
 	network *Network
 	gpio    *GPIO
 	i2c     *I2C
+	console hal.ConsoleHAL
 }
 
 // New returns a [HAL] with all sub-interfaces initialised.
 // Each sub-type is also exported individually for targeted embedding.
+//
+// The console sub-interface is left unset: most simulated targets have no
+// redirectable serial port, so [HAL.Console] returns nil until [HAL.SetConsole]
+// installs one.
 func New() *HAL {
 	return &HAL{
 		chassis: &Chassis{},
@@ -44,7 +49,22 @@ func (h *HAL) Storage() hal.StorageHAL { return h.storage }
 func (h *HAL) Network() hal.NetworkHAL { return h.network }
 func (h *HAL) GPIO() hal.GPIOHAL       { return h.gpio }
 func (h *HAL) I2C() hal.I2CHAL         { return h.i2c }
-func (h *HAL) Close() error            { return nil }
+
+// Console returns the console installed by [HAL.SetConsole], or nil when the
+// simulated target has no redirectable serial port.
+func (h *HAL) Console() hal.ConsoleHAL {
+	if h.console == nil {
+		return nil
+	}
+	return h.console
+}
+
+// SetConsole installs the console sub-interface returned by [HAL.Console].
+// Tests typically pass [*Console]; production wiring may pass any
+// [hal.ConsoleHAL] implementation.
+func (h *HAL) SetConsole(c hal.ConsoleHAL) { h.console = c }
+
+func (h *HAL) Close() error { return nil }
 
 // --- Chassis ---
 
@@ -260,6 +280,118 @@ func (g *GPIO) Watch(_ context.Context, pin string, cb func(bool)) (func(), erro
 		}
 	}
 	return cancel, nil
+}
+
+// --- Console ---
+
+// Console is the mock [hal.ConsoleHAL].
+type Console struct {
+	mu sync.Mutex
+
+	// Conn is returned by Open when OpenHook is nil. Nil means "no console
+	// hardware": Open then returns hal.ErrNotSupported.
+	Conn hal.ConsoleConn
+
+	// OpenHook allows tests to inject custom behaviour (e.g. fail the open).
+	OpenHook func(ctx context.Context) (hal.ConsoleConn, error)
+
+	// OpenCount records how many activations attached to the console.
+	OpenCount int
+}
+
+func (c *Console) Open(ctx context.Context) (hal.ConsoleConn, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.OpenCount++
+	if c.OpenHook != nil {
+		return c.OpenHook(ctx)
+	}
+	if c.Conn == nil {
+		return nil, hal.ErrNotSupported
+	}
+	return c.Conn, nil
+}
+
+// FakeConsoleConn is an in-memory [hal.ConsoleConn] for tests.
+type FakeConsoleConn struct {
+	mu sync.Mutex
+
+	// RX holds console output waiting to be drained by ReadAvailable.
+	RX []byte
+	// TX records everything written toward the system console.
+	TX []byte
+
+	Closed   bool
+	Breaks   int
+	WriteErr error
+	ReadErr  error
+
+	// WriteLimit, when > 0, caps how many bytes a single Write accepts,
+	// forcing the partial accepts (and NACKs) a flow-controlled serial
+	// controller produces.
+	WriteLimit int
+}
+
+func (f *FakeConsoleConn) ReadAvailable(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ReadErr != nil {
+		return 0, f.ReadErr
+	}
+	n := copy(p, f.RX)
+	f.RX = f.RX[n:]
+	return n, nil
+}
+
+func (f *FakeConsoleConn) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.WriteErr != nil {
+		return 0, f.WriteErr
+	}
+	if f.WriteLimit > 0 && len(p) > f.WriteLimit {
+		p = p[:f.WriteLimit]
+	}
+	f.TX = append(f.TX, p...)
+	return len(p), nil
+}
+
+func (f *FakeConsoleConn) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Closed = true
+	return nil
+}
+
+func (f *FakeConsoleConn) SendBreak(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Breaks++
+	return nil
+}
+
+// FeedRX appends bytes to the pending console output, as if the system had
+// written them to its serial port. Safe for concurrent use with a running
+// SOL session, unlike direct RX mutation.
+func (f *FakeConsoleConn) FeedRX(p []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.RX = append(f.RX, p...)
+}
+
+// TXString returns everything written toward the system console so far.
+func (f *FakeConsoleConn) TXString() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return string(f.TX)
+}
+
+// IsClosed reports whether Close was called. Safe for concurrent use with a
+// running SOL session, unlike direct Closed reads.
+func (f *FakeConsoleConn) IsClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.Closed
 }
 
 // --- I2C ---

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -74,6 +74,10 @@ func handleColdReset(ctx context.Context, hctx *HandlerContext, _ []byte) ([]byt
 	if err := ch.ColdReset(ctx); err != nil {
 		return nil, types.CodeUnspecifiedError, err
 	}
+	// A BMC cold reset aborts any SOL parameter set in progress: the
+	// volatile SOL configuration (#0 set in progress, #6 bit rate) returns
+	// to its power-up state (Table 26-3, Table 26-5).
+	hctx.BMC.SOL.Config().ResetVolatile()
 	return nil, types.CodeOK, nil
 }
 

--- a/pkg/handlers/payload.go
+++ b/pkg/handlers/payload.go
@@ -1,0 +1,304 @@
+package handlers
+
+// Payload management command handlers (spec v2.0 §24, "RMCP+ Support and
+// Payload Commands") and SOL configuration handlers (§26).
+//
+// Only the standard SOL payload type (01h, Table 13-16) is implemented; the
+// payload instance capacity is 1 (Table 24-6), matching the single shared
+// serial port of the reference hardware model (§15.3).
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// NetFnTransportRequest is the request NetFn for Transport commands (§23).
+const NetFnTransportRequest uint8 = 0x0c
+
+// payloadTypeSOL is the SOL payload type number (Table 13-16).
+const payloadTypeSOL = 0x01
+
+// solFormatVersion is the BCD major.minor of the implemented SOL payload
+// format (Table 24-11): "The Format Version for the SOL payload implemented
+// per this specification is 1.0 (10h)".
+const solFormatVersion = 0x10
+
+// RegisterPayloadHandlers adds the payload management commands (§24) to r.
+func RegisterPayloadHandlers(r *Registry) {
+	r.RegisterFunc(types.CommandActivatePayload, handleActivatePayload)
+	r.RegisterFunc(types.CommandDeactivatePayload, handleDeactivatePayload)
+	r.RegisterFunc(types.CommandGetPayloadActivationStatus, handleGetPayloadActivationStatus)
+	r.RegisterFunc(types.CommandGetPayloadInstanceInfo, handleGetPayloadInstanceInfo)
+	r.RegisterFunc(types.CommandSetUserPayloadAccess, handleSetUserPayloadAccess)
+	r.RegisterFunc(types.CommandGetUserPayloadAccess, handleGetUserPayloadAccess)
+	r.RegisterFunc(types.CommandGetChannelPayloadSupport, handleGetChannelPayloadSupport)
+	r.RegisterFunc(types.CommandGetChannelPayloadVersion, handleGetChannelPayloadVersion)
+	r.RegisterFunc(types.CommandSuspendResumePayloadEncryption, handleSuspendResumePayloadEncryption)
+}
+
+// RegisterSOLHandlers adds the SOL configuration commands (§26) to r.
+//
+// SOL Activating (§26.1) is intentionally absent: it is a BMC→console
+// notification only meaningful with serial port sharing, which this BMC does
+// not implement (§26 Table 26-1 footnote 2).
+func RegisterSOLHandlers(r *Registry) {
+	r.RegisterFunc(types.CommandSetSOLConfigParam, handleSetSOLConfigParam)
+	r.RegisterFunc(types.CommandGetSOLConfigParam, handleGetSOLConfigParam)
+}
+
+// solCommandCC maps SOL store errors to the command-specific completion
+// codes of the payload commands (named constants in pkg/types,
+// Tables 24-2 / 24-3 / 24-5).
+func solCommandCC(err error) types.CompletionCode {
+	switch {
+	case err == nil:
+		return types.CodeOK
+	case errors.Is(err, bmc.ErrSOLAlreadyActive):
+		return types.CodeActivatePayloadAlreadyActive
+	case errors.Is(err, bmc.ErrSOLNotActive):
+		return types.CodeDeactivatePayloadAlreadyDeactivated
+	case errors.Is(err, bmc.ErrSOLDisabled), errors.Is(err, hal.ErrNotSupported):
+		// No redirectable console on the target reads as "payload type is
+		// disabled" to the remote console.
+		return types.CodeActivatePayloadTypeDisabled
+	case errors.Is(err, bmc.ErrSOLEncryptionUnavailable):
+		return types.CodeActivatePayloadCannotActivateWithEncryption
+	case errors.Is(err, bmc.ErrSOLEncryptionRequired):
+		return types.CodeActivatePayloadCannotActivateWithoutEncryption
+	case errors.Is(err, bmc.ErrSOLAuthenticationUnavailable):
+		return types.CodeRequestDataFieldInvalid
+	case errors.Is(err, bmc.ErrSOLOperationUnsupported):
+		return types.CodeSuspendResumePayloadEncryptionNotSupported
+	case errors.Is(err, bmc.ErrSOLEncryptionForced):
+		return types.CodeSuspendResumePayloadEncryptionNotAllowed
+	case errors.Is(err, bmc.ErrSOLEncryptionUnavailableForSession):
+		return types.CodeSuspendResumePayloadEncryptionNotAvailable
+	case errors.Is(err, bmc.ErrSOLInstanceNotActive):
+		return types.CodeSuspendResumePayloadEncryptionNotActive
+	case errors.Is(err, bmc.ErrSOLPrivilege), errors.Is(err, bmc.ErrSOLNotOwner):
+		return types.CodeInsufficientPrivilege
+	default:
+		return codeFromErr(err)
+	}
+}
+
+// resolveChannel maps the request channel nibble to an effective channel
+// number: 0Eh selects "the channel this request was issued over"
+// (spec v2.0 §6.6 note on channel numbering).
+func resolveChannel(hctx *HandlerContext, reqChannel uint8) uint8 {
+	if reqChannel == 0x0e && hctx.Session != nil {
+		return hctx.Session.Channel
+	}
+	return reqChannel
+}
+
+// parseSOLSelector validates the payload type / instance pair carried by the
+// payload activation commands. ok=false means the completion code is set.
+func parseSOLSelector(data []byte, needInstance bool) (instance uint8, cc types.CompletionCode, ok bool) {
+	if len(data) < 1 || (needInstance && len(data) < 2) {
+		return 0, types.CodeRequestDataLengthInvalid, false
+	}
+	if data[0]&0x3f != payloadTypeSOL {
+		// 0h (IPMI Message) is not activatable; OEM/other types are not
+		// implemented by this BMC (Table 24-2 note).
+		return 0, types.CodeRequestDataFieldInvalid, false
+	}
+	if !needInstance {
+		return 0, types.CodeOK, true
+	}
+	instance = data[1] & 0x0f
+	if instance == 0 || instance > bmc.SOLMaxInstances {
+		return 0, types.CodeParameterOutOfRange, false
+	}
+	return instance, types.CodeOK, true
+}
+
+func handleActivatePayload(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	_, cc, ok := parseSOLSelector(data, true)
+	if !ok {
+		return nil, cc, nil
+	}
+	// Payload activation is an RMCP+ concept; a v1.5 session has no payload
+	// carrier to activate onto.
+	if hctx.Session == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+
+	var aux uint8
+	if len(data) >= 3 {
+		aux = data[2]
+	}
+	// Bit [5] (Test Mode) is accepted but never enabled: the auxiliary
+	// response data reports test mode inactive (Table 24-2).
+	if _, err := hctx.BMC.SOL.Activate(ctx, hctx.Session, aux&0x80 != 0, aux&0x40 != 0); err != nil {
+		return nil, solCommandCC(err), nil
+	}
+
+	port := hctx.BMC.SOL.Config().PayloadPort
+
+	// Table 24-2 response: aux data (4 bytes LE, bit0 = test mode enabled),
+	// payload sizes, UDP port, VLAN (FFFFh = not used).
+	resp := make([]byte, 12)
+	binary.LittleEndian.PutUint16(resp[4:6], 255) // inbound payload size incl. 4-byte SOL header
+	binary.LittleEndian.PutUint16(resp[6:8], 255) // outbound payload size
+	binary.LittleEndian.PutUint16(resp[8:10], port)
+	binary.LittleEndian.PutUint16(resp[10:12], 0xffff)
+	return resp, types.CodeOK, nil
+}
+
+// handleSuspendResumePayloadEncryption implements Table 24-5 for the SOL
+// payload (Table 24-4: the command controls whether SOL payload data from
+// the BMC is encrypted). Run-time control only exists when the channel can
+// do encryption at all, which is exactly when the command is mandatory
+// (Table 24-1 footnote 3).
+func handleSuspendResumePayloadEncryption(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	_, cc, ok := parseSOLSelector(data, true)
+	if !ok {
+		return nil, cc, nil
+	}
+	if len(data) < 3 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	// Run-time encryption control is an RMCP+ concept; a v1.5 session has no
+	// payload protection to toggle.
+	if hctx.Session == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	if err := hctx.BMC.SOL.SuspendResumeEncryption(hctx.Session, data[2]&0x1f); err != nil {
+		return nil, solCommandCC(err), nil
+	}
+	return nil, types.CodeOK, nil
+}
+
+func handleDeactivatePayload(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	_, cc, ok := parseSOLSelector(data, true)
+	if !ok {
+		return nil, cc, nil
+	}
+	if hctx.Session == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	if err := hctx.BMC.SOL.Deactivate(hctx.Session); err != nil {
+		return nil, solCommandCC(err), nil
+	}
+	return nil, types.CodeOK, nil
+}
+
+func handleGetPayloadActivationStatus(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	_, cc, ok := parseSOLSelector(data, false)
+	if !ok {
+		return nil, cc, nil
+	}
+	capacity, active1to8, active9to16 := hctx.BMC.SOL.ActivationStatus()
+	return []byte{capacity, active1to8, active9to16}, types.CodeOK, nil
+}
+
+func handleGetPayloadInstanceInfo(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	instance, cc, ok := parseSOLSelector(data, true)
+	if !ok {
+		return nil, cc, nil
+	}
+	resp := make([]byte, 12)
+	binary.LittleEndian.PutUint32(resp[0:4], hctx.BMC.SOL.ActiveSessionID(instance))
+	// Table 24-7 SOL payload-specific data byte 1: system serial port number
+	// being redirected (1-based; this BMC redirects exactly one port).
+	resp[4] = 1
+	return resp, types.CodeOK, nil
+}
+
+func handleSetUserPayloadAccess(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 6 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	op := data[1] >> 6
+	if op > 1 {
+		return nil, types.CodeRequestDataFieldInvalid, nil // 10b/11b reserved (Table 24-8)
+	}
+	userID := data[1] & 0x3f
+	user, err := hctx.BMC.Users.Get(userID)
+	if err != nil {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+	access := user.PayloadAccessFor(resolveChannel(hctx, data[0]&0x0f))
+	if op == 0 { // ENABLE: 1-bits enable, 0-bits leave unchanged
+		access.Standard1 |= data[2]
+		access.OEM1 |= data[4]
+	} else { // DISABLE
+		access.Standard1 &^= data[2]
+		access.OEM1 &^= data[4]
+	}
+	return nil, types.CodeOK, nil
+}
+
+func handleGetUserPayloadAccess(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 2 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	user, err := hctx.BMC.Users.Get(data[1] & 0x3f)
+	if err != nil {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+	access := user.PayloadAccessFor(resolveChannel(hctx, data[0]&0x0f))
+	return []byte{access.Standard1, 0, access.OEM1, 0}, types.CodeOK, nil
+}
+
+func handleGetChannelPayloadSupport(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 1 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	resp := make([]byte, 3)
+	// Standard payload types 0-7: IPMI Message is always carried; SOL only
+	// when a console exists and the type is enabled (Table 26-5 #1).
+	resp[0] = 0x01
+	if hctx.BMC.SOL.Supported() {
+		resp[0] |= 0x02
+	}
+	// Session setup payload types 0-7 (Table 13-16): Open Session request/
+	// response + RAKP messages 1-4.
+	resp[2] = 0x3f
+	return resp, types.CodeOK, nil
+}
+
+func handleGetChannelPayloadVersion(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 2 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	if data[1]&0x3f != payloadTypeSOL || !hctx.BMC.SOL.Supported() {
+		return nil, types.CodeGetChannelPayloadVersionNotAvailable, nil
+	}
+	return []byte{solFormatVersion}, types.CodeOK, nil
+}
+
+func handleSetSOLConfigParam(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 2 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	// The channel nibble selects which channel's parameters to write; this
+	// BMC keeps one SOL parameter set (single LAN channel model), so the
+	// selector alone decides.
+	cc := hctx.BMC.SOL.Config().SetParam(data[1], data[2:])
+	return nil, cc, nil
+}
+
+func handleGetSOLConfigParam(ctx context.Context, hctx *HandlerContext, data []byte) ([]byte, types.CompletionCode, error) {
+	if len(data) < 4 {
+		return nil, types.CodeRequestDataLengthInvalid, nil
+	}
+	revisionOnly := data[0]&0x80 != 0
+	paramData, ok := hctx.BMC.SOL.Config().GetParam(data[1])
+	if !ok {
+		return nil, types.CodeParameterNotSupported, nil
+	}
+	// Parameter revision 11h: present revision 1, backward compatible to 1
+	// (Table 26-4).
+	resp := []byte{0x11}
+	if !revisionOnly {
+		resp = append(resp, paramData...)
+	}
+	return resp, types.CodeOK, nil
+}

--- a/pkg/handlers/payload.go
+++ b/pkg/handlers/payload.go
@@ -224,14 +224,10 @@ func handleSetUserPayloadAccess(ctx context.Context, hctx *HandlerContext, data 
 	if err != nil {
 		return nil, types.CodeRequestDataFieldInvalid, nil
 	}
-	access := user.PayloadAccessFor(resolveChannel(hctx, data[0]&0x0f))
-	if op == 0 { // ENABLE: 1-bits enable, 0-bits leave unchanged
-		access.Standard1 |= data[2]
-		access.OEM1 |= data[4]
-	} else { // DISABLE
-		access.Standard1 &^= data[2]
-		access.OEM1 &^= data[4]
-	}
+	// The update runs under the user's payload-access lock: the read-modify-
+	// write must be atomic against a concurrent Set/Get on another session
+	// authenticated as the same user.
+	user.SetPayloadAccess(resolveChannel(hctx, data[0]&0x0f), op == 0, data[2], data[4])
 	return nil, types.CodeOK, nil
 }
 
@@ -251,7 +247,10 @@ func handleGetChannelPayloadSupport(ctx context.Context, hctx *HandlerContext, d
 	if len(data) < 1 {
 		return nil, types.CodeRequestDataLengthInvalid, nil
 	}
-	resp := make([]byte, 3)
+	// §24.8 response: standard payload enables 1-2, session-setup payload
+	// enables 1-2, OEM payload enables 1-2, then two reserved bytes — 8 in
+	// total; spec-conformant clients reject shorter replies.
+	resp := make([]byte, 8)
 	// Standard payload types 0-7: IPMI Message is always carried; SOL only
 	// when a console exists and the type is enabled (Table 26-5 #1).
 	resp[0] = 0x01

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -55,6 +55,19 @@ func NewRegistry() *Registry {
 	}
 }
 
+// RegisterAllHandlers adds every standard command handler to r. Keeping the
+// full set behind one call prevents callers that build their own registry
+// (custom middleware, OEM overrides) from silently missing command groups
+// added later.
+func RegisterAllHandlers(r *Registry) {
+	RegisterAppHandlers(r)
+	RegisterSessionHandlers(r)
+	RegisterChassisHandlers(r)
+	RegisterStorageHandlers(r)
+	RegisterPayloadHandlers(r)
+	RegisterSOLHandlers(r)
+}
+
 // Register adds or replaces the handler for c, whose NetFn must be the
 // *request* NetFn (even value).  c is remembered so that dispatching the
 // command reports it through [HandlerContext.Command]; pass one of the

--- a/pkg/handlers/session_v15_policy.go
+++ b/pkg/handlers/session_v15_policy.go
@@ -19,14 +19,15 @@ func MinimumPrivilege(netFn, cmd uint8) bmc.PrivilegeLevel {
 		switch cmd {
 		case CmdColdReset, CmdWarmReset:
 			return bmc.PrivilegeLevelAdministrator
-		case 0x4c: // Set User Payload Access, like Set User Access (§24.6)
+		case 0x4c: // Set User Payload Access (§24.6, Table 24-8): user administration
 			return bmc.PrivilegeLevelAdministrator
 		default:
 			return bmc.PrivilegeLevelUser
 		}
 	case NetFnTransportRequest:
-		// SOL configuration writes mirror LAN configuration writes; the
-		// Activate Payload privilege itself comes from SOL parameter #2.
+		// Set SOL Configuration Parameters (§26.2) is a configuration write
+		// like Set LAN Configuration Parameters; the Activate Payload
+		// privilege itself comes from SOL parameter #2 (Table 26-5).
 		if cmd == 0x21 { // Set SOL Configuration Parameters
 			return bmc.PrivilegeLevelAdministrator
 		}

--- a/pkg/handlers/session_v15_policy.go
+++ b/pkg/handlers/session_v15_policy.go
@@ -19,9 +19,18 @@ func MinimumPrivilege(netFn, cmd uint8) bmc.PrivilegeLevel {
 		switch cmd {
 		case CmdColdReset, CmdWarmReset:
 			return bmc.PrivilegeLevelAdministrator
+		case 0x4c: // Set User Payload Access, like Set User Access (§24.6)
+			return bmc.PrivilegeLevelAdministrator
 		default:
 			return bmc.PrivilegeLevelUser
 		}
+	case NetFnTransportRequest:
+		// SOL configuration writes mirror LAN configuration writes; the
+		// Activate Payload privilege itself comes from SOL parameter #2.
+		if cmd == 0x21 { // Set SOL Configuration Parameters
+			return bmc.PrivilegeLevelAdministrator
+		}
+		return bmc.PrivilegeLevelUser
 	default:
 		return bmc.PrivilegeLevelUser
 	}

--- a/pkg/server/integrity_test.go
+++ b/pkg/server/integrity_test.go
@@ -38,13 +38,13 @@ func TestSendRMCPPlusSessionAddsIntegrityTrailer(t *testing.T) {
 	srv := &Server{conn: conn}
 	sess := &bmc.Session{
 		ConsoleID:    0x11223344,
-		OutboundSeq:  7,
+		OutboundSeq:  6, // sendSessionPayload advances to 7
 		IntegrityAlg: types.IntegrityAlg_HMAC_SHA1_96,
 		K1:           []byte("0123456789abcdefghij"),
 	}
 	payload := []byte{0x20, 0x18, 0xc8, 0x81, 0x00}
 
-	srv.sendRMCPPlusSession(testAddr("console"), srvPayloadIPMI, 0, sess, payload)
+	srv.sendSessionPayload(testAddr("console"), sess, srvPayloadIPMI, 0, payload)
 
 	if len(conn.writes) != 1 {
 		t.Fatalf("want one packet, got %d", len(conn.writes))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,21 +179,11 @@ func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Ser
 	// authentication exactly like command responses.
 	b.SOL.SetSenderFactory(func(sess *bmc.Session, inst *bmc.SOLInstance) bmc.SOLSendFunc {
 		return func(pkt *types.SOLPayloadPacket) error {
-			payload := pkt.Pack()
-			var flags uint8
-			if inst.OutboundEncrypted() && len(sess.K2) >= 16 {
-				enc, err := crypto.EncryptAESPayload(payload, sess.K2, crypto.RandomBytes(16))
-				if err != nil {
-					return err
-				}
-				payload = enc
-				flags |= protocol.PayloadEncryptedFlag
-			}
 			if s.solDebug {
 				fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q (async %s)\n",
 					solStamp(), sess.BMCID, pkt.SequenceNumber, pkt.AckedSequenceNumber, pkt.AcceptedCharacterCount, pkt.NACK, pkt.ControlByte, pkt.CharacterData, sess.Addr)
 			}
-			s.sendSessionPayload(sess.Addr, sess, srvPayloadSOL, flags, payload)
+			s.respondInSession(sess.Addr, sess, srvPayloadSOL, inst.OutboundEncrypted(), pkt.Pack())
 			return nil
 		}
 	})
@@ -448,7 +438,7 @@ func (s *Server) runSOLWorker(sessionID uint32, q chan solJob) {
 			if err != nil {
 				continue // session went away; payload auto-deactivates (§24.2)
 			}
-			s.processSOLJob(sess, job)
+			s.processSOLJob(sess, job, q)
 		case <-idle.C():
 			s.solMu.Lock()
 			if len(q) == 0 {
@@ -477,8 +467,11 @@ func acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint
 	return true
 }
 
-// processSOLJob verifies and dispatches one queued SOL packet.
-func (s *Server) processSOLJob(sess *bmc.Session, job solJob) {
+// processSOLJob verifies and dispatches one queued SOL packet. A Flush
+// Inbound (Table 15-2 bit [1]) additionally drops the packets still queued
+// behind it: keystrokes the console asked to discard must not reach the
+// system console later.
+func (s *Server) processSOLJob(sess *bmc.Session, job solJob, q chan solJob) {
 	_, inboundSeq, _, flags, payload, ok := protocol.ParseRMCPPlusHeader(job.pkt)
 	if !ok {
 		return
@@ -500,7 +493,26 @@ func (s *Server) processSOLJob(sess *bmc.Session, job solJob) {
 		return
 	}
 
-	s.dispatchSOLSession(context.Background(), job.addr, sess, payload, encrypted)
+	if s.dispatchSOLSession(context.Background(), job.addr, sess, payload, encrypted) {
+		if n := drainSOLQueue(q); n > 0 && s.solDebug {
+			fmt.Fprintf(os.Stderr, "%s sol! sess=%x flush inbound: dropped %d queued packet(s)\n",
+				solStamp(), sess.BMCID, n)
+		}
+	}
+}
+
+// drainSOLQueue drops all packets currently queued for a session, returning
+// how many were dropped.
+func drainSOLQueue(q chan solJob) int {
+	n := 0
+	for {
+		select {
+		case <-q:
+			n++
+		default:
+			return n
+		}
+	}
 }
 
 // dispatchIPMIPreSession handles IPMI commands that arrive before a session exists.
@@ -546,34 +558,37 @@ func (s *Server) dispatchIPMISession(ctx context.Context, addr net.Addr, sess *b
 // constrains only BMC→console data, so a console sending cleartext on an
 // encrypted activation is served as-is; §13.29 decryption applies whenever
 // the packet carries the encrypted flag. Outbound data keeps the negotiated
-// outbound protection (§24.4 / Table 24-4).
-func (s *Server) dispatchSOLSession(ctx context.Context, addr net.Addr, sess *bmc.Session, payload []byte, encrypted bool) {
+// outbound protection (§24.4 / Table 24-4). It reports whether the packet
+// carried the Flush Inbound operation (Table 15-2 bit [1]).
+func (s *Server) dispatchSOLSession(ctx context.Context, addr net.Addr, sess *bmc.Session, payload []byte, encrypted bool) (flushed bool) {
 	inst := s.bmc.SOL.InstanceBySession(sess.BMCID)
 	if inst == nil {
-		return
+		return false
 	}
 
 	plain, ok := decryptSessionPayload(sess, payload, encrypted)
 	if !ok {
-		return
+		return false
 	}
 	var in types.SOLPayloadPacket
 	if err := in.Unpack(plain); err != nil {
-		return
+		return false
 	}
+	flushed = in.ControlByte&0x02 != 0
 	if s.solDebug {
 		fmt.Fprintf(os.Stderr, "%s sol< sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q\n",
 			solStamp(), sess.BMCID, in.SequenceNumber, in.AckedSequenceNumber, in.AcceptedCharacterCount, in.NACK, in.ControlByte, in.CharacterData)
 	}
 	out := s.bmc.SOL.ProcessPacket(ctx, sess.BMCID, &in)
 	if out == nil {
-		return
+		return flushed
 	}
 	if s.solDebug {
 		fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q\n",
 			solStamp(), sess.BMCID, out.SequenceNumber, out.AckedSequenceNumber, out.AcceptedCharacterCount, out.NACK, out.ControlByte, out.CharacterData)
 	}
 	s.respondInSession(addr, sess, srvPayloadSOL, inst.OutboundEncrypted(), out.Pack())
+	return flushed
 }
 
 // decryptSessionPayload returns the plaintext of an in-session payload,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -186,11 +186,14 @@ func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Ser
 			})
 		}
 		return func(pkt *types.SOLPayloadPacket) error {
+			// The pump runs outside ProcMu (and must not take it — see
+			// Session.addrMu), so the console address is read under addrMu.
+			addr := sess.GetAddr()
 			if s.solDebug {
 				fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q (async %s)\n",
-					solStamp(), sess.BMCID, pkt.SequenceNumber, pkt.AckedSequenceNumber, pkt.AcceptedCharacterCount, pkt.NACK, pkt.ControlByte, pkt.CharacterData, sess.Addr)
+					solStamp(), sess.BMCID, pkt.SequenceNumber, pkt.AckedSequenceNumber, pkt.AcceptedCharacterCount, pkt.NACK, pkt.ControlByte, pkt.CharacterData, addr)
 			}
-			s.respondInSession(sess.Addr, sess, srvPayloadSOL, inst.OutboundEncrypted(), pkt.Pack())
+			s.respondInSession(addr, sess, srvPayloadSOL, inst.OutboundEncrypted(), pkt.Pack())
 			return nil
 		}
 	})
@@ -235,9 +238,17 @@ func (s *Server) Serve(ctx context.Context) error {
 }
 
 // solSessionPacket reports whether pkt is an in-session RMCP+ SOL payload
-// packet, returning its session ID. ParseRMCPPlusHeader bounds-checks the
-// header; session-ID 0h packets (pre-session traffic) are not SOL.
+// packet, returning its session ID. Only RMCP+ (v2.0) packets carry a
+// session layer: a v1.5 LAN packet's sequence/session bytes alias the RMCP+
+// header layout well enough that ParseRMCPPlusHeader would misread it as
+// SOL (payload type 1) and the command would be queued and dropped — so the
+// message class and the auth-type byte (0x06 = RMCP+) that handleIPMI uses
+// are required first. ParseRMCPPlusHeader bounds-checks the header;
+// session-ID 0h packets (pre-session traffic) are not SOL.
 func solSessionPacket(pkt []byte) (uint32, bool) {
+	if len(pkt) < 5 || pkt[3]&0x1F != 0x07 || pkt[4] != 0x06 {
+		return 0, false
+	}
 	sessionID, _, payloadType, _, _, ok := protocol.ParseRMCPPlusHeader(pkt)
 	return sessionID, ok && sessionID != 0 && payloadType == protocol.PayloadSOL
 }
@@ -443,7 +454,16 @@ func (s *Server) runSOLWorker(sessionID uint32, q chan solJob) {
 			idle.Reset(solWorkerIdleTimeout)
 			sess, err := s.bmc.Sessions.Get(sessionID)
 			if err != nil {
-				continue // session went away; payload auto-deactivates (§24.2)
+				// Session unknown (forged packet) or gone. Session IDs are
+				// minted only during the RAKP handshake, so an ID that is
+				// unknown now can never become valid: retiring the queue
+				// immediately, rather than idle-waiting solWorkerIdleTimeout,
+				// stops unauthenticated packets from accumulating one
+				// goroutine + buffered channel per claimed ID for 90 s each.
+				s.solMu.Lock()
+				delete(s.solQueues, sessionID)
+				s.solMu.Unlock()
+				return
 			}
 			s.processSOLJob(sess, job, q)
 		case <-idle.C():
@@ -470,7 +490,7 @@ func acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint
 		return false
 	}
 	sess.InboundSeq = inboundSeq
-	sess.Addr = addr
+	sess.SetAddr(addr)
 	return true
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,8 +18,11 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/clock"
@@ -33,6 +36,7 @@ import (
 // Payload type aliases from pkg/protocol for readability within this file.
 const (
 	srvPayloadIPMI                = protocol.PayloadIPMI
+	srvPayloadSOL                 = protocol.PayloadSOL
 	srvPayloadOpenSessionResponse = protocol.PayloadOpenSessionResponse
 	srvPayloadOpenSessionRequest  = protocol.PayloadOpenSessionRequest
 	srvPayloadRAKPMessage1        = protocol.PayloadRAKPMessage1
@@ -43,20 +47,56 @@ const (
 
 const defaultBufferSize = 4096
 
+// WithSOLDebug traces every SOL data-plane packet (decoded fields on
+// receipt/send, raw wire bytes on transmit) to stderr. SOL failures are
+// otherwise invisible to command tracing: the data plane rides the session
+// directly and never passes through the handler registry.
+func WithSOLDebug() ServerOption {
+	return func(s *Server) { s.solDebug = true }
+}
+
+// solStamp prefixes SOL trace lines with a millisecond timestamp: stall and
+// retry patterns in the data plane are only readable with per-packet timing.
+func solStamp() string { return time.Now().Format("15:04:05.000") }
+
 // Server is an IPMI BMC server.
 //
 // Create one with [NewServer], then call [Server.Serve] to start accepting
 // packets.  Serve blocks until ctx is cancelled or [Server.Close] is called.
 type Server struct {
-	bmc     *bmc.BMC
-	conn    transport.PacketConn
-	reg     *handlers.Registry
-	clk     clock.Clock
-	bufSize int
+	bmc      *bmc.BMC
+	conn     transport.PacketConn
+	reg      *handlers.Registry
+	clk      clock.Clock
+	bufSize  int
+	solDebug bool
+
+	// solQueues holds one ordered packet queue per session for the SOL data
+	// plane. The Serve loop spawns a goroutine per packet; for SOL that
+	// would apply console keystrokes in scheduler order, so SOL packets are
+	// funneled through a per-session channel drained by a single worker.
+	solMu     sync.Mutex
+	solQueues map[uint32]chan solJob
+	solDone   chan struct{} // closed by Close; retires all SOL workers
 
 	mu     sync.Mutex
 	closed bool
 }
+
+// solJob carries one inbound SOL packet through the per-session ordered
+// queue.
+type solJob struct {
+	addr net.Addr
+	pkt  []byte // full wire packet; integrity verification needs the trailer
+}
+
+// solQueueCapacity bounds queued SOL packets per session; excess packets are
+// dropped (UDP semantics — the console retries unacknowledged data).
+const solQueueCapacity = 64
+
+// solWorkerIdleTimeout retires a session's SOL worker after this much
+// silence; the next packet starts a fresh one.
+const solWorkerIdleTimeout = 90 * time.Second
 
 // ServerOption configures a [Server].
 type ServerOption func(*Server)
@@ -113,21 +153,50 @@ func WithV15Disabled() ServerOption {
 // unless overridden via [WithHandlerRegistry].
 func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Server {
 	reg := handlers.NewRegistry()
-	handlers.RegisterAppHandlers(reg)
-	handlers.RegisterSessionHandlers(reg)
-	handlers.RegisterChassisHandlers(reg)
-	handlers.RegisterStorageHandlers(reg)
+	handlers.RegisterAllHandlers(reg)
 
 	s := &Server{
-		bmc:     b,
-		conn:    conn,
-		reg:     reg,
-		clk:     b.Clock(),
-		bufSize: defaultBufferSize,
+		bmc:       b,
+		conn:      conn,
+		reg:       reg,
+		clk:       b.Clock(),
+		bufSize:   defaultBufferSize,
+		solQueues: make(map[uint32]chan solJob),
+		solDone:   make(chan struct{}),
 	}
 	for _, o := range opts {
 		o(s)
 	}
+	// Activate Payload reports the port payloads are served on (Table 24-2);
+	// learn it from the transport when possible.
+	if la, ok := conn.(interface{ LocalAddr() net.Addr }); ok {
+		if ua, ok := la.LocalAddr().(*net.UDPAddr); ok && ua.Port != 0 {
+			b.SOL.Config().PayloadPort = uint16(ua.Port)
+		}
+	}
+	// SOL data is pushed asynchronously (§15.3); the factory hands each
+	// activation a sender that applies the session's encryption and
+	// authentication exactly like command responses.
+	b.SOL.SetSenderFactory(func(sess *bmc.Session, inst *bmc.SOLInstance) bmc.SOLSendFunc {
+		return func(pkt *types.SOLPayloadPacket) error {
+			payload := pkt.Pack()
+			var flags uint8
+			if inst.OutboundEncrypted() && len(sess.K2) >= 16 {
+				enc, err := crypto.EncryptAESPayload(payload, sess.K2, crypto.RandomBytes(16))
+				if err != nil {
+					return err
+				}
+				payload = enc
+				flags |= protocol.PayloadEncryptedFlag
+			}
+			if s.solDebug {
+				fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q (async %s)\n",
+					solStamp(), sess.BMCID, pkt.SequenceNumber, pkt.AckedSequenceNumber, pkt.AcceptedCharacterCount, pkt.NACK, pkt.ControlByte, pkt.CharacterData, sess.Addr)
+			}
+			s.sendSessionPayload(sess.Addr, sess, srvPayloadSOL, flags, payload)
+			return nil
+		}
+	})
 	return s
 }
 
@@ -156,18 +225,46 @@ func (s *Server) Serve(ctx context.Context) error {
 
 		pkt := make([]byte, n)
 		copy(pkt, buf[:n])
+
+		// SOL session packets are queued in the read loop itself: dispatch
+		// happens from per-packet goroutines, and a keystroke burst handed
+		// to the queue in scheduler order would reach the console garbled.
+		if sessionID, ok := solSessionPacket(pkt); ok {
+			s.enqueueSOL(sessionID, addr, pkt)
+			continue
+		}
 		go s.handlePacket(ctx, addr, pkt)
 	}
+}
+
+// solSessionPacket reports whether pkt is an in-session RMCP+ SOL payload
+// packet, returning its session ID. ParseRMCPPlusHeader bounds-checks the
+// header; session-ID 0h packets (pre-session traffic) are not SOL.
+func solSessionPacket(pkt []byte) (uint32, bool) {
+	sessionID, _, payloadType, _, _, ok := protocol.ParseRMCPPlusHeader(pkt)
+	return sessionID, ok && sessionID != 0 && payloadType == protocol.PayloadSOL
 }
 
 // Close shuts down the server and its transport.
 func (s *Server) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.closed {
+		s.mu.Unlock()
 		return nil
 	}
 	s.closed = true
+	s.mu.Unlock()
+
+	// Retire SOL workers before the transport dies so none sends through a
+	// closing conn; their queues go with them.
+	s.solMu.Lock()
+	close(s.solDone)
+	s.solQueues = make(map[uint32]chan solJob)
+	s.solMu.Unlock()
+
+	if s.bmc != nil {
+		s.bmc.SOL.CloseAll()
+	}
 	return s.conn.Close()
 }
 
@@ -284,15 +381,126 @@ func (s *Server) handleRMCPPlus(addr net.Addr, pkt []byte) {
 		if err != nil {
 			return
 		}
-		if !verifyRMCPPlusIntegrity(pkt, sess, authenticated) {
+		// The seq window check and dispatch must be atomic per session:
+		// packets of one session arrive in order but are dispatched from
+		// per-packet goroutines.
+		sess.ProcMu.Lock()
+		defer sess.ProcMu.Unlock()
+		if !acceptInbound(sess, pkt, addr, inboundSeq, authenticated) {
 			return
 		}
-		if !bmc.InboundSeqValid(sess.InboundSeq, inboundSeq) {
-			return
-		}
-		sess.InboundSeq = inboundSeq
 		s.dispatchIPMISession(ctx, addr, sess, payload, encrypted)
+
+	case srvPayloadSOL:
+		// In-session SOL packets never reach here: the Serve loop routes
+		// them to the ordered per-session queue (see solSessionPacket).
+		// A session-ID-less SOL packet is meaningless; drop it.
+		return
 	}
+}
+
+// enqueueSOL queues an inbound SOL packet for the session's ordered worker,
+// starting the worker on first use. Called from the Serve loop so that queue
+// order is socket read order. Packets beyond solQueueCapacity are dropped;
+// the console retries unacknowledged data (§15.11).
+func (s *Server) enqueueSOL(sessionID uint32, addr net.Addr, pkt []byte) {
+	s.solMu.Lock()
+	defer s.solMu.Unlock()
+	select {
+	case <-s.solDone:
+		return // closing: drop like any packet to an unreachable BMC
+	default:
+	}
+	q, ok := s.solQueues[sessionID]
+	if !ok {
+		q = make(chan solJob, solQueueCapacity)
+		s.solQueues[sessionID] = q
+		go s.runSOLWorker(sessionID, q)
+	}
+	select {
+	case q <- solJob{addr: addr, pkt: pkt}:
+	default:
+		if s.solDebug {
+			fmt.Fprintf(os.Stderr, "%s sol! sess=%x queue full, packet dropped\n", solStamp(), sessionID)
+		}
+	}
+}
+
+// runSOLWorker drains one session's SOL queue in arrival order. It retires
+// itself after solWorkerIdleTimeout of silence, but only with the queue
+// empty and under solMu, so a packet can never land in a worker-less queue.
+func (s *Server) runSOLWorker(sessionID uint32, q chan solJob) {
+	idle := s.clk.NewTimer(solWorkerIdleTimeout)
+	defer idle.Stop()
+	for {
+		select {
+		case <-s.solDone:
+			return
+		case job := <-q:
+			if !idle.Stop() {
+				select {
+				case <-idle.C():
+				default:
+				}
+			}
+			idle.Reset(solWorkerIdleTimeout)
+			sess, err := s.bmc.Sessions.Get(sessionID)
+			if err != nil {
+				continue // session went away; payload auto-deactivates (§24.2)
+			}
+			s.processSOLJob(sess, job)
+		case <-idle.C():
+			s.solMu.Lock()
+			if len(q) == 0 {
+				delete(s.solQueues, sessionID)
+				s.solMu.Unlock()
+				return
+			}
+			s.solMu.Unlock()
+			idle.Reset(solWorkerIdleTimeout)
+		}
+	}
+}
+
+// acceptInbound verifies one in-session packet's integrity and session
+// sequence window, recording the sender address on success. sess.ProcMu
+// must be held: the window check-then-set is only atomic under it.
+func acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint32, authenticated bool) bool {
+	if !verifyRMCPPlusIntegrity(pkt, sess, authenticated) {
+		return false
+	}
+	if !bmc.InboundSeqValid(sess.InboundSeq, inboundSeq) {
+		return false
+	}
+	sess.InboundSeq = inboundSeq
+	sess.Addr = addr
+	return true
+}
+
+// processSOLJob verifies and dispatches one queued SOL packet.
+func (s *Server) processSOLJob(sess *bmc.Session, job solJob) {
+	_, inboundSeq, _, flags, payload, ok := protocol.ParseRMCPPlusHeader(job.pkt)
+	if !ok {
+		return
+	}
+	encrypted := flags&protocol.PayloadEncryptedFlag != 0
+	authenticated := flags&protocol.PayloadAuthenticatedFlag != 0
+
+	// Unlike IPMI commands, the SOL dispatch runs outside ProcMu: the worker
+	// is the only SOL processor per session, and holding it would serialize
+	// the data plane against command responses of the same session.
+	sess.ProcMu.Lock()
+	accepted := acceptInbound(sess, job.pkt, job.addr, inboundSeq, authenticated)
+	sess.ProcMu.Unlock()
+	if !accepted {
+		if s.solDebug {
+			fmt.Fprintf(os.Stderr, "%s sol! sess=%x dropped: seq=%d outside window or integrity failed\n",
+				solStamp(), sess.BMCID, inboundSeq)
+		}
+		return
+	}
+
+	s.dispatchSOLSession(context.Background(), job.addr, sess, payload, encrypted)
 }
 
 // dispatchIPMIPreSession handles IPMI commands that arrive before a session exists.
@@ -309,13 +517,9 @@ func (s *Server) dispatchIPMIPreSession(ctx context.Context, addr net.Addr, payl
 
 // dispatchIPMISession handles IPMI commands within an authenticated session.
 func (s *Server) dispatchIPMISession(ctx context.Context, addr net.Addr, sess *bmc.Session, payload []byte, encrypted bool) {
-	ipmiPayload := payload
-	if encrypted && len(sess.K2) >= 16 {
-		dec, err := crypto.DecryptAESPayload(payload, sess.K2)
-		if err != nil {
-			return
-		}
-		ipmiPayload = dec
+	ipmiPayload, ok := decryptSessionPayload(sess, payload, encrypted)
+	if !ok {
+		return
 	}
 
 	netFn, cmd, data, seq, ok := protocol.ParseIPMIRequest(ipmiPayload)
@@ -333,39 +537,99 @@ func (s *Server) dispatchIPMISession(ctx context.Context, addr net.Addr, sess *b
 	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
 	rawResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
 
-	var finalPayload []byte
-	flags := uint8(0)
-	if encrypted && len(sess.K2) >= 16 {
-		enc, err := crypto.EncryptAESPayload(rawResp, sess.K2, crypto.RandomBytes(16))
+	s.respondInSession(addr, sess, srvPayloadIPMI, encrypted, rawResp)
+}
+
+// dispatchSOLSession handles one in-session SOL payload packet (spec v2.0
+// §15.9). Inbound packets are processed on their own protection flags — the
+// encryption/authentication negotiated at activation (Table 24-2 aux data)
+// constrains only BMC→console data, so a console sending cleartext on an
+// encrypted activation is served as-is; §13.29 decryption applies whenever
+// the packet carries the encrypted flag. Outbound data keeps the negotiated
+// outbound protection (§24.4 / Table 24-4).
+func (s *Server) dispatchSOLSession(ctx context.Context, addr net.Addr, sess *bmc.Session, payload []byte, encrypted bool) {
+	inst := s.bmc.SOL.InstanceBySession(sess.BMCID)
+	if inst == nil {
+		return
+	}
+
+	plain, ok := decryptSessionPayload(sess, payload, encrypted)
+	if !ok {
+		return
+	}
+	var in types.SOLPayloadPacket
+	if err := in.Unpack(plain); err != nil {
+		return
+	}
+	if s.solDebug {
+		fmt.Fprintf(os.Stderr, "%s sol< sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q\n",
+			solStamp(), sess.BMCID, in.SequenceNumber, in.AckedSequenceNumber, in.AcceptedCharacterCount, in.NACK, in.ControlByte, in.CharacterData)
+	}
+	out := s.bmc.SOL.ProcessPacket(ctx, sess.BMCID, &in)
+	if out == nil {
+		return
+	}
+	if s.solDebug {
+		fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q\n",
+			solStamp(), sess.BMCID, out.SequenceNumber, out.AckedSequenceNumber, out.AcceptedCharacterCount, out.NACK, out.ControlByte, out.CharacterData)
+	}
+	s.respondInSession(addr, sess, srvPayloadSOL, inst.OutboundEncrypted(), out.Pack())
+}
+
+// decryptSessionPayload returns the plaintext of an in-session payload,
+// decrypting with K2 when the encrypted flag is set (v2.0 §13.29).
+func decryptSessionPayload(sess *bmc.Session, payload []byte, encrypted bool) ([]byte, bool) {
+	if !encrypted {
+		return payload, true
+	}
+	if len(sess.K2) < 16 {
+		return nil, false
+	}
+	dec, err := crypto.DecryptAESPayload(payload, sess.K2)
+	if err != nil {
+		return nil, false
+	}
+	return dec, true
+}
+
+// respondInSession encrypts (when requested), authenticates, and sends one
+// in-session payload, advancing the outbound session sequence number shared
+// by IPMI commands and SOL packets (§15.5).
+func (s *Server) respondInSession(addr net.Addr, sess *bmc.Session, payloadType uint8, encrypt bool, payload []byte) {
+	finalPayload := payload
+	var flags uint8
+	if encrypt && len(sess.K2) >= 16 {
+		enc, err := crypto.EncryptAESPayload(payload, sess.K2, crypto.RandomBytes(16))
 		if err != nil {
 			return
 		}
 		finalPayload = enc
 		flags |= protocol.PayloadEncryptedFlag
-	} else {
-		finalPayload = rawResp
 	}
-
-	sess.OutboundSeq++
-	s.sendRMCPPlusSession(addr, srvPayloadIPMI, flags, sess, finalPayload)
+	s.sendSessionPayload(addr, sess, payloadType, flags, finalPayload)
 }
 
-// sendRMCPPlus sends a session-zero (unauthenticated) RMCP+ packet.
-func (s *Server) sendRMCPPlus(addr net.Addr, payloadType, flags uint8, payload []byte) {
-	pkt := protocol.BuildRMCPPlusPacket(payloadType, flags, 0, 0, payload)
-	_, _ = s.conn.WriteTo(pkt, addr)
-}
-
-// sendRMCPPlusSession sends an authenticated / optionally encrypted RMCP+ packet.
-func (s *Server) sendRMCPPlusSession(addr net.Addr, payloadType, flags uint8, sess *bmc.Session, payload []byte) {
+// sendSessionPayload authenticates (per the session integrity algorithm) and
+// sends one in-session payload. Used for command responses and asynchronous
+// SOL packets alike.
+func (s *Server) sendSessionPayload(addr net.Addr, sess *bmc.Session, payloadType, flags uint8, payload []byte) {
 	if sess.IntegrityAlg != types.IntegrityAlg_None {
 		flags |= protocol.PayloadAuthenticatedFlag
 	}
-	pkt := protocol.BuildRMCPPlusPacket(payloadType, flags, sess.ConsoleID, sess.OutboundSeq, payload)
+	pkt := protocol.BuildRMCPPlusPacket(payloadType, flags, sess.ConsoleID, sess.NextOutboundSeq(), payload)
 	var ok bool
 	pkt, ok = appendRMCPPlusIntegrity(pkt, sess)
 	if !ok {
 		return
 	}
+	if s.solDebug && payloadType == srvPayloadSOL {
+		fmt.Fprintf(os.Stderr, "%s sol! wire %x\n", solStamp(), pkt)
+	}
+	_, _ = s.conn.WriteTo(pkt, addr)
+}
+
+// sendRMCPPlus sends a session-zero (unauthenticated) RMCP+ packet.
+func (s *Server) sendRMCPPlus(addr net.Addr, payloadType, flags uint8, payload []byte) {
+	pkt := protocol.BuildRMCPPlusPacket(payloadType, flags, 0, 0, payload)
 	_, _ = s.conn.WriteTo(pkt, addr)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -178,6 +178,13 @@ func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Ser
 	// activation a sender that applies the session's encryption and
 	// authentication exactly like command responses.
 	b.SOL.SetSenderFactory(func(sess *bmc.Session, inst *bmc.SOLInstance) bmc.SOLSendFunc {
+		if s.solDebug {
+			// Console lifecycle events (reconnect) ride the same trace
+			// facility as the packet lines.
+			inst.SetTracef(func(format string, args ...any) {
+				fmt.Fprintf(os.Stderr, "%s "+format, append([]any{solStamp()}, args...)...)
+			})
+		}
 		return func(pkt *types.SOLPayloadPacket) error {
 			if s.solDebug {
 				fmt.Fprintf(os.Stderr, "%s sol> sess=%x seq=%d ack=%d accept=%d nack=%v ctrl=%#02x data=%q (async %s)\n",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+)
+
+// TestSOLQueueRetiresForUnknownSession verifies a forged SOL packet for a
+// session ID that does not exist retires its queue and worker immediately
+// instead of holding them until solWorkerIdleTimeout: unauthenticated
+// packets must not accumulate one goroutine + buffered channel per claimed
+// ID for 90 s each.
+func TestSOLQueueRetiresForUnknownSession(t *testing.T) {
+	b := bmc.New(bmc.DeviceInfo{}, [16]byte{}, mock.New())
+	s := &Server{
+		bmc:       b,
+		clk:       b.Clock(),
+		solQueues: make(map[uint32]chan solJob),
+		solDone:   make(chan struct{}),
+	}
+	s.enqueueSOL(0xdeadbeef, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5000}, []byte{0})
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		s.solMu.Lock()
+		n := len(s.solQueues)
+		s.solMu.Unlock()
+		if n == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("queue for unknown session retained; forged packets would accumulate workers")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestSOLSessionPacketRejectsV15 verifies a v1.5 LAN packet is never
+// classified as SOL: its sequence/session bytes alias the RMCP+ header
+// layout (payload type 1 = SOL) and would otherwise be queued and dropped
+// instead of executed.
+func TestSOLSessionPacketRejectsV15(t *testing.T) {
+	// v1.5 MD5-authenticated packet whose session-sequence LSB (byte 5) is
+	// 0x01 — ParseRMCPPlusHeader would read it as a SOL payload; the session
+	// ID bytes parse non-zero and the fake payload length (session-ID bytes
+	// 2-3) is small enough to pass the bounds check.
+	pkt := make([]byte, 24)
+	pkt[3] = 0x07 // class IPMI
+	pkt[4] = 0x01 // auth type MD5 (v1.5)
+	pkt[5] = 0x01 // session sequence LSB, aliases payload type SOL
+	pkt[7] = 0x10 // session ID (LE), non-zero
+	if _, ok := solSessionPacket(pkt); ok {
+		t.Fatal("v1.5 packet classified as SOL")
+	}
+
+	// A genuine in-session RMCP+ SOL packet still classifies.
+	sol := protocol.BuildRMCPPlusPacket(protocol.PayloadSOL, 0, 0x1234, 1, []byte{0x01})
+	id, ok := solSessionPacket(sol)
+	if !ok || id != 0x1234 {
+		t.Fatalf("RMCP+ SOL packet: ok=%v id=%#x, want true/0x1234", ok, id)
+	}
+}

--- a/pkg/transport/udp/udp.go
+++ b/pkg/transport/udp/udp.go
@@ -77,3 +77,7 @@ func (c *Conn) WriteTo(data []byte, addr net.Addr) (int, error) {
 }
 
 func (c *Conn) Close() error { return c.conn.Close() }
+
+// LocalAddr returns the bound address, e.g. so the server can learn the RMCP
+// port it serves for Activate Payload responses (spec v2.0 Table 24-2).
+func (c *Conn) LocalAddr() net.Addr { return c.conn.LocalAddr() }

--- a/test/e2e/chassis_codec_test.sh
+++ b/test/e2e/chassis_codec_test.sh
@@ -29,7 +29,7 @@ GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-$((9800 + RANDOM % 1000))}"
 PORT="${GOIPMI_SERVER_PORT}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
-IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:faea53b}"
 
 # ---------------------------------------------------------------------------
 # Find or choose an ipmitool (local install, else Docker image).

--- a/test/e2e/cipher_suite_test.sh
+++ b/test/e2e/cipher_suite_test.sh
@@ -41,7 +41,7 @@ PORT_EXTENDED="${GOIPMI_SERVER_PORT_EXTENDED:-$((11100 + RANDOM % 1000))}"
 PORT_CROSS="${GOIPMI_SERVER_PORT_CROSS:-$((11300 + RANDOM % 1000))}"
 USER="${GOIPMI_USER:-ADMIN}"
 PASS="${GOIPMI_PASS:-ADMIN}"
-IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:faea53b}"
 
 # ---------------------------------------------------------------------------
 # Find or choose an ipmitool (local install, else Docker image).

--- a/test/e2e/server_test.sh
+++ b/test/e2e/server_test.sh
@@ -10,7 +10,7 @@
 #                         client e2e / CI ipmi-simulator on 9623)
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #   IPMITOOL_IMAGE     – Docker image to use when ipmitool is not found
-#                         (default: ghcr.io/halfcrazy/ipmitool:eecd64f)
+#                         (default: ghcr.io/halfcrazy/ipmitool:faea53b)
 #
 # Requires: make build  (or: make test-e2e-server)
 #
@@ -28,7 +28,7 @@ e2e_init
 GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-$((9700 + RANDOM % 1000))}"
 GOIPMI_USER="${GOIPMI_USER:-ADMIN}"
 GOIPMI_PASS="${GOIPMI_PASS:-ADMIN}"
-IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:eecd64f}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:faea53b}"
 
 # ---------------------------------------------------------------------------
 # Find or choose an ipmitool

--- a/test/e2e/sol_test.sh
+++ b/test/e2e/sol_test.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# sol_test.sh — E2E test for SOL (Serial over LAN, spec v2.0 §15) against
+# goipmi-server.
+#
+# Starts goipmi-server with a PTY-backed console (GOIPMI_SERVER_CONSOLE=pty)
+# and drives real SOL clients. The PTY slave plays the role of the system
+# serial port: bytes written there are console output, bytes read there are
+# remote-console keystrokes.
+#
+# Clients exercised (each available one gets the full interactive suite):
+#   - local ipmitool           (ipmitool sol activate)
+#   - Docker ipmitool          (fallback when no local binary; entrypoint of
+#                               the image is ipmitool, stdin via docker -i)
+#   - local goipmi binary      (goipmi sol activate — our own client, which
+#                               polls with SOL packets unlike ipmitool)
+#
+# Requires Linux (PTY allocation). With neither local ipmitool nor Docker
+# the ipmitool suites are skipped; the goipmi suite always runs.
+#
+# Environment variables:
+#   GOIPMI_SERVER_PORT – port for the server to listen on (default: random)
+#   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
+#   IPMITOOL_IMAGE     – Docker image fallback (default: ghcr.io/halfcrazy/ipmitool:faea53b)
+#
+# Requires: make build  (or: make test-e2e-sol)
+#
+# Usage:
+#   ./test/e2e/sol_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT:-$((10700 + RANDOM % 1000))}"
+GOIPMI_USER="${GOIPMI_USER:-ADMIN}"
+GOIPMI_PASS="${GOIPMI_PASS:-ADMIN}"
+IPMITOOL_IMAGE="${IPMITOOL_IMAGE:-ghcr.io/halfcrazy/ipmitool:faea53b}"
+
+IPMITOOL_BIN="${IPMITOOL_BIN:-}"
+if [ -z "${IPMITOOL_BIN}" ] && command -v ipmitool &>/dev/null; then
+	IPMITOOL_BIN="ipmitool"
+fi
+
+FORCE_DOCKER=0
+if [ "${IPMITOOL_BIN}" = "docker" ]; then
+	# Escape hatch to exercise the container path on hosts that also have a
+	# local ipmitool.
+	FORCE_DOCKER=1
+	IPMITOOL_BIN=""
+fi
+
+HAVE_DOCKER=0
+if [ -z "${IPMITOOL_BIN}" ] && command -v docker &>/dev/null && docker info &>/dev/null; then
+	HAVE_DOCKER=1
+fi
+
+if [ -n "${IPMITOOL_BIN}" ]; then
+	echo "==> Using ipmitool: ${IPMITOOL_BIN}"
+elif [ "${HAVE_DOCKER}" -eq 1 ]; then
+	echo "==> No local ipmitool; using Docker image: ${IPMITOOL_IMAGE}"
+else
+	echo "==> No ipmitool (local or Docker); ipmitool suites will be skipped"
+fi
+
+# ---------------------------------------------------------------------------
+# Start the server with a PTY console
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d)"
+SERVER_LOG="${WORK}/server.log"
+
+CLIENT_PID=""
+SOL_CAT_PID=""
+DOCKER_NAME="goipmi-sol-e2e-$$"
+
+cleanup() {
+	if [ -n "${CLIENT_PID:-}" ] && kill -0 "${CLIENT_PID}" 2>/dev/null; then
+		kill -9 "${CLIENT_PID}" 2>/dev/null || true
+	fi
+	if [ -n "${SOL_CAT_PID:-}" ] && kill -0 "${SOL_CAT_PID}" 2>/dev/null; then
+		kill "${SOL_CAT_PID}" 2>/dev/null || true
+	fi
+	if [ "${HAVE_DOCKER}" -eq 1 ] && [ -z "${IPMITOOL_BIN}" ]; then
+		docker rm -f "${DOCKER_NAME}" >/dev/null 2>&1 || true
+	fi
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+	exec 9>&- 2>/dev/null || true
+	# Keep the work dir (server trace, client log, slave capture) when a
+	# case failed; the diagnostics dump below then stays inspectable.
+	if [ -z "${KEEP_WORK:-}" ]; then
+		rm -rf "${WORK}"
+	fi
+}
+trap cleanup EXIT
+
+echo "==> Starting goipmi-server on :${GOIPMI_SERVER_PORT} with PTY console ..."
+# GOIPMI_SERVER_TRACE: per-packet SOL trace (sol< / sol> lines with
+# timestamps) goes to SERVER_LOG; failures below dump it.
+GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT}" \
+GOIPMI_SERVER_USER="${GOIPMI_USER}" \
+GOIPMI_SERVER_PASS="${GOIPMI_PASS}" \
+GOIPMI_SERVER_CONSOLE=pty \
+GOIPMI_SERVER_TRACE=1 \
+	"${SERVER_BIN}" > "${SERVER_LOG}" 2>&1 &
+SERVER_PID=$!
+sleep 2
+
+if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+	echo -e "${RED}ERROR: goipmi-server exited early${NC}" >&2
+	cat "${SERVER_LOG}" >&2
+	exit 1
+fi
+
+SLAVE="$(grep "console pty slave" "${SERVER_LOG}" | awk '{print $NF}')"
+if [ -z "${SLAVE}" ]; then
+	echo -e "${RED}ERROR: server did not report a PTY slave path${NC}" >&2
+	cat "${SERVER_LOG}" >&2
+	exit 1
+fi
+echo "==> Console PTY slave: ${SLAVE}"
+# Raw bytes both ways: no echo, no CR/LF translation on the system side.
+stty -F "${SLAVE}" raw -echo
+
+wait_for() { # wait_for <file> <pattern> <tenths-of-second>
+	local file="$1" pattern="$2" ticks="${3:-50}" i
+	for ((i = 0; i < ticks; i++)); do
+		grep -qa "${pattern}" "${file}" 2>/dev/null && return 0
+		sleep 0.1
+	done
+	return 1
+}
+
+failures=0
+
+# ---------------------------------------------------------------------------
+# Client abstractions
+# ---------------------------------------------------------------------------
+# MODE is one of: ipmitool | ipmitool-docker | goipmi
+# SOL_OUT/SOL_FIFO/SOL_IN_GOT are per-suite files under WORK.
+
+ipmi_oneshot() { # one-shot ipmitool command in the current mode
+	case "${MODE}" in
+	ipmitool-docker)
+		docker run --rm --network host "${IPMITOOL_IMAGE}" \
+			-I lanplus -H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" \
+			-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" "$@"
+		;;
+	*)
+		"${IPMITOOL_BIN}" -I lanplus -H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" \
+			-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" "$@"
+		;;
+	esac
+}
+
+sol_activate_bg() { # start the interactive client of the current mode
+	case "${MODE}" in
+	ipmitool)
+		# stdbuf -o0: ipmitool block-buffers stdout when redirected to a
+		# file, which would hide the activation banner.
+		stdbuf -o0 "${IPMITOOL_BIN}" -I lanplus -H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" \
+			-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" sol activate \
+			< "${SOL_FIFO}" > "${SOL_OUT}" 2>&1 &
+		;;
+	ipmitool-docker)
+		# No stdbuf inside the image: activation is detected by polling
+		# Get Payload Activation Status instead of the banner (see
+		# wait_activated). Console data itself is fflush'd per packet by
+		# ipmitool, so it needs no unbuffering help.
+		docker run --rm -i --network host --name "${DOCKER_NAME}" "${IPMITOOL_IMAGE}" \
+			-I lanplus -H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" \
+			-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" sol activate \
+			< "${SOL_FIFO}" > "${SOL_OUT}" 2>&1 &
+		;;
+	goipmi)
+		# Go writes are unbuffered; the banner is reliable as-is. --debug
+		# logs every client packet exchange to SOL_OUT (dumped on failure).
+		"${GOIPMI}" --debug -I lanplus -H 127.0.0.1 -p "${GOIPMI_SERVER_PORT}" \
+			-U "${GOIPMI_USER}" -P "${GOIPMI_PASS}" sol activate \
+			< "${SOL_FIFO}" > "${SOL_OUT}" 2>&1 &
+		;;
+	esac
+	CLIENT_PID=$!
+}
+
+wait_activated() { # wait until the payload is active (≈5s)
+	case "${MODE}" in
+	ipmitool-docker)
+		local i status
+		# Poll Get Payload Activation Status (§24.4, App 4Ah): byte 2 of the
+		# response is the instance 1-8 bitmask; bit0 = instance 1 active.
+		for ((i = 0; i < 20; i++)); do
+			status="$(ipmi_oneshot raw 0x06 0x4a 0x01 2>/dev/null | tr -d ' \n')"
+			[ "${status:2:2}" = "01" ] && return 0
+			sleep 0.25
+		done
+		return 1
+		;;
+	ipmitool)
+		wait_for "${SOL_OUT}" "SOL Session operational" 50
+		;;
+	goipmi)
+		wait_for "${SOL_OUT}" "SOL payload activated" 50
+		;;
+	esac
+}
+
+stop_client() { # ask the client to exit via the ~. escape, then reap
+	printf '\r~.' >&9 2>/dev/null || true
+	local i
+	for ((i = 0; i < 25; i++)); do
+		[ -n "${CLIENT_PID}" ] && kill -0 "${CLIENT_PID}" 2>/dev/null || break
+		sleep 0.2
+	done
+	if [ -n "${CLIENT_PID}" ] && kill -0 "${CLIENT_PID}" 2>/dev/null; then
+		kill -9 "${CLIENT_PID}" 2>/dev/null || true
+		[ "${MODE}" = "ipmitool-docker" ] && docker rm -f "${DOCKER_NAME}" >/dev/null 2>&1 || true
+	fi
+	wait "${CLIENT_PID}" 2>/dev/null || true
+	CLIENT_PID=""
+}
+
+# ---------------------------------------------------------------------------
+# The interactive suite, run once per available client
+# ---------------------------------------------------------------------------
+case_outbound() { # console output reaches the remote client
+	printf 'E2E-OUT-%s\r\n' "${MODE}" > "${SLAVE}"
+	wait_for "${SOL_OUT}" "E2E-OUT-${MODE}" 50
+}
+
+case_streaming() { # multi-packet output arrives complete and in order
+	local i
+	for ((i = 1; i <= 40; i++)); do
+		printf 'stream-line-%02d\r\n' "${i}" > "${SLAVE}"
+	done
+	printf 'E2E-STREAM-END-%s\r\n' "${MODE}" > "${SLAVE}"
+	wait_for "${SOL_OUT}" "E2E-STREAM-END-${MODE}" 100 &&
+		grep -qa "stream-line-01" "${SOL_OUT}" && grep -qa "stream-line-40" "${SOL_OUT}"
+}
+
+case_inbound() { # remote keystrokes land on the system serial port
+	# Reap the previous inbound case's reader: its 5 s window outlives the
+	# case, and a lingering reader shares the slave with this case's cat,
+	# splitting — or, having blocked first, entirely consuming — the
+	# keystrokes. pkill -P catches the cat itself in case timeout does not
+	# forward the signal.
+	if [ -n "${SOL_CAT_PID:-}" ] && kill -0 "${SOL_CAT_PID}" 2>/dev/null; then
+		kill "${SOL_CAT_PID}" 2>/dev/null || true
+		wait "${SOL_CAT_PID}" 2>/dev/null || true
+		pkill -TERM -P "${SOL_CAT_PID}" 2>/dev/null || true
+	fi
+	# EIO on stderr is expected: the SOL session ends (PTY master closes)
+	# before the 5 s timeout, and reads on an orphaned slave return EIO.
+	timeout 5 cat "${SLAVE}" 2>/dev/null > "${SOL_IN_GOT}" &
+	SOL_CAT_PID=$!
+	printf 'E2E-IN-%s' "${MODE}" >&9
+	wait_for "${SOL_IN_GOT}" "E2E-IN-${MODE}" 50
+}
+
+reconnect_case() { # console fault (SIGUSR1) → reconnect → recovery
+	# The SOL session from the interactive suite is still active. Break the
+	# console link: console reads fail, the instance flips broken, and the
+	# first reconnect attempt (1s later, default policy) fails too.
+	kill -USR1 "${SERVER_PID}"
+	sleep 1.5
+
+	# The remote console must be unaffected by the outage: process alive and
+	# quiet. (ipmitool keeps the session alive with Get Device ID keepalives;
+	# it only exits after 6 missed keepalives, and the RMCP+ path is fine.)
+	if ! kill -0 "${CLIENT_PID}" 2>/dev/null; then
+		echo "client exited during console outage" >&2
+		return 1
+	fi
+	if grep -qaE "Error|FAIL|connection" "${SOL_OUT}"; then
+		echo "client reported an error during console outage" >&2
+		cat "${SOL_OUT}" >&2
+		return 1
+	fi
+
+	# Restore the console link; the next reconnect attempt succeeds and the
+	# fresh console's output must reach the still-open session.
+	kill -USR2 "${SERVER_PID}"
+	local i
+	for ((i = 0; i < 40; i++)); do
+		printf 'E2E-RECONNECT-%s
+' "${MODE}" > "${SLAVE}"
+		if grep -qa "E2E-RECONNECT-${MODE}" "${SOL_OUT}"; then
+			return 0
+		fi
+		sleep 0.25
+	done
+	echo "console output did not resume after reconnect" >&2
+	return 1
+}
+
+run_interactive_suite() {
+	local label="$1"
+	SOL_FIFO="${WORK}/${MODE}_in"
+	SOL_OUT="${WORK}/${MODE}_out.txt"
+	SOL_IN_GOT="${WORK}/${MODE}_slave.txt"
+	rm -f "${SOL_FIFO}"
+	mkfifo "${SOL_FIFO}"
+	: > "${SOL_OUT}"
+
+	# O_RDWR avoids the reader/writer open deadlock on the fifo.
+	exec 9<> "${SOL_FIFO}"
+	sol_activate_bg
+
+	e2e_run_test "${label}: sol activate" wait_activated || ((FAILURES++)) || true
+	e2e_run_test "${label}: outbound (BMC → console)" case_outbound || ((FAILURES++)) || true
+	e2e_run_test "${label}: outbound streaming (40 lines)" case_streaming || ((FAILURES++)) || true
+	e2e_run_test "${label}: inbound (console → BMC)" case_inbound || ((FAILURES++)) || true
+	e2e_run_test "${label}: deactivate via ~." stop_client || ((FAILURES++)) || true
+	exec 9>&-
+}
+
+# FAILURES is global; run_interactive_suite increments it (uppercase to tell
+# it apart from the e2e_run_test callers in other suites).
+FAILURES=0
+
+if [ -n "${IPMITOOL_BIN}" ]; then
+	MODE="ipmitool"
+	e2e_run_test "ipmitool: sol info" ipmi_oneshot sol info || ((FAILURES++)) || true
+	run_interactive_suite "ipmitool"
+
+	# Recovery: a fresh `sol deactivate` (different session, admin privilege)
+	# force-frees a stale payload, after which activation works again (§24.2).
+	force_deactivate_case() {
+		exec 9<> "${SOL_FIFO}"
+		sol_activate_bg
+		if ! wait_activated; then
+			echo "re-activate failed" >&2
+			return 1
+		fi
+		if ! ipmi_oneshot sol deactivate >/dev/null 2>&1; then
+			echo "sol deactivate failed" >&2
+			return 1
+		fi
+		stop_client
+		exec 9>&-
+		: > "${SOL_OUT}"
+		exec 9<> "${SOL_FIFO}"
+		sol_activate_bg
+		local rc=0
+		wait_activated || rc=1
+		stop_client
+		exec 9>&-
+		return "${rc}"
+	}
+	e2e_run_test "ipmitool: force-deactivate frees payload" force_deactivate_case || ((FAILURES++)) || true
+
+elif [ "${HAVE_DOCKER}" -eq 1 ]; then
+	MODE="ipmitool-docker"
+	e2e_run_test "ipmitool(docker): sol info" ipmi_oneshot sol info || ((FAILURES++)) || true
+	run_interactive_suite "ipmitool(docker)"
+fi
+
+MODE="goipmi"
+run_interactive_suite "goipmi"
+
+if [ "${FAILURES}" -gt 0 ]; then
+	KEEP_WORK=1
+	echo "==> goipmi-server SOL trace (full):" >&2
+	grep -E "sol[<>!]" "${SERVER_LOG}" >&2
+	echo "==> goipmi client log (full):" >&2
+	cat "${WORK}/goipmi_out.txt" 2>/dev/null >&2
+	echo "==> slave capture:" >&2
+	cat "${WORK}/goipmi_slave.txt" 2>/dev/null >&2
+	echo "==> work dir kept at: ${WORK}" >&2
+fi
+
+e2e_report "SOL E2E" "${FAILURES}"

--- a/test/e2e/sol_test.sh
+++ b/test/e2e/sol_test.sh
@@ -231,19 +231,24 @@ stop_client() { # ask the client to exit via the ~. escape, then reap
 # ---------------------------------------------------------------------------
 # The interactive suite, run once per available client
 # ---------------------------------------------------------------------------
-case_outbound() { # console output reaches the remote client
+case_outbound() { # console output reaches the remote client exactly once
 	printf 'E2E-OUT-%s\r\n' "${MODE}" > "${SLAVE}"
-	wait_for "${SOL_OUT}" "E2E-OUT-${MODE}" 50
+	# A retransmission (§15.9/§15.11) must not be re-delivered: the marker
+	# appears in the client's output exactly once. The goipmi --debug hex
+	# dumps carry no ASCII, so counts are unaffected by them.
+	wait_for "${SOL_OUT}" "E2E-OUT-${MODE}" 50 &&
+		[ "$(grep -c "E2E-OUT-${MODE}" "${SOL_OUT}")" -eq 1 ]
 }
 
-case_streaming() { # multi-packet output arrives complete and in order
+case_streaming() { # multi-packet output arrives complete, in order, once each
 	local i
 	for ((i = 1; i <= 40; i++)); do
 		printf 'stream-line-%02d\r\n' "${i}" > "${SLAVE}"
 	done
 	printf 'E2E-STREAM-END-%s\r\n' "${MODE}" > "${SLAVE}"
 	wait_for "${SOL_OUT}" "E2E-STREAM-END-${MODE}" 100 &&
-		grep -qa "stream-line-01" "${SOL_OUT}" && grep -qa "stream-line-40" "${SOL_OUT}"
+		[ "$(grep -c "stream-line-01" "${SOL_OUT}")" -eq 1 ] &&
+		[ "$(grep -c "stream-line-40" "${SOL_OUT}")" -eq 1 ]
 }
 
 case_inbound() { # remote keystrokes land on the system serial port

--- a/test/e2e/sol_test.sh
+++ b/test/e2e/sol_test.sh
@@ -21,6 +21,8 @@
 #   GOIPMI_SERVER_PORT – port for the server to listen on (default: random)
 #   IPMITOOL_BIN       – path to ipmitool   (auto-detected if unset)
 #   IPMITOOL_IMAGE     – Docker image fallback (default: ghcr.io/halfcrazy/ipmitool:faea53b)
+#   SOL_RECONNECT      – enable server-side console reconnection and run the
+#                        outage/recovery suite (default: 1)
 #
 # Requires: make build  (or: make test-e2e-sol)
 #
@@ -97,6 +99,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+SOL_RECONNECT="${SOL_RECONNECT:-1}"
+
 echo "==> Starting goipmi-server on :${GOIPMI_SERVER_PORT} with PTY console ..."
 # GOIPMI_SERVER_TRACE: per-packet SOL trace (sol< / sol> lines with
 # timestamps) goes to SERVER_LOG; failures below dump it.
@@ -104,6 +108,7 @@ GOIPMI_SERVER_PORT="${GOIPMI_SERVER_PORT}" \
 GOIPMI_SERVER_USER="${GOIPMI_USER}" \
 GOIPMI_SERVER_PASS="${GOIPMI_PASS}" \
 GOIPMI_SERVER_CONSOLE=pty \
+GOIPMI_SERVER_SOL_RECONNECT="${SOL_RECONNECT}" \
 GOIPMI_SERVER_TRACE=1 \
 	"${SERVER_BIN}" > "${SERVER_LOG}" 2>&1 &
 SERVER_PID=$!
@@ -313,6 +318,9 @@ run_interactive_suite() {
 	e2e_run_test "${label}: outbound (BMC → console)" case_outbound || ((FAILURES++)) || true
 	e2e_run_test "${label}: outbound streaming (40 lines)" case_streaming || ((FAILURES++)) || true
 	e2e_run_test "${label}: inbound (console → BMC)" case_inbound || ((FAILURES++)) || true
+	if [ "${SOL_RECONNECT}" = "1" ]; then
+		e2e_run_test "${label}: reconnect after console fault" reconnect_case || ((FAILURES++)) || true
+	fi
 	e2e_run_test "${label}: deactivate via ~." stop_client || ((FAILURES++)) || true
 	exec 9>&-
 }


### PR DESCRIPTION
## Summary

Implements Serial over LAN (SOL) end to end per the IPMI v2.0 spec: goipmi-server
now hosts a redirectable system console over RMCP+, interoperable with real
clients (`ipmitool sol activate`, `goipmi sol activate`). Covers the server
payload data plane, the console HAL with a Linux PTY backend, console
reconnection after link failure, and a client-side fix for SOL response matching.

## Changes

**feat(server): SOL payload management** — `pkg/bmc/sol.go`, `pkg/server/server.go`, `pkg/handlers/payload.go`, `pkg/hal`
- `ConsoleHAL`/`ConsoleConn` abstraction with a PTY backend (`GOIPMI_SERVER_CONSOLE=pty|<device>`)
- `SOLStore`/`SOLInstance` state machine: Table 15-2 sequencing, partial ACK, Suspend NACK (Table 15-3), §15.11 retry/drop with transmit-overrun reporting, Flush Outbound
- `SOLConfig` (Table 26-5 params 0–8, volatile semantics per §15.8); per-user payload access (§24.6/24.7)
- Payload commands (§24): Activate/Deactivate Payload, Get Payload Activation Status/Instance Info, Set/Get User Payload Access, Get Channel Payload Support/Version, Suspend/Resume Payload Encryption; SOL config commands (§26.2/26.3)
- Async output pump (§15.3), per-session ordered inbound queue, per-packet SOL wire tracing (`GOIPMI_SERVER_TRACE`)

**feat(bmc): reconnect SOL console after failure**
- Injectable reconnect policy (exponential backoff); the payload survives a console
  link outage, reports status bit [5], and resumes on re-attach — invisible to the
  remote console. SIGUSR1/SIGUSR2 fault injection on goipmi-server drives the e2e
  outage/recovery suite; it is linux-only (like the console backend it toggles),
  keeping goipmi-server buildable on other platforms.
- Console reconnects are traced: on re-attach a `sol!` line naming the session id
  and failed-attempt count is emitted behind `GOIPMI_SERVER_TRACE`, via an
  injectable sink that printf-style loggers (logrus.Printf, zap SugaredLogger.Infof)
  accept as-is.

**fix(bmc): align SOL data plane with spec v2.0 review findings**
- Suspend/partial-ACK semantics, Flush Inbound queue drain, status-bit handling
  per Table 15-2/15-3.

**fix(client): match SOL responses by acked sequence number**
- The SOL exchange consumed the first datagram in the socket queue; the server's
  async retransmissions (§15.11, reusing the original payload sequence number)
  were re-displayed, duplicating console output and lagging the ACK bookkeeping.
  Responses are now matched by the acked-sequence-number echo (§15.9/§15.11);
  stale retransmissions are discarded. Regression-tested with exact-once delivery
  assertions.

## Testing

- Go loopback tests: full client/server path, pump retries, activation conflicts
  (80h), Suspend NACK/Flush, retry replay, deactivation status, reconnect
  outage/recovery (incl. trace emission), exact-once delivery
- `test/e2e/sol_test.sh`: real clients (local ipmitool / docker ipmitool / goipmi)
  against a PTY console — activation, outbound, 40-line streaming, inbound
  keystrokes, console-fault reconnect, `~.` deactivation, force-deactivate recovery
- CI `make test-e2e`: client/server/chassis/cipher-suite/SOL suites green on the
  final commits

## Notes

- Spec sections referenced throughout the code: ipmi-spec-v2.0-2013 §13.26–13.29,
  §15, §24, §26
- The alpine/musl ipmitool 1.8.19 crash on SOL data is an upstream client bug
  (2-byte overflow, fixed post-1.8.19); the e2e ipmitool image therefore defaults
  to a Debian build
