### PR TITLE
fix(client): stop SOL input after stream exit

### DIFF
--- a/pkg/client/sol_stream.go
+++ b/pkg/client/sol_stream.go
@@ -40,6 +40,9 @@ func readSOLInput(ctx context.Context, in io.Reader) <-chan solConsoleInput {
 		reader := bufio.NewReader(in)
 		for {
 			value, err := reader.ReadByte()
+			if ctx.Err() != nil {
+				return
+			}
 			event := solConsoleInput{value: value, err: err}
 			select {
 			case events <- event:
@@ -63,7 +66,10 @@ func (c *Client) runSOLStream(
 	pollInterval time.Duration,
 	interrupt <-chan os.Signal,
 ) error {
-	input := readSOLInput(ctx, in)
+	inputCtx, cancelInput := context.WithCancel(ctx)
+	defer cancelInput()
+
+	input := readSOLInput(inputCtx, in)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
Cancel the input reader context whenever the SOL stream returns so an abandoned reader cannot consume data intended for a later session. Check cancellation after a blocked read completes before reading again.