### PR TITLE
fix(client): retry unaccepted SOL data

### DIFF
--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -171,6 +171,75 @@ func TestSOLSessionLoopback(t *testing.T) {
 	waitForCondition(t, "console conn close", fake.IsClosed)
 }
 
+type rejectingConsole struct {
+	mock.FakeConsoleConn
+
+	mu sync.Mutex
+
+	rejects int
+	writes  int
+}
+
+func (c *rejectingConsole) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if len(p) == 0 {
+		c.mu.Unlock()
+		return 0, nil
+	}
+	c.writes++
+	if c.rejects != 0 {
+		if c.rejects > 0 {
+			c.rejects--
+		}
+		c.mu.Unlock()
+		return 0, nil
+	}
+	c.mu.Unlock()
+	return c.FakeConsoleConn.Write(p)
+}
+
+func (c *rejectingConsole) state() (writes int, tx string) {
+	c.mu.Lock()
+	writes = c.writes
+	c.mu.Unlock()
+	return writes, c.TXString()
+}
+
+func TestSOLStreamRetriesUnacceptedData(t *testing.T) {
+	console := &rejectingConsole{rejects: 1}
+	c, _ := newSOLTestServerWithConsole(t, &mock.Console{Conn: console})
+
+	err := c.SOLActivate(context.Background(), strings.NewReader("x"), io.Discard, &SOLActivateOptions{
+		PollInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("SOLActivate() error = %v", err)
+	}
+
+	writes, tx := console.state()
+	if writes != 2 || tx != "x" {
+		t.Fatalf("console writes = %d, data = %q, want 2 writes and %q", writes, tx, "x")
+	}
+}
+
+func TestSOLStreamBoundsUnacceptedDataRetries(t *testing.T) {
+	console := &rejectingConsole{rejects: -1}
+	c, _ := newSOLTestServerWithConsole(t, &mock.Console{Conn: console})
+
+	err := c.SOLActivate(context.Background(), strings.NewReader("x"), io.Discard, &SOLActivateOptions{
+		PollInterval: time.Hour,
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not accept") {
+		t.Fatalf("SOLActivate() error = %v, want bounded data transmission error", err)
+	}
+
+	writes, tx := console.state()
+	if writes != defaultSOLTransmitRetryCount+1 || tx != "" {
+		t.Fatalf("console writes = %d, data = %q, want %d writes and no data",
+			writes, tx, defaultSOLTransmitRetryCount+1)
+	}
+}
+
 // TestSOLActivateConflict verifies that a second activation while SOL is
 // active fails with 80h (payload already active on another session,
 // Table 24-2).

--- a/pkg/client/sol_stream.go
+++ b/pkg/client/sol_stream.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -16,6 +17,11 @@ type SOLStreamOptions struct {
 	// Zero selects a default (100ms).
 	PollInterval time.Duration
 }
+
+const (
+	defaultSOLTransmitRetryCount    = 3
+	defaultSOLTransmitRetryInterval = 100 * time.Millisecond
+)
 
 // SOLStream exchanges console data over an already active SOL payload. Input is transmitted
 // unchanged, unlike [Client.SOLActivate], this method does not interpret terminal escape sequences
@@ -71,7 +77,7 @@ func (c *Client) runSOLStream(
 	var remoteSeq uint8
 	var pendingAckCount uint8
 
-	sendPacket := func(chars []byte) error {
+	sendPacket := func(chars []byte) (*types.SOLPayloadResponse, error) {
 		req := &types.SOLPayloadRequest{
 			SOLPayloadPacket: types.SOLPayloadPacket{
 				SequenceNumber:         localSeq,
@@ -82,7 +88,7 @@ func (c *Client) runSOLStream(
 		}
 		res, err := c.SOLPayload(ctx, req)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		localSeq++
 		if localSeq > 0x0f {
@@ -95,13 +101,60 @@ func (c *Client) runSOLStream(
 
 		if len(res.CharacterData) > 0 {
 			if _, err := out.Write(res.CharacterData); err != nil {
+				return nil, err
+			}
+		}
+		return res, nil
+	}
+
+	sendData := func(chars []byte) error {
+		pending := chars
+		noProgressRetries := 0
+		for len(pending) > 0 {
+			// Retry only the data the BMC did not accept, using a fresh SOL sequence.
+			res, err := sendPacket(pending)
+			if err != nil {
 				return err
+			}
+
+			// The accepted count applies only to the data in this request.
+			accepted := int(res.AcceptedCharacterCount)
+			if accepted > len(pending) {
+				return fmt.Errorf("BMC acknowledged %d characters for a %d-byte SOL packet", accepted, len(pending))
+			}
+
+			if accepted > 0 {
+				// Any progress resets the consecutive no-progress retry budget.
+				noProgressRetries = 0
+			} else {
+				noProgressRetries++
+			}
+
+			// Remove the accepted data from the pending buffer.
+			pending = pending[accepted:]
+			if len(pending) == 0 {
+				return nil
+			}
+
+			// If the BMC did not accept any data, retry up to a limit.
+			if noProgressRetries > defaultSOLTransmitRetryCount {
+				return fmt.Errorf("BMC did not accept %d SOL data byte(s) after %d retries",
+					len(pending), defaultSOLTransmitRetryCount)
+			}
+
+			// Wait before retrying.
+			timer := time.NewTimer(defaultSOLTransmitRetryInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
 			}
 		}
 		return nil
 	}
 
-	if err := sendPacket(nil); err != nil {
+	if _, err := sendPacket(nil); err != nil {
 		return err
 	}
 
@@ -119,11 +172,11 @@ func (c *Client) runSOLStream(
 				return consoleInput.err
 			}
 
-			if err := sendPacket([]byte{consoleInput.value}); err != nil {
+			if err := sendData([]byte{consoleInput.value}); err != nil {
 				return err
 			}
 		case <-ticker.C:
-			if err := sendPacket(nil); err != nil {
+			if _, err := sendPacket(nil); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Honor the BMC accepted character count and retry remaining data with a fresh SOL sequence. Bound retries when no progress is made.