### PR TITLE
fix(server): eliminate data races in concurrent packet handling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,3 +50,20 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: make vet
+
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      # Always run with the race detector: it is a superset of a plain run, and
+      # the server shares session/config state across a goroutine per packet.
+      - name: Run tests
+        run: make test-race

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ test: fmt vet
 			--cover --coverprofile cover.out --trace --progress  $(TEST_ARGS)\
 			./pkg/... ./cmd/...
 
+# Run tests with the race detector. The server spawns a goroutine per packet and
+# shares session/config state across them, so race coverage is worth keeping.
+test-race:
+	go test -race -timeout 120s ./pkg/... ./cmd/...
+
 # Build goipmi and goipmi-server binaries
 build: fmt vet
 	go build -ldflags "$(LDFLAGS)" -o $(OUTPUT_DIR)/goipmi ./cmd/goipmi

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -36,14 +36,30 @@ type DeviceInfo struct {
 type BMC struct {
 	Info DeviceInfo
 	GUID [16]byte
-	KG   []byte // BMC key (Kg); nil means "one-key" mode using Kuid only
 
-	// CipherSuites is the set of RMCP+ cipher suites the server advertises and
+	// cfgMu guards the runtime-reconfigurable config fields kg, cipherSuites,
+	// v15AuthTypes, and v15Disabled. Readers on the packet hot path take the
+	// read lock and copy out; the options and setters take the write lock. The
+	// fields are unexported so every access provably goes through it.
+	cfgMu sync.RWMutex
+
+	// kg is the BMC key (Kg); nil means "one-key" mode using Kuid only.
+	// Set via [WithKG], read via [BMC.ResolvedKG] and [BMC.HasKG].
+	kg []byte
+
+	// cipherSuites is the set of RMCP+ cipher suites the server advertises and
 	// accepts during the Open Session handshake. Defaults to
 	// [DefaultCipherSuites] when nil. Each suite must be supported by the
 	// reference server (see [SupportedCipherSuite]); this is validated in
-	// [WithCipherSuites].
-	CipherSuites []types.CipherSuiteID
+	// [WithCipherSuites] and [BMC.SetCipherSuites]. Read it via
+	// [BMC.ResolvedCipherSuites].
+	cipherSuites []types.CipherSuiteID
+
+	// v15AuthTypes lists the v1.5 authentication types this BMC advertises and
+	// accepts. Set via [WithV15AuthTypes], read via [BMC.ResolvedV15AuthTypes].
+	v15AuthTypes []V15AuthType
+	// v15Disabled disables IPMI v1.5 LAN sessions when true.
+	v15Disabled bool
 
 	Users    *UserStore
 	Channels *ChannelStore
@@ -51,10 +67,6 @@ type BMC struct {
 
 	// V15Sessions tracks IPMI v1.5 LAN sessions (separate from RMCP+ sessions).
 	V15Sessions *V15SessionStore
-	// V15AuthTypes lists the v1.5 authentication types this BMC advertises and accepts.
-	V15AuthTypes []V15AuthType
-	// v15Disabled disables IPMI v1.5 LAN sessions when true.
-	v15Disabled bool
 
 	// SDRRepo tracks SDR repository reservation state (v2.0§33.11).
 	SDRRepo *SDRRepoStore
@@ -80,9 +92,28 @@ type Option func(*BMC)
 func WithKG(kg []byte) Option {
 	return func(b *BMC) {
 		if len(kg) > 0 {
-			b.KG = kg
+			b.cfgMu.Lock()
+			b.kg = append([]byte(nil), kg...)
+			b.cfgMu.Unlock()
 		}
 	}
+}
+
+// ResolvedKG returns a copy of the BMC key (Kg), or nil in one-key mode.
+func (b *BMC) ResolvedKG() []byte {
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	if len(b.kg) == 0 {
+		return nil
+	}
+	return append([]byte(nil), b.kg...)
+}
+
+// HasKG reports whether a BMC key (Kg) is configured, without copying it.
+func (b *BMC) HasKG() bool {
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	return len(b.kg) > 0
 }
 
 // WithClock injects a custom [clock.Clock].  Defaults to [clock.Real].
@@ -94,42 +125,66 @@ func WithClock(c clock.Clock) Option {
 // and accepts. Pass nil/empty to restore [DefaultV15AuthTypes].
 func WithV15AuthTypes(types []V15AuthType) Option {
 	return func(b *BMC) {
+		b.cfgMu.Lock()
+		defer b.cfgMu.Unlock()
 		if len(types) == 0 {
-			b.V15AuthTypes = nil
+			b.v15AuthTypes = nil
 			return
 		}
-		b.V15AuthTypes = append(b.V15AuthTypes[:0:0], types...)
+		b.v15AuthTypes = append(b.v15AuthTypes[:0:0], types...)
 		b.v15Disabled = false
 	}
 }
 
 // WithV15Disabled turns off IPMI v1.5 LAN session support. RMCP+ (v2.0) is unaffected.
 func WithV15Disabled() Option {
-	return func(b *BMC) { b.v15Disabled = true }
+	return func(b *BMC) {
+		b.cfgMu.Lock()
+		b.v15Disabled = true
+		b.cfgMu.Unlock()
+	}
 }
 
 // V15LANEnabled reports whether the BMC advertises and accepts IPMI v1.5 sessions.
 func (b *BMC) V15LANEnabled() bool {
-	return b != nil && !b.v15Disabled && len(b.ResolvedV15AuthTypes()) > 0
+	if b == nil {
+		return false
+	}
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	return !b.v15Disabled && len(b.resolvedV15AuthTypesLocked()) > 0
 }
 
-// ResolvedV15AuthTypes returns the v1.5 auth type list, defaulting to MD5.
-func (b *BMC) ResolvedV15AuthTypes() []V15AuthType {
+// resolvedV15AuthTypesLocked returns the internal v1.5 auth type list (not a
+// copy) and must be called with cfgMu held.
+func (b *BMC) resolvedV15AuthTypesLocked() []V15AuthType {
 	if b.v15Disabled {
 		return nil
 	}
-	if len(b.V15AuthTypes) > 0 {
-		return b.V15AuthTypes
+	if len(b.v15AuthTypes) > 0 {
+		return b.v15AuthTypes
 	}
 	return DefaultV15AuthTypes
 }
 
+// ResolvedV15AuthTypes returns a copy of the v1.5 auth type list, defaulting to MD5.
+func (b *BMC) ResolvedV15AuthTypes() []V15AuthType {
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	return append([]V15AuthType(nil), b.resolvedV15AuthTypesLocked()...)
+}
+
 // V15AuthTypeEnabled reports whether authType is configured on this BMC.
 func (b *BMC) V15AuthTypeEnabled(authType V15AuthType) bool {
-	if !b.V15LANEnabled() {
+	if b == nil {
 		return false
 	}
-	for _, t := range b.ResolvedV15AuthTypes() {
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	if b.v15Disabled {
+		return false
+	}
+	for _, t := range b.resolvedV15AuthTypesLocked() {
 		if t == authType {
 			return true
 		}
@@ -147,13 +202,15 @@ func WithCipherSuites(ids []types.CipherSuiteID) Option {
 	}
 }
 
-// ResolvedCipherSuites returns the cipher suite list to use for advertisement,
-// falling back to [DefaultCipherSuites] when none was configured.
+// ResolvedCipherSuites returns a copy of the cipher suite list to use for
+// advertisement, falling back to [DefaultCipherSuites] when none was configured.
 func (b *BMC) ResolvedCipherSuites() []types.CipherSuiteID {
-	if len(b.CipherSuites) > 0 {
-		return b.CipherSuites
+	b.cfgMu.RLock()
+	defer b.cfgMu.RUnlock()
+	if len(b.cipherSuites) > 0 {
+		return append([]types.CipherSuiteID(nil), b.cipherSuites...)
 	}
-	return DefaultCipherSuites
+	return append([]types.CipherSuiteID(nil), DefaultCipherSuites...)
 }
 
 // SetCipherSuites replaces the configured cipher suite list. Each ID must be
@@ -165,11 +222,17 @@ func (b *BMC) SetCipherSuites(ids []types.CipherSuiteID) {
 
 func (b *BMC) setCipherSuites(ids []types.CipherSuiteID) {
 	if len(ids) == 0 {
-		b.CipherSuites = nil
+		b.cfgMu.Lock()
+		b.cipherSuites = nil
+		b.cfgMu.Unlock()
 		return
 	}
+	// Validate before taking the lock; validateCipherSuites panics on an
+	// unsupported suite, so we never install a partially-validated list.
 	validateCipherSuites(ids)
-	b.CipherSuites = append(b.CipherSuites[:0:0], ids...)
+	b.cfgMu.Lock()
+	b.cipherSuites = append(b.cipherSuites[:0:0], ids...)
+	b.cfgMu.Unlock()
 }
 
 // New creates a BMC with sane defaults.

--- a/pkg/bmc/channel.go
+++ b/pkg/bmc/channel.go
@@ -83,7 +83,9 @@ func NewChannelStore() *ChannelStore {
 	return s
 }
 
-// Get returns the channel at number n, or [ErrChannelNotFound].
+// Get returns a snapshot copy of the channel at number n, or
+// [ErrChannelNotFound]. [Channel] is all scalar fields, so the copy is a
+// complete, independent snapshot; mutate the store via [ChannelStore.Set].
 func (s *ChannelStore) Get(n uint8) (*Channel, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -91,23 +93,27 @@ func (s *ChannelStore) Get(n uint8) (*Channel, error) {
 	if !ok {
 		return nil, fmt.Errorf("channel %d: %w", n, ErrChannelNotFound)
 	}
-	return ch, nil
+	cp := *ch
+	return &cp, nil
 }
 
-// Set adds or replaces the channel at number n.
+// Set adds or replaces the channel at number n, storing a private copy so the
+// caller cannot mutate stored state afterwards.
 func (s *ChannelStore) Set(ch *Channel) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.channels[ch.Number] = ch
+	cp := *ch
+	s.channels[cp.Number] = &cp
 }
 
-// All returns a snapshot of all configured channels.
+// All returns snapshot copies of all configured channels.
 func (s *ChannelStore) All() []*Channel {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]*Channel, 0, len(s.channels))
 	for _, ch := range s.channels {
-		out = append(out, ch)
+		cp := *ch
+		out = append(out, &cp)
 	}
 	return out
 }

--- a/pkg/bmc/eviction_test.go
+++ b/pkg/bmc/eviction_test.go
@@ -1,0 +1,78 @@
+package bmc
+
+import (
+	"testing"
+	"time"
+)
+
+// TestV15EvictExpiredNoDeadlockUnderHeldLock guards the eviction lock-order
+// invariant: eviction never takes a session's ProcMu, so a goroutine holding
+// one (as Get Session Challenge -> CreatePending -> eviction does when
+// dispatched under the per-session lock) can trigger eviction safely. The
+// clock is advanced past the timeout so the held-ProcMu session is the one
+// actually being evicted, not merely skipped as fresh.
+func TestV15EvictExpiredNoDeadlockUnderHeldLock(t *testing.T) {
+	clk := &mockClock{now: time.Now()}
+	store := NewV15SessionStore(clk)
+	us := NewUserStore()
+	u, err := us.Add(2, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := store.CreatePending(V15AuthTypeMD5, u, [16]byte{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clk.now = clk.now.Add(DefaultInactivityTimeout + DefaultInactivityTimeoutTolerance + time.Second)
+
+	sess.ProcMu.Lock()
+	defer sess.ProcMu.Unlock()
+
+	done := make(chan int)
+	go func() {
+		done <- store.EvictExpired()
+	}()
+
+	select {
+	case n := <-done:
+		if n != 1 {
+			t.Fatalf("want 1 evicted session, got %d", n)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("DEADLOCK: EvictExpired blocked on a session lock held by the caller")
+	}
+}
+
+// TestRMCPPlusEvictExpiredNoDeadlockUnderHeldLock is the RMCP+ counterpart:
+// the same self-deadlock would exist if the v2.0 store's eviction ever waited
+// on ProcMu.
+func TestRMCPPlusEvictExpiredNoDeadlockUnderHeldLock(t *testing.T) {
+	clk := &mockClock{now: time.Now()}
+	store := NewSessionStore(clk)
+
+	sess, err := store.Allocate(0xABCD1234, 0, 0, 0, PrivilegeLevelAdministrator, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clk.now = clk.now.Add(DefaultInactivityTimeout + DefaultInactivityTimeoutTolerance + time.Second)
+
+	sess.ProcMu.Lock()
+	defer sess.ProcMu.Unlock()
+
+	done := make(chan int)
+	go func() {
+		done <- store.EvictExpired()
+	}()
+
+	select {
+	case n := <-done:
+		if n != 1 {
+			t.Fatalf("want 1 evicted session, got %d", n)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("DEADLOCK: EvictExpired blocked on a session lock held by the caller")
+	}
+}

--- a/pkg/bmc/session.go
+++ b/pkg/bmc/session.go
@@ -85,7 +85,10 @@ type Session struct {
 	// ProcMu serializes per-session packet processing. The server spawns a
 	// goroutine per inbound packet; without this lock, a burst of packets
 	// from one session is processed in scheduler order — scrambling SOL
-	// keystroke bytes and racing the inbound-seq check-then-set.
+	// keystroke bytes and racing the inbound-seq check-then-set. The RAKP
+	// handlers take it too: duplicate handshake messages for one pending
+	// session otherwise race on the nonces, derived keys, and state below.
+	// ProcMu may be held while taking the store lock, never the reverse.
 	ProcMu sync.Mutex
 
 	// Session keys derived during RAKP.
@@ -106,7 +109,10 @@ type Session struct {
 	// Channel this session arrived on.
 	Channel uint8
 
-	// Timing
+	// Timing. LastActivity is guarded by the store lock: it is refreshed via
+	// [SessionStore.Touch] when a validated packet is processed and read by
+	// eviction, both under that lock. CreatedAt is set before the session is
+	// published into the store and never written again.
 	CreatedAt    time.Time
 	LastActivity time.Time
 }
@@ -165,7 +171,12 @@ func NewSessionStoreWithOptions(clk clock.Clock, opts ...SessionStoreOption) *Se
 // Allocate creates a new pending session and returns it.
 // If capacity is reached, it evicts the oldest pending session (LRU per spec).
 // Returns [ErrSessionFull] only when all slots are occupied by active sessions.
-func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integrityAlg types.IntegrityAlg, cryptAlg types.CryptAlg) (*Session, error) {
+//
+// maxPriv and channel are stored before the session is inserted into the map so
+// the struct is fully initialized before it becomes reachable to other
+// goroutines; callers must not write session fields after Allocate returns
+// without holding [Session.ProcMu].
+func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integrityAlg types.IntegrityAlg, cryptAlg types.CryptAlg, maxPriv PrivilegeLevel, channel uint8) (*Session, error) {
 	s.mu.Lock()
 
 	// Collect the evicted IDs so their removal hooks (payload deactivation,
@@ -206,6 +217,8 @@ func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integri
 		AuthAlg:      authAlg,
 		IntegrityAlg: integrityAlg,
 		CryptAlg:     cryptAlg,
+		MaxPrivilege: maxPriv,
+		Channel:      channel,
 		CreatedAt:    now,
 		LastActivity: now,
 	}
@@ -213,8 +226,11 @@ func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integri
 	return sess, nil
 }
 
-// Get returns the session for bmcID, or [ErrNoSession].
-// It also updates [Session.LastActivity].
+// Get returns the session for bmcID, or [ErrNoSession]. It is a pure lookup:
+// activity is refreshed separately via [SessionStore.Touch], only once a packet
+// has passed integrity and sequence validation. Refreshing on lookup would let
+// packets that fail validation, or that merely name a session ID, keep the
+// session alive forever.
 func (s *SessionStore) Get(bmcID uint32) (*Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -222,8 +238,38 @@ func (s *SessionStore) Get(bmcID uint32) (*Session, error) {
 	if !ok {
 		return nil, fmt.Errorf("session 0x%08x: %w", bmcID, ErrNoSession)
 	}
-	sess.LastActivity = s.clock.Now()
 	return sess, nil
+}
+
+// Touch refreshes the session's inactivity clock. The server calls it for every
+// packet that passed integrity and sequence validation. Handshake packets never
+// touch: RAKP messages carry no authenticator, so the inactivity budget stamped
+// at allocation bounds the whole handshake instead.
+func (s *SessionStore) Touch(bmcID uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[bmcID]; ok {
+		sess.LastActivity = s.clock.Now()
+	}
+}
+
+// Activate marks the session active after RAKP completes, or returns
+// [ErrNoSession] when the session was evicted in the meantime (capacity
+// pressure evicts the oldest pending session, which can be one whose RAKP3 is
+// in flight); activating the orphaned struct would hand the console a
+// successful RAKP4 for a session that no longer exists. It takes the store
+// lock because the pending-session eviction scan reads State under it, while
+// the caller holds [Session.ProcMu], so a reader under either lock observes a
+// consistent value.
+func (s *SessionStore) Activate(bmcID uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[bmcID]
+	if !ok {
+		return fmt.Errorf("session 0x%08x: %w", bmcID, ErrNoSession)
+	}
+	sess.State = SessionStateActive
+	return nil
 }
 
 // Close marks a session as closed and removes it from the store.

--- a/pkg/bmc/session_test.go
+++ b/pkg/bmc/session_test.go
@@ -19,7 +19,7 @@ func TestSessionStore_AllocateAndGet(t *testing.T) {
 	clk := &mockClock{now: time.Now()}
 	s := NewSessionStore(clk)
 
-	sess, err := s.Allocate(0xABCD1234, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	sess, err := s.Allocate(0xABCD1234, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, PrivilegeLevelAdministrator, 1)
 	if err != nil {
 		t.Fatalf("Allocate: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestSessionStore_AllocateAndGet(t *testing.T) {
 
 func TestSessionStore_Close(t *testing.T) {
 	s := NewSessionStore(clock.Real)
-	sess, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	sess, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, PrivilegeLevelAdministrator, 1)
 
 	if err := s.Close(sess.BMCID); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -55,7 +55,7 @@ func TestSessionStore_EvictExpired(t *testing.T) {
 	clk := &mockClock{now: time.Now()}
 	s := NewSessionStoreWithOptions(clk, WithInactivityTimeout(10*time.Second))
 
-	sess, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	sess, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, PrivilegeLevelAdministrator, 1)
 
 	// Advance time past the timeout.
 	clk.now = clk.now.Add(20 * time.Second)
@@ -72,13 +72,13 @@ func TestSessionStore_FullEvictsOldestPending(t *testing.T) {
 	clk := &mockClock{now: time.Now()}
 	s := NewSessionStoreWithOptions(clk, WithMaxSessions(2))
 
-	s1, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	s1, _ := s.Allocate(1, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, PrivilegeLevelAdministrator, 1)
 	clk.now = clk.now.Add(time.Second)
-	_, _ = s.Allocate(2, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	_, _ = s.Allocate(2, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, PrivilegeLevelAdministrator, 1)
 
 	// Third allocation should evict s1 (oldest pending).
 	clk.now = clk.now.Add(time.Second)
-	_, err := s.Allocate(3, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	_, err := s.Allocate(3, types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, PrivilegeLevelAdministrator, 1)
 	if err != nil {
 		t.Fatalf("expected successful allocation after eviction, got: %v", err)
 	}

--- a/pkg/bmc/session_v15.go
+++ b/pkg/bmc/session_v15.go
@@ -58,7 +58,24 @@ const (
 )
 
 // V15Session holds IPMI v1.5 session state.
+//
+// Concurrency: it follows the same pattern as the v2.0 [Session]. ProcMu
+// serializes per-session packet processing and guards the per-packet fields
+// written during dispatch: the sequence counters, InboundRcvd, and
+// PrivilegeLevel. SessionID, State, and MaxPrivilege are written after
+// publication only by [V15SessionStore.Activate], which runs under the store
+// lock while its caller holds ProcMu, so a reader under either lock observes a
+// consistent value (the Count* helpers read them under the store lock).
+// LastActivity is guarded by the store lock and refreshed via
+// [V15SessionStore.Touch]. TempSessionID, AuthType, Challenge, Channel, User,
+// and CreatedAt are set before the session is published and never written
+// again. ProcMu may be held while taking the store lock, never the reverse.
 type V15Session struct {
+	// ProcMu serializes per-session packet processing. The server spawns a
+	// goroutine per inbound packet; without this lock, concurrent packets of
+	// one session race on the sequence window check-then-set and the counters.
+	ProcMu sync.Mutex
+
 	TempSessionID uint32
 	SessionID     uint32
 	State         V15SessionState
@@ -100,6 +117,8 @@ func NewV15SessionStore(clk clock.Clock) *V15SessionStore {
 }
 
 // CreatePending allocates a pending v1.5 session after Get Session Challenge.
+// The session is fully initialized before it is inserted into the map, so no
+// unguarded field write happens after it becomes reachable to other goroutines.
 func (s *V15SessionStore) CreatePending(authType V15AuthType, user *User, challenge [16]byte, channel uint8) (*V15Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -138,7 +157,11 @@ func (s *V15SessionStore) CreatePending(authType V15AuthType, user *User, challe
 	return sess, nil
 }
 
-// Get returns a session by its current lookup ID without updating activity.
+// Get returns a session by its current lookup ID. It is a pure lookup: activity
+// is refreshed separately via [V15SessionStore.Touch], only once a packet has
+// passed authentication and sequence validation. Refreshing on lookup would let
+// packets that fail validation, or that merely name a session ID, keep the
+// session alive forever.
 func (s *V15SessionStore) Get(id uint32) (*V15Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -149,14 +172,14 @@ func (s *V15SessionStore) Get(id uint32) (*V15Session, error) {
 	return sess, nil
 }
 
-// Touch records valid session activity for inactivity timeout (spec v1.5§6.11.13 / v2.0§6.12.15).
-func (s *V15SessionStore) Touch(sess *V15Session) {
-	if sess == nil {
-		return
-	}
+// Touch refreshes the session's inactivity clock. The server calls it for every
+// packet that passed authentication and sequence validation.
+func (s *V15SessionStore) Touch(id uint32) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	sess.LastActivity = s.clock.Now()
+	if sess, ok := s.sessions[id]; ok {
+		sess.LastActivity = s.clock.Now()
+	}
 }
 
 // CountActiveSessions returns the number of active v1.5 sessions.
@@ -210,11 +233,21 @@ func (s *V15SessionStore) CountActiveSessionsWithMaxPrivilegeAtLeast(min Privile
 // empty receive bitmap — otherwise the first packet (seq == inboundSeq) is
 // rejected as a duplicate and clients such as ipmitool stall for a full LAN
 // timeout before retrying with inboundSeq+1.
+//
+// Precondition: the caller must hold pending's ProcMu. Activate mutates fields
+// of an already-published session (SessionID, State, MaxPrivilege,
+// PrivilegeLevel, the seq counters, and LastActivity) under the store lock;
+// per-packet readers hold ProcMu and the store's Count* and eviction scans
+// hold the store lock, so with the writer holding both, a reader under either
+// lock observes a consistent session.
+//
+// A session evicted between lookup and activation is reported as not pending
+// rather than silently re-inserted.
 func (s *V15SessionStore) Activate(pending *V15Session, permanentID, inboundSeq, outboundSeq uint32, maxPrivilege PrivilegeLevel) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if pending.State != V15SessionStatePending {
+	if pending.State != V15SessionStatePending || s.sessions[pending.TempSessionID] != pending {
 		return errors.New("session is not pending")
 	}
 	delete(s.sessions, pending.TempSessionID)
@@ -264,13 +297,17 @@ func (s *V15SessionStore) Close(id uint32) error {
 	return nil
 }
 
-// EvictExpired removes inactive v1.5 sessions past the timeout.
+// EvictExpired removes inactive v1.5 sessions past the timeout. Eviction reads
+// LastActivity and deletes under the store lock only; it never takes a
+// session's ProcMu, so a handler holding one can trigger eviction safely.
 func (s *V15SessionStore) EvictExpired() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.evictExpiredLocked()
 }
 
+// evictExpiredLocked removes sessions inactive beyond the timeout. s.mu must be
+// held.
 func (s *V15SessionStore) evictExpiredLocked() int {
 	now := s.clock.Now()
 	limit := s.timeout + DefaultInactivityTimeoutTolerance
@@ -284,6 +321,8 @@ func (s *V15SessionStore) evictExpiredLocked() int {
 	return n
 }
 
+// evictOldestPendingLocked removes the oldest pending session, returning true
+// if one was removed. s.mu must be held.
 func (s *V15SessionStore) evictOldestPendingLocked() bool {
 	var oldest *V15Session
 	var oldestID uint32

--- a/pkg/bmc/sol_test.go
+++ b/pkg/bmc/sol_test.go
@@ -22,7 +22,7 @@ import (
 // payload access on channel 1.
 func newSOLTestSession(t *testing.T, b *BMC) *Session {
 	t.Helper()
-	sess, err := b.Sessions.Allocate(0xA5A5A5A5, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	sess, err := b.Sessions.Allocate(0xA5A5A5A5, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, PrivilegeLevelAdministrator, 1)
 	if err != nil {
 		t.Fatalf("allocate session: %v", err)
 	}

--- a/pkg/bmc/user.go
+++ b/pkg/bmc/user.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 )
 
@@ -45,14 +46,10 @@ type User struct {
 	ChannelAccess map[uint8]UserChannelAccess
 
 	// PayloadAccess holds per-channel payload activation rights keyed by
-	// channel number (spec v2.0 §24.6/§24.7). Guarded by payloadMu: entries
-	// are created and updated by the payload-access commands while SOL
-	// activation reads them, and two sessions authenticated as the same
-	// user (or a session plus the SOL activation path) can do so
-	// concurrently — an unlocked map write is a fatal "concurrent map
-	// writes" runtime error.
-	payloadMu     sync.Mutex
-	PayloadAccess map[uint8]*UserPayloadAccess
+	// channel number (spec v2.0 §24.6/§24.7). Like every other mutable User
+	// field it follows the store's snapshot discipline: lookups hand out
+	// deep copies, and a runtime change goes through [UserStore.Update].
+	PayloadAccess map[uint8]UserPayloadAccess
 }
 
 // UserPayloadAccess records a user's payload activation rights on one
@@ -69,26 +66,24 @@ type UserPayloadAccess struct {
 const defaultStandardPayload1 = 0x02
 
 // SOLEnabled reports whether the user may activate the SOL payload.
-func (a *UserPayloadAccess) SOLEnabled() bool { return a.Standard1&0x02 != 0 }
+func (a UserPayloadAccess) SOLEnabled() bool { return a.Standard1&0x02 != 0 }
 
-// PayloadAccessFor returns a snapshot of the user's payload access entry for
-// channel, creating it with default rights (SOL enabled) on first use. A copy
-// is returned so readers never race a concurrent Set Payload Access update on
-// the live entry.
-func (u *User) PayloadAccessFor(channel uint8) *UserPayloadAccess {
-	u.payloadMu.Lock()
-	defer u.payloadMu.Unlock()
-	a := *u.getOrCreatePayloadAccess(channel)
-	return &a
+// PayloadAccessFor returns the user's payload access entry for channel, or the
+// default rights (SOL enabled) when none was ever set.
+func (u *User) PayloadAccessFor(channel uint8) UserPayloadAccess {
+	if a, ok := u.PayloadAccess[channel]; ok {
+		return a
+	}
+	return UserPayloadAccess{Standard1: defaultStandardPayload1}
 }
 
 // SetPayloadAccess applies an enable/disable update to the user's payload
 // access entry for channel (spec v2.0 Table 24-8: on enable, 1-bits set and
-// 0-bits leave unchanged; on disable, 1-bits clear).
+// 0-bits leave unchanged; on disable, 1-bits clear). Like any other User
+// mutation, call it at construction time or on the live user inside a
+// [UserStore.Update] callback, never on a store-returned snapshot.
 func (u *User) SetPayloadAccess(channel uint8, enable bool, standard1, oem1 uint8) {
-	u.payloadMu.Lock()
-	defer u.payloadMu.Unlock()
-	a := u.getOrCreatePayloadAccess(channel)
+	a := u.PayloadAccessFor(channel)
 	if enable {
 		a.Standard1 |= standard1
 		a.OEM1 |= oem1
@@ -96,20 +91,10 @@ func (u *User) SetPayloadAccess(channel uint8, enable bool, standard1, oem1 uint
 		a.Standard1 &^= standard1
 		a.OEM1 &^= oem1
 	}
-}
-
-// getOrCreatePayloadAccess returns the user's live entry for channel, creating
-// it with default rights (SOL enabled) on first use. u.payloadMu must be held.
-func (u *User) getOrCreatePayloadAccess(channel uint8) *UserPayloadAccess {
 	if u.PayloadAccess == nil {
-		u.PayloadAccess = make(map[uint8]*UserPayloadAccess)
+		u.PayloadAccess = make(map[uint8]UserPayloadAccess)
 	}
-	a, ok := u.PayloadAccess[channel]
-	if !ok {
-		a = &UserPayloadAccess{Standard1: defaultStandardPayload1}
-		u.PayloadAccess[channel] = a
-	}
-	return a
+	u.PayloadAccess[channel] = a
 }
 
 // SetPassword copies up to MaxPasswordLen bytes from raw into the User's password field.
@@ -154,7 +139,23 @@ func NewUserStore() *UserStore {
 	return s
 }
 
-// Add creates a new user at the given ID.
+// copyUser returns a deep copy of u: the struct value (Password is a value
+// array, Name a string, both safe to copy) plus fresh access maps. The copy
+// shares no mutable state with the stored user, so callers may read it without
+// holding any lock.
+func copyUser(u *User) *User {
+	if u == nil {
+		return nil
+	}
+	cp := *u
+	cp.ChannelAccess = maps.Clone(u.ChannelAccess)
+	cp.PayloadAccess = maps.Clone(u.PayloadAccess)
+	return &cp
+}
+
+// Add creates a new user at the given ID and returns the live [*User] for
+// construction-time seeding. Mutating the returned pointer is only safe before
+// the server starts serving; use [UserStore.Update] for runtime changes.
 // Returns [ErrInvalidUserID] for IDs outside 1-63, or [ErrUsernameTaken] if
 // name is non-empty and already in use.
 func (s *UserStore) Add(id uint8, name string) (*User, error) {
@@ -181,7 +182,8 @@ func (s *UserStore) Add(id uint8, name string) (*User, error) {
 	return u, nil
 }
 
-// Get returns the user at the given ID, or [ErrUserNotFound].
+// Get returns a snapshot copy of the user at the given ID, or [ErrUserNotFound].
+// The returned [*User] is a private copy; mutate the store via [UserStore.Update].
 func (s *UserStore) Get(id uint8) (*User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -189,24 +191,25 @@ func (s *UserStore) Get(id uint8) (*User, error) {
 	if !ok {
 		return nil, fmt.Errorf("user %d: %w", id, ErrUserNotFound)
 	}
-	return u, nil
+	return copyUser(u), nil
 }
 
-// GetByName returns the user with the given name, or [ErrUserNotFound].
-// An empty name matches the anonymous user (ID 1).
+// GetByName returns a snapshot copy of the user with the given name, or
+// [ErrUserNotFound]. An empty name matches the anonymous user (ID 1).
 func (s *UserStore) GetByName(name string) (*User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, u := range s.users {
 		if u.Name == name {
-			return u, nil
+			return copyUser(u), nil
 		}
 	}
 	return nil, fmt.Errorf("user %q: %w", name, ErrUserNotFound)
 }
 
-// FindEnabledByNameOnChannel scans user IDs 1..MaxUsers in order and returns
-// the first enabled user with a matching name and channel access (spec v1.5§18.24 / v2.0§22.27).
+// FindEnabledByNameOnChannel scans user IDs 1..MaxUsers in order and returns a
+// snapshot copy of the first enabled user with a matching name and channel
+// access (spec v1.5§18.24 / v2.0§22.27).
 func (s *UserStore) FindEnabledByNameOnChannel(name string, channel uint8) (*User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -222,9 +225,27 @@ func (s *UserStore) FindEnabledByNameOnChannel(name string, channel uint8) (*Use
 		if !ok || !access.Enabled {
 			continue
 		}
-		return u, nil
+		return copyUser(u), nil
 	}
 	return nil, fmt.Errorf("user %q on channel %d: %w", name, channel, ErrUserNotFound)
+}
+
+// Update runs fn against the live [*User] for id under the store write lock, the
+// race-free way to mutate a user at runtime (e.g. from a Set User Password
+// handler). Returns [ErrUserNotFound] if id is not present.
+//
+// fn runs with the store lock held: it must not call back into the store (that
+// self-deadlocks on the non-reentrant lock) and must not retain the [*User]
+// past its return, since using the live pointer outside the lock recreates the
+// race the snapshot lookups exist to prevent.
+func (s *UserStore) Update(id uint8, fn func(*User) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[id]
+	if !ok {
+		return fmt.Errorf("user %d: %w", id, ErrUserNotFound)
+	}
+	return fn(u)
 }
 
 // Delete removes a user by ID.  User 1 (anonymous) cannot be deleted.

--- a/pkg/bmc/user_test.go
+++ b/pkg/bmc/user_test.go
@@ -103,29 +103,48 @@ func TestUserVerifyPassword(t *testing.T) {
 }
 
 // TestUserPayloadAccessConcurrent hammers one account's payload access table
-// from many goroutines: two sessions authenticated as the same user (or a
-// session plus the SOL activation path) can issue Set/Get Payload Access
-// concurrently, and the lazily-created per-channel map must survive — an
-// unlocked map write is a fatal "concurrent map writes" runtime error.
+// from many goroutines through the store: two sessions authenticated as the
+// same user (or a session plus the SOL activation path) can issue Set/Get
+// Payload Access concurrently. Writers go through [UserStore.Update] and
+// readers through the snapshot copies [UserStore.Get] hands out, which is the
+// concurrency contract the server relies on.
 func TestUserPayloadAccessConcurrent(t *testing.T) {
-	u := &User{}
+	s := NewUserStore()
+	if _, err := s.Add(2, "payload"); err != nil {
+		t.Fatal(err)
+	}
 	var wg sync.WaitGroup
 	for i := 0; i < 16; i++ {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
+				u, err := s.Get(2)
+				if err != nil {
+					t.Error(err)
+					return
+				}
 				u.PayloadAccessFor(1).SOLEnabled()
 			}
 		}()
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
-				u.SetPayloadAccess(1, true, 2, 0)
+				if err := s.Update(2, func(u *User) error {
+					u.SetPayloadAccess(1, true, 2, 0)
+					return nil
+				}); err != nil {
+					t.Error(err)
+					return
+				}
 			}
 		}()
 	}
 	wg.Wait()
+	u, err := s.Get(2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !u.PayloadAccessFor(1).SOLEnabled() {
 		t.Fatal("SOL access bit lost under concurrency")
 	}

--- a/pkg/client/cmd_sol_activate.go
+++ b/pkg/client/cmd_sol_activate.go
@@ -39,9 +39,9 @@ const (
 	// would terminate the SSH connection instead of just the SOL session.
 	// This choice avoids conflicts and allows the SOL session to exit cleanly
 	// while keeping the SSH connection intact.
-	SOLEscapeSequence     = "~X"
-	solEscapePrefix      = '~'
-	solEscapeTerminator  = 'X'
+	SOLEscapeSequence   = "~X"
+	solEscapePrefix     = '~'
+	solEscapeTerminator = 'X'
 )
 
 func solActivatePollInterval(opts *SOLActivateOptions) time.Duration {

--- a/pkg/client/server_rakp_sha256_test.go
+++ b/pkg/client/server_rakp_sha256_test.go
@@ -28,12 +28,11 @@ func TestRAKP_SHA256_CrossValidation(t *testing.T) {
 	b := newSHA256TestBMC(t, username, password)
 
 	sess, err := b.Sessions.Allocate(consoleID,
-		types.AuthAlg_HMAC_SHA256, types.IntegrityAlg_HMAC_SHA256_128, types.CryptAlg_AES_CBC_128)
+		types.AuthAlg_HMAC_SHA256, types.IntegrityAlg_HMAC_SHA256_128, types.CryptAlg_AES_CBC_128,
+		bmc.PrivilegeLevelAdministrator, 1)
 	if err != nil {
 		t.Fatalf("allocate session: %v", err)
 	}
-	sess.Channel = 1
-	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
 
 	// Build RAKP1 with a fixed console random for reproducibility.
 	var consoleRand [16]byte
@@ -188,7 +187,7 @@ func TestRAKP4_CrossValidation_AuthAlgorithm(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b := newSHA256TestBMC(t, username, password)
 
-			sess, err := b.Sessions.Allocate(consoleID, tc.authAlg, tc.integrityAlg, types.CryptAlg_None)
+			sess, err := b.Sessions.Allocate(consoleID, tc.authAlg, tc.integrityAlg, types.CryptAlg_None, bmc.PrivilegeLevelAdministrator, 1)
 			if err != nil {
 				t.Fatalf("allocate session: %v", err)
 			}

--- a/pkg/handlers/context.go
+++ b/pkg/handlers/context.go
@@ -22,8 +22,21 @@ import (
 )
 
 // HandlerContext carries per-request BMC state to a [Handler].
-// All fields are read-only from the handler's perspective; mutations must go
-// through the store methods (which are goroutine-safe).
+//
+// Concurrency contract:
+//   - Session / V15Session: the server holds the session's ProcMu for the
+//     entire dispatch, so a handler may read and write these session fields
+//     directly (only Set Session Privilege Level does, on PrivilegeLevel).
+//     Registry-dispatched handlers must NOT take ProcMu themselves; it is
+//     already held, and the mutex is not reentrant. The RAKP handlers
+//     ([HandleOpenSession], [HandleRAKP1], [HandleRAKP3]) are the exception:
+//     they are dispatched outside the in-session path and take ProcMu
+//     themselves, so calling them from a registry-dispatched handler
+//     self-deadlocks.
+//   - User / Channel: independent snapshot copies, safe to read without locking
+//     but not connected to the store. To change a user or channel at runtime,
+//     use [bmc.UserStore.Update] or [bmc.ChannelStore.Set].
+//   - BMC: goroutine-safe; mutate shared state only through its store methods.
 type HandlerContext struct {
 	// Command identifies the request being dispatched.  [Registry.Dispatch]
 	// fills it in from the command table, so middleware and handlers can name

--- a/pkg/handlers/payload.go
+++ b/pkg/handlers/payload.go
@@ -220,14 +220,15 @@ func handleSetUserPayloadAccess(ctx context.Context, hctx *HandlerContext, data 
 		return nil, types.CodeRequestDataFieldInvalid, nil // 10b/11b reserved (Table 24-8)
 	}
 	userID := data[1] & 0x3f
-	user, err := hctx.BMC.Users.Get(userID)
-	if err != nil {
+	// The read-modify-write runs on the live user under the store's write
+	// lock, so it is atomic against a concurrent Set/Get on another session
+	// authenticated as the same user.
+	if err := hctx.BMC.Users.Update(userID, func(u *bmc.User) error {
+		u.SetPayloadAccess(resolveChannel(hctx, data[0]&0x0f), op == 0, data[2], data[4])
+		return nil
+	}); err != nil {
 		return nil, types.CodeRequestDataFieldInvalid, nil
 	}
-	// The update runs under the user's payload-access lock: the read-modify-
-	// write must be atomic against a concurrent Set/Get on another session
-	// authenticated as the same user.
-	user.SetPayloadAccess(resolveChannel(hctx, data[0]&0x0f), op == 0, data[2], data[4])
 	return nil, types.CodeOK, nil
 }
 

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -41,6 +41,12 @@ func makeKey(netFn, cmd uint8) commandKey {
 }
 
 // Registry maps (NetFn, Cmd) pairs to [Handler] implementations.
+//
+// Concurrency: all registration ([Registry.Register], [Registry.RegisterFunc],
+// [Registry.Use], [Registry.Merge]) must complete before the server starts
+// serving. The registry is read-only during dispatch and is not synchronized,
+// so registering after [server.Server.Serve] has begun races with in-flight
+// packet handling.
 type Registry struct {
 	handlers   map[commandKey]Handler
 	commands   map[commandKey]types.Command

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -211,15 +211,18 @@ func HandleOpenSession(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, er
 		return buildOpenSessionError(tag, consoleID, code), nil
 	}
 
-	sess, err := b.Sessions.Allocate(consoleID, authAlg, intAlg, cryptAlg)
+	maxPrivilege := bmc.PrivilegeLevel(maxPriv)
+	if maxPrivilege == 0 {
+		maxPrivilege = bmc.PrivilegeLevelAdministrator
+	}
+
+	// Allocate fully initializes the session (including MaxPrivilege and
+	// Channel) before inserting it into the store, so no lock-free field write
+	// happens after it becomes reachable.
+	sess, err := b.Sessions.Allocate(consoleID, authAlg, intAlg, cryptAlg, maxPrivilege, lanChannelNumber)
 	if err != nil {
 		return buildOpenSessionError(tag, consoleID, 0x01), nil // Insufficient resources
 	}
-	sess.MaxPrivilege = bmc.PrivilegeLevel(maxPriv)
-	if sess.MaxPrivilege == 0 {
-		sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
-	}
-	sess.Channel = lanChannelNumber
 
 	authPayload, integPayload, cryptPayload := rmcpplus.NewAlgorithmPayloads(authAlg, intAlg, cryptAlg)
 	resp := &rmcpplus.OpenSessionResponse{
@@ -264,6 +267,20 @@ func HandleRAKP1(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, error) {
 	if err != nil {
 		return rakp2Error(tag, 0, 0x02), nil // Invalid Session ID
 	}
+	// Hold ProcMu across every session field read/write below. Handshake
+	// packets are dispatched outside the server's in-session path (they carry
+	// no session ID in the RMCP+ header), so this handler must serialize
+	// itself: duplicate RAKP1s for one pending session otherwise race on the
+	// nonces and derived keys. ProcMu-then-store-lock is the allowed order;
+	// the Close calls below take only the store lock.
+	//
+	// Deliberately no activity refresh here: RAKP1 carries no authenticator,
+	// so refreshing would let anyone who saw a session ID keep that session
+	// alive with replayed handshake packets. The inactivity budget stamped at
+	// allocation bounds the whole handshake instead, and it is orders of
+	// magnitude more than three round trips need.
+	sess.ProcMu.Lock()
+	defer sess.ProcMu.Unlock()
 	if sess.State != bmc.SessionStatePending {
 		return rakp2Error(tag, sess.ConsoleID, 0x08), nil // Inactive Session ID
 	}
@@ -338,6 +355,11 @@ func HandleRAKP3(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, error) {
 	if err != nil {
 		return rakp4Error(tag, 0, 0x02), nil // Invalid Session ID
 	}
+	// Hold ProcMu across all session field reads/writes and key derivation.
+	// See HandleRAKP1 for the lock-order rationale and for why the handshake
+	// deliberately never refreshes session activity.
+	sess.ProcMu.Lock()
+	defer sess.ProcMu.Unlock()
 
 	// If the console sent a non-zero status in RAKP3, it means the console
 	// rejected RAKP2.  Close the session and return an error response.
@@ -369,7 +391,9 @@ func HandleRAKP3(ctx context.Context, b *bmc.BMC, data []byte) ([]byte, error) {
 	if err := deriveSessKeys(sess, b); err != nil {
 		return rakp4Error(tag, sess.ConsoleID, 0xFF), err
 	}
-	sess.State = bmc.SessionStateActive
+	if err := b.Sessions.Activate(bmcSessionID); err != nil {
+		return rakp4Error(tag, sess.ConsoleID, 0x02), nil // Invalid Session ID
+	}
 	sess.PrivilegeLevel = sess.MaxPrivilege
 
 	// Compute RAKP4 auth code using SIK as HMAC key.

--- a/pkg/handlers/session_activity_test.go
+++ b/pkg/handlers/session_activity_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// advanceableClock is a Clock whose current time can be moved forward by tests.
+type advanceableClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *advanceableClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *advanceableClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func (c *advanceableClock) NewTimer(d time.Duration) clock.Timer   { return clock.Real.NewTimer(d) }
+func (c *advanceableClock) NewTicker(d time.Duration) clock.Ticker { return clock.Real.NewTicker(d) }
+
+func newAdminBMC(clk clock.Clock) (*bmc.BMC, error) {
+	info := bmc.DeviceInfo{
+		DeviceID:                1,
+		DeviceRevision:          1,
+		FirmwareMajor:           2,
+		IPMIVersion:             0x20,
+		ManufacturerID:          0x000157,
+		ProductID:               0x0001,
+		AdditionalDeviceSupport: 0x39,
+	}
+	b := bmc.New(info, [16]byte{}, mock.New(), bmc.WithClock(clk))
+	user, err := b.Users.Add(2, "ADMIN")
+	if err != nil {
+		return nil, err
+	}
+	user.SetPassword([]byte("ADMIN"))
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+	return b, nil
+}
+
+// TestHandleRAKP1DoesNotRefreshLastActivity asserts RAKP Message 1 leaves the
+// session's LastActivity alone. RAKP messages carry no authenticator, so a
+// refresh would let anyone who saw a session ID keep that session alive with
+// replayed handshake packets; the budget stamped at allocation bounds the
+// handshake instead.
+func TestHandleRAKP1DoesNotRefreshLastActivity(t *testing.T) {
+	clk := &advanceableClock{now: time.Now()}
+	b, err := newAdminBMC(clk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	created := sess.LastActivity
+
+	clk.advance(30 * time.Second)
+
+	resp, err := HandleRAKP1(context.Background(), b, rakp1Payload(sess.BMCID, bmc.PrivilegeLevelAdministrator, "ADMIN"))
+	if err != nil {
+		t.Fatalf("HandleRAKP1: %v", err)
+	}
+	if len(resp) < 2 || resp[1] != 0x00 {
+		t.Fatalf("want successful RAKP2 response, got %x", resp)
+	}
+	if !sess.LastActivity.Equal(created) {
+		t.Fatalf("LastActivity changed by RAKP1: created=%v after=%v", created, sess.LastActivity)
+	}
+}
+
+// TestHandleRAKP3DoesNotRefreshLastActivity asserts a malformed RAKP Message 3
+// naming a pending session leaves LastActivity alone: refreshing before the
+// message is authenticated would let garbage packets hold the pending slot open
+// forever, which is exactly the keepalive the touch-on-validated-packets design
+// removes.
+func TestHandleRAKP3DoesNotRefreshLastActivity(t *testing.T) {
+	clk := &advanceableClock{now: time.Now()}
+	b, err := newAdminBMC(clk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	created := sess.LastActivity
+
+	clk.advance(30 * time.Second)
+
+	// Minimal RAKP3 payload: tag, statusCode=0, bmc session ID. The unpack
+	// fails, so this is exactly the garbage packet that must not count as
+	// activity.
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint32(payload[4:8], sess.BMCID)
+	if _, err := HandleRAKP3(context.Background(), b, payload); err != nil {
+		t.Fatalf("HandleRAKP3: %v", err)
+	}
+	if !sess.LastActivity.Equal(created) {
+		t.Fatalf("LastActivity changed by malformed RAKP3: created=%v after=%v", created, sess.LastActivity)
+	}
+}

--- a/pkg/handlers/session_crypto.go
+++ b/pkg/handlers/session_crypto.go
@@ -45,8 +45,8 @@ func computeRAKP4AuthCode(sess *bmc.Session, b *bmc.BMC) ([]byte, error) {
 // deriveSessKeys computes SIK, K1, and K2 from the session parameters per spec §13.31-13.32.
 func deriveSessKeys(sess *bmc.Session, b *bmc.BMC) error {
 	var sikKey []byte
-	if len(b.KG) > 0 {
-		sikKey = b.KG
+	if kg := b.ResolvedKG(); len(kg) > 0 {
+		sikKey = kg
 	} else {
 		sikKey = paddedPassword(sess)
 	}

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -48,12 +48,10 @@ func TestHandleRAKP1RejectsUnauthorizedPrivilege(t *testing.T) {
 		MaxPrivilege: bmc.PrivilegeLevelUser,
 		Enabled:      true,
 	}
-	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
 	if err != nil {
 		t.Fatalf("allocate session: %v", err)
 	}
-	sess.Channel = lanChannelNumber
-	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
 
 	resp, err := HandleRAKP1(context.Background(), b, rakp1Payload(sess.BMCID, bmc.PrivilegeLevelAdministrator, "operator"))
 	if err != nil {
@@ -79,12 +77,10 @@ func TestHandleRAKP1AcceptsAuthorizedPrivilege(t *testing.T) {
 		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
 		Enabled:      true,
 	}
-	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
 	if err != nil {
 		t.Fatalf("allocate session: %v", err)
 	}
-	sess.Channel = lanChannelNumber
-	sess.MaxPrivilege = bmc.PrivilegeLevelAdministrator
 
 	resp, err := HandleRAKP1(context.Background(), b, rakp1Payload(sess.BMCID, bmc.PrivilegeLevelAdministrator, "ADMIN"))
 	if err != nil {
@@ -93,7 +89,9 @@ func TestHandleRAKP1AcceptsAuthorizedPrivilege(t *testing.T) {
 	if len(resp) < 40 || resp[1] != 0x00 {
 		t.Fatalf("want successful RAKP2 response, got %x", resp)
 	}
-	if sess.User != user {
+	// Users.GetByName returns a snapshot copy, so compare by identity fields
+	// rather than pointer equality.
+	if sess.User == nil || sess.User.Name != user.Name || sess.User.ID != user.ID {
 		t.Fatalf("session user was not recorded")
 	}
 }
@@ -378,7 +376,7 @@ func TestComputeRAKP4AuthCode_UsesAuthAlgorithm(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sess, err := b.Sessions.Allocate(0x11223344, tc.auth, tc.integ, types.CryptAlg_None)
+			sess, err := b.Sessions.Allocate(0x11223344, tc.auth, tc.integ, types.CryptAlg_None, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
 			if err != nil {
 				t.Fatalf("allocate session: %v", err)
 			}

--- a/pkg/handlers/session_v15_policy.go
+++ b/pkg/handlers/session_v15_policy.go
@@ -60,7 +60,7 @@ func fillChannelAuthCapsByte4(resp []byte, b *bmc.BMC, ch *bmc.Channel) {
 		return
 	}
 	resp[2] = 0x04 // Non-Null usernames enabled
-	if b != nil && len(b.KG) > 0 {
+	if b != nil && b.HasKG() {
 		resp[2] |= 0x20
 	}
 	if !ch.PerMessageAuth {

--- a/pkg/server/race_session_test.go
+++ b/pkg/server/race_session_test.go
@@ -1,0 +1,243 @@
+package server
+
+// RMCP+ per-session data-race regression tests driven over raw UDP.
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+	"github.com/bougou/go-ipmi/pkg/rmcpplus"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func raceMustWrite(t *testing.T, c *net.UDPConn, b []byte) {
+	t.Helper()
+	if _, err := c.Write(b); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func raceMustReadPayload(t *testing.T, c *net.UDPConn) []byte {
+	t.Helper()
+	buf := make([]byte, 4096)
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, _, payload, ok := protocol.ParseRMCPPlusHeader(buf[:n])
+	if !ok {
+		t.Fatal("bad rmcp+ response")
+	}
+	return payload
+}
+
+// raceOpenSessionSuite0 opens a suite-0 (no auth/integrity/confidentiality)
+// session so the session can go active and carry plaintext IPMI without
+// reimplementing RAKP crypto.
+func raceOpenSessionSuite0(t *testing.T, c *net.UDPConn, consoleID uint32) uint32 {
+	t.Helper()
+	authP, integP, cryptP := rmcpplus.NewAlgorithmPayloads(
+		types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None)
+	req := &rmcpplus.OpenSessionRequest{
+		RequestedMaximumPrivilegeLevel: types.PrivilegeLevelAdministrator,
+		RemoteConsoleSessionID:         consoleID,
+		AuthenticationPayload:          authP,
+		IntegrityPayload:               integP,
+		ConfidentialityPayload:         cryptP,
+	}
+	raceMustWrite(t, c, protocol.BuildRMCPPlusPacket(protocol.PayloadOpenSessionRequest, 0, 0, 0, req.Pack()))
+
+	var resp rmcpplus.OpenSessionResponse
+	if err := resp.Unpack(raceMustReadPayload(t, c)); err != nil {
+		t.Fatal(err)
+	}
+	if resp.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		t.Fatalf("open session status %v", resp.RmcpStatusCode)
+	}
+	return resp.ManagedSystemSessionID
+}
+
+// raceDoRAKPNone completes the RAKP handshake for an AuthAlg_None session.
+func raceDoRAKPNone(t *testing.T, c *net.UDPConn, bmcID uint32) {
+	t.Helper()
+	m1 := &rmcpplus.RAKPMessage1{
+		ManagedSystemSessionID:         bmcID,
+		RequestedMaximumPrivilegeLevel: types.PrivilegeLevelAdministrator,
+		UsernameLength:                 uint8(len(raceUser)),
+		Username:                       []byte(raceUser),
+	}
+	raceMustWrite(t, c, protocol.BuildRMCPPlusPacket(protocol.PayloadRAKPMessage1, 0, 0, 0, m1.Pack()))
+	var msg2 rmcpplus.RAKPMessage2
+	msg2.AuthAlg = types.AuthAlg_None
+	if err := msg2.Unpack(raceMustReadPayload(t, c)); err != nil {
+		t.Fatalf("rakp2 unpack: %v", err)
+	}
+	if msg2.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		t.Fatalf("rakp2 status %v", msg2.RmcpStatusCode)
+	}
+
+	m3 := &rmcpplus.RAKPMessage3{
+		RmcpStatusCode:         types.RmcpStatusCodeNoErrors,
+		ManagedSystemSessionID: bmcID,
+	}
+	raceMustWrite(t, c, protocol.BuildRMCPPlusPacket(protocol.PayloadRAKPMessage3, 0, 0, 0, m3.Pack()))
+	var msg4 rmcpplus.RAKPMessage4
+	msg4.AuthAlg = types.AuthAlg_None
+	if err := msg4.Unpack(raceMustReadPayload(t, c)); err != nil {
+		t.Fatalf("rakp4 unpack: %v", err)
+	}
+	if msg4.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		t.Fatalf("rakp4 status %v (session not active)", msg4.RmcpStatusCode)
+	}
+}
+
+// raceGetDeviceIDPayload builds a minimal IPMB-format Get Device ID request.
+func raceGetDeviceIDPayload() []byte {
+	return []byte{
+		0x20,      // rsAddr
+		0x06 << 2, // netFn/lun (App)
+		0x00,      // csum1
+		0x81,      // rqAddr
+		0x01 << 2, // rqSeq/lun
+		0x01,      // cmd = Get Device ID
+		0x00,      // csum2 (stripped)
+	}
+}
+
+// TestActiveSessionSeqRace establishes an active suite-0 session, then fires
+// many plaintext IPMI packets on the SAME session from several sockets. Each is
+// dispatched in its own server goroutine; before the per-session lock, the
+// shared inbound/outbound sequence writes raced.
+func TestActiveSessionSeqRace(t *testing.T) {
+	b := raceNewBMC(t, bmc.WithCipherSuites([]types.CipherSuiteID{types.CipherSuiteID0}))
+	port, _, stop := raceStartServer(t, b)
+	defer stop()
+
+	hs, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bmcID := raceOpenSessionSuite0(t, hs, 0x11223344)
+	raceDoRAKPNone(t, hs, bmcID)
+	_ = hs.Close()
+
+	sessPkt := protocol.BuildRMCPPlusPacket(protocol.PayloadIPMI, 0, bmcID, 1, raceGetDeviceIDPayload())
+
+	var wg sync.WaitGroup
+	var responded atomic.Bool
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+			if err != nil {
+				return
+			}
+			defer c.Close()
+			buf := make([]byte, 4096)
+			for range 60 {
+				_, _ = c.Write(sessPkt)
+				_ = c.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+				if _, err := c.Read(buf); err == nil {
+					responded.Store(true)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	// The race detector is the real assertion; this only guards against the
+	// packets silently never reaching the session dispatch path at all.
+	if !responded.Load() {
+		t.Fatal("no session packet got a response; the burst never exercised the dispatch path")
+	}
+	if n := b.Sessions.Count(); n != 1 {
+		t.Fatalf("want the 1 established session to survive the burst, got %d", n)
+	}
+}
+
+func raceRAKP1Packet(bmcSessionID uint32, tag uint8) []byte {
+	msg := &rmcpplus.RAKPMessage1{
+		MessageTag:                     tag,
+		ManagedSystemSessionID:         bmcSessionID,
+		RequestedMaximumPrivilegeLevel: types.PrivilegeLevelAdministrator,
+		UsernameLength:                 uint8(len(raceUser)),
+		Username:                       []byte(raceUser),
+	}
+	return protocol.BuildRMCPPlusPacket(protocol.PayloadRAKPMessage1, 0, 0, 0, msg.Pack())
+}
+
+// raceOpenSessionSHA1 opens a suite-3 session (used only to obtain a pending
+// session ID for the RAKP1 race).
+func raceOpenSessionSHA1(t *testing.T, cl *net.UDPConn, consoleID uint32) uint32 {
+	t.Helper()
+	authP, integP, cryptP := rmcpplus.NewAlgorithmPayloads(
+		types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128)
+	req := &rmcpplus.OpenSessionRequest{
+		RequestedMaximumPrivilegeLevel: types.PrivilegeLevelAdministrator,
+		RemoteConsoleSessionID:         consoleID,
+		AuthenticationPayload:          authP,
+		IntegrityPayload:               integP,
+		ConfidentialityPayload:         cryptP,
+	}
+	raceMustWrite(t, cl, protocol.BuildRMCPPlusPacket(protocol.PayloadOpenSessionRequest, 0, 0, 0, req.Pack()))
+	var resp rmcpplus.OpenSessionResponse
+	if err := resp.Unpack(raceMustReadPayload(t, cl)); err != nil {
+		t.Fatal(err)
+	}
+	if resp.RmcpStatusCode != types.RmcpStatusCodeNoErrors {
+		t.Fatalf("open session error status %v", resp.RmcpStatusCode)
+	}
+	return resp.ManagedSystemSessionID
+}
+
+// TestRAKP1SamePendingSessionRace fires many RAKP Message 1 packets targeting
+// the SAME pending session. Each is dispatched in its own server goroutine;
+// before the per-session lock, HandleRAKP1's writes to the shared session
+// (ConsoleRand, Role, User, BMCRand) raced.
+func TestRAKP1SamePendingSessionRace(t *testing.T) {
+	b := raceNewBMC(t)
+	port, _, stop := raceStartServer(t, b)
+	defer stop()
+
+	cl, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	bmcID := raceOpenSessionSHA1(t, cl, 0xaabbccdd)
+
+	var wg sync.WaitGroup
+	var responded atomic.Bool
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+			if err != nil {
+				return
+			}
+			defer c.Close()
+			buf := make([]byte, 4096)
+			for range 40 {
+				_, _ = c.Write(raceRAKP1Packet(bmcID, uint8(i)))
+				_ = c.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+				if _, err := c.Read(buf); err == nil {
+					responded.Store(true)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	// The race detector is the real assertion; this only guards against the
+	// RAKP1 burst silently never reaching the handshake path at all.
+	if !responded.Load() {
+		t.Fatal("no RAKP1 packet got a response; the burst never exercised the handshake path")
+	}
+}

--- a/pkg/server/race_test.go
+++ b/pkg/server/race_test.go
@@ -1,0 +1,196 @@
+package server
+
+// Data-race regression tests. Each spins up a real server and drives concurrent
+// traffic that, before the per-session lock / copy-out / config-lock fixes,
+// tripped the race detector. Run with: go test -race ./pkg/server/...
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/client"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+const (
+	raceUser = "admin"
+	racePass = "adminpass1234567"
+)
+
+// raceNewBMC builds a BMC with an enabled admin user on the LAN channel.
+func raceNewBMC(t *testing.T, opts ...bmc.Option) *bmc.BMC {
+	t.Helper()
+
+	b := bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, mock.New(),
+		append([]bmc.Option{bmc.WithClock(clock.Real)}, opts...)...)
+
+	admin, err := b.Users.Add(2, raceUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin.SetPassword([]byte(racePass))
+	admin.Enabled = true
+	admin.ChannelAccess[1] = bmc.UserChannelAccess{MaxPrivilege: bmc.PrivilegeLevelAdministrator, Enabled: true}
+
+	return b
+}
+
+// raceStartServer starts b on a loopback UDP socket and returns its port, a
+// context, and a stop func.
+func raceStartServer(t *testing.T, b *bmc.BMC) (int, context.Context, func()) {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := conn.LocalAddr().(*net.UDPAddr).Port //nolint:forcetypeassert
+
+	srv := NewServer(b, udp.Wrap(conn, udp.WithReadTimeout(time.Second)))
+	ctx, cancel := context.WithCancel(context.Background())
+	go srv.Serve(ctx) //nolint:errcheck
+
+	// Poll for readiness with an ASF Presence Ping instead of a fixed sleep:
+	// under -race on a loaded CI runner, a fixed delay is both too long on a
+	// fast machine and too short on a slow one.
+	probe, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer probe.Close()
+	deadline := time.Now().Add(5 * time.Second)
+	buf := make([]byte, 64)
+	for {
+		// RMCP/ASF Presence Ping (class 0x06, type 0x80).
+		_, _ = probe.Write([]byte{0x06, 0x00, 0xff, 0x06, 0x00, 0x00, 0x11, 0xbe, 0x80, 0x00, 0x00, 0x00})
+		_ = probe.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		if _, err := probe.Read(buf); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("server did not answer ASF presence ping within 5s")
+		}
+	}
+
+	return port, ctx, func() { cancel(); _ = srv.Close() }
+}
+
+// raceConnectLoop runs four goroutines that each establish and close iters
+// RMCP+ (suite 3) sessions, exercising the server's read of user/channel/cipher
+// state on the handshake hot path.
+func raceConnectLoop(ctx context.Context, wg *sync.WaitGroup, port, iters int) {
+	for range 4 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				cl, err := client.NewClient("127.0.0.1", port, raceUser, racePass)
+				if err != nil {
+					continue
+				}
+
+				cl = cl.WithTimeout(2 * time.Second).WithCipherSuiteID(types.CipherSuiteID3)
+
+				if err := cl.Connect(ctx); err == nil {
+					_ = cl.Close(ctx)
+				}
+			}
+		}()
+	}
+}
+
+// TestUserMutationRace mutates a user at runtime via the race-free
+// UserStore.Update path while the server authenticates concurrent LAN sessions.
+// It guards the copy-out in UserStore.Get/GetByName: the handshake reads users
+// through those snapshot accessors without holding the store lock, so reverting
+// them to hand out live *User pointers would race this concurrent writer.
+func TestUserMutationRace(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for range 200 {
+			_ = b.Users.Update(2, func(u *bmc.User) error {
+				u.SetPassword([]byte(racePass))
+				u.Enabled = true
+				return nil
+			})
+		}
+	}()
+
+	raceConnectLoop(ctx, &wg, port, 25)
+
+	wg.Wait()
+}
+
+// TestCipherSuitesMutationRace reconfigures the advertised cipher suites at
+// runtime (BMC.SetCipherSuites) while the server reads them via
+// ResolvedCipherSuites on every Open Session Request and Get Channel Cipher
+// Suites. The config RWMutex serializes writer and readers.
+func TestCipherSuitesMutationRace(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for range 500 {
+			b.SetCipherSuites([]types.CipherSuiteID{types.CipherSuiteID3, types.CipherSuiteID17})
+		}
+	}()
+
+	raceConnectLoop(ctx, &wg, port, 25)
+
+	wg.Wait()
+}
+
+// TestChannelReconfigRace republishes a channel at runtime via the race-free
+// ChannelStore.Set path while the server reads channel config (via
+// ChannelStore.Get snapshots) on every RAKP3. Set stores a private copy and Get
+// returns one, so writer and readers never share a Channel.
+func TestChannelReconfigRace(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for range 500 {
+			b.Channels.Set(&bmc.Channel{
+				Number:         1,
+				Medium:         bmc.ChannelMediumLAN,
+				AccessMode:     bmc.ChannelAccessAlways,
+				MaxPrivilege:   bmc.PrivilegeLevelAdministrator,
+				PerMessageAuth: true,
+				UserLevelAuth:  true,
+			})
+		}
+	}()
+
+	raceConnectLoop(ctx, &wg, port, 25)
+
+	wg.Wait()
+}

--- a/pkg/server/race_v15_test.go
+++ b/pkg/server/race_v15_test.go
@@ -1,0 +1,148 @@
+package server
+
+// IPMI v1.5 per-session data-race regression test driven over raw UDP.
+
+import (
+	"encoding/binary"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// raceBuildIPMIRequest builds a raw IPMI LAN request message (Table 13-8).
+func raceBuildIPMIRequest(netFn, cmd, seq uint8, data []byte) []byte {
+	msg := make([]byte, 7+len(data))
+	msg[0] = protocol.BMCAddr
+	msg[1] = netFn << 2
+	msg[2] = protocol.Checksum(msg[0:2])
+	msg[3] = protocol.RemoteConsoleAddr
+	msg[4] = seq << 2
+	msg[5] = cmd
+	copy(msg[6:], data)
+	msg[6+len(data)] = protocol.Checksum(msg[3 : 6+len(data)])
+	return msg
+}
+
+func raceWrapV15(authType types.AuthType, seq, sessionID uint32, authCode, payload []byte) []byte {
+	hdr := types.SessionHeader15{
+		AuthType:      authType,
+		Sequence:      seq,
+		SessionID:     sessionID,
+		AuthCode:      authCode,
+		PayloadLength: uint8(len(payload)),
+	}
+	out := []byte{0x06, 0x00, 0xff, 0x07} // RMCP header, class IPMI
+	out = append(out, hdr.Pack()...)
+	out = append(out, payload...)
+	return out
+}
+
+// TestV15SessionFieldRace establishes a real IPMI v1.5 (-A MD5) session, then
+// fires several authenticated command packets for the SAME session
+// concurrently. Before the per-session lock, the server mutated the shared
+// v1.5 session sequence fields lock-free once the pointer was fetched.
+func TestV15SessionFieldRace(t *testing.T) {
+	const netFnApp, cmdGetDeviceID, cmdGetSessionChallenge, cmdActivateSession = 0x06, 0x01, 0x39, 0x3a
+
+	b := raceNewBMC(t)
+
+	// The seeded admin password from raceNewBMC, zero-padded to 16 bytes per the
+	// v1.5 AuthCode algorithms.
+	var padded [16]byte
+	copy(padded[:], racePass)
+	pass16 := padded[:]
+
+	port, _, stop := raceStartServer(t, b)
+	defer stop()
+
+	srvAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}
+	cl, err := net.DialUDP("udp", nil, srvAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	roundtrip := func(pkt []byte) []byte {
+		if _, err := cl.Write(pkt); err != nil {
+			t.Fatal(err)
+		}
+		_ = cl.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 4096)
+		n, err := cl.Read(buf)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		return buf[:n]
+	}
+
+	// ---- Get Session Challenge (AuthType NONE, session 0, seq 0) ----
+	var uname [16]byte
+	copy(uname[:], raceUser)
+	gscData := append([]byte{byte(bmc.V15AuthTypeMD5)}, uname[:]...)
+	gscReq := raceBuildIPMIRequest(netFnApp, cmdGetSessionChallenge, 1, gscData)
+	resp := roundtrip(raceWrapV15(types.AuthTypeNone, 0, 0, nil, gscReq))
+
+	var s15 types.Session15
+	if err := s15.Unpack(resp[4:]); err != nil {
+		t.Fatalf("unpack GSC resp: %v", err)
+	}
+	_, _, gscBody, _, ok := protocol.ParseIPMIRequest(s15.Payload)
+	if !ok || len(gscBody) < 21 || gscBody[0] != 0 {
+		t.Fatalf("bad GSC body len=%d ok=%v cc=%#x", len(gscBody), ok, gscBody[0])
+	}
+	tempSessionID := binary.LittleEndian.Uint32(gscBody[1:5])
+	var challenge [16]byte
+	copy(challenge[:], gscBody[5:21])
+
+	// ---- Activate Session (AuthType MD5, temp session id, seq 0) ----
+	actData := make([]byte, 22)
+	actData[0] = byte(bmc.V15AuthTypeMD5)
+	actData[1] = byte(bmc.PrivilegeLevelAdministrator)
+	copy(actData[2:18], challenge[:])
+	binary.LittleEndian.PutUint32(actData[18:22], 1)
+	actReq := raceBuildIPMIRequest(netFnApp, cmdActivateSession, 2, actData)
+	actAuth := handlers.GenV15AuthCode(pass16, bmc.V15AuthTypeMD5, tempSessionID, actReq, 0)
+	resp = roundtrip(raceWrapV15(types.AuthTypeMD5, 0, tempSessionID, actAuth, actReq))
+
+	if err := s15.Unpack(resp[4:]); err != nil {
+		t.Fatalf("unpack Activate resp: %v", err)
+	}
+	_, _, actBody, _, ok := protocol.ParseIPMIRequest(s15.Payload)
+	if !ok || len(actBody) < 11 || actBody[0] != 0 {
+		t.Fatalf("bad Activate body len=%d ok=%v cc=%#x", len(actBody), ok, actBody[0])
+	}
+	permSessionID := binary.LittleEndian.Uint32(actBody[2:6])
+	inboundSeq := binary.LittleEndian.Uint32(actBody[6:10])
+
+	// ---- Fire N authenticated GetDeviceID packets on the SAME session ----
+	const n = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		seq := inboundSeq + uint32(i)
+		wg.Add(1)
+		go func(seq uint32) {
+			defer wg.Done()
+			req := raceBuildIPMIRequest(netFnApp, cmdGetDeviceID, uint8(seq&0x3f), nil)
+			auth := handlers.GenV15AuthCode(pass16, bmc.V15AuthTypeMD5, permSessionID, req, seq)
+			pkt := raceWrapV15(types.AuthTypeMD5, seq, permSessionID, auth, req)
+			<-start
+			s, err := net.DialUDP("udp", nil, srvAddr)
+			if err != nil {
+				return
+			}
+			defer s.Close()
+			_, _ = s.Write(pkt)
+			_ = s.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+			_, _ = s.Read(make([]byte, 4096))
+		}(seq)
+	}
+	close(start)
+	wg.Wait()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -102,7 +102,9 @@ const solWorkerIdleTimeout = 90 * time.Second
 type ServerOption func(*Server)
 
 // WithHandlerRegistry replaces the default handler registry.
-// Use this to add OEM commands or override built-in handlers.
+// Use this to add OEM commands or override built-in handlers. All registration
+// on r must be complete before [Server.Serve] is called; the registry is
+// read-only and unsynchronized during dispatch.
 func WithHandlerRegistry(r *handlers.Registry) ServerOption {
 	return func(s *Server) { s.reg = r }
 }
@@ -394,7 +396,7 @@ func (s *Server) handleRMCPPlus(addr net.Addr, pkt []byte) {
 		// per-packet goroutines.
 		sess.ProcMu.Lock()
 		defer sess.ProcMu.Unlock()
-		if !acceptInbound(sess, pkt, addr, inboundSeq, authenticated) {
+		if !s.acceptInbound(sess, pkt, addr, inboundSeq, authenticated) {
 			return
 		}
 		s.dispatchIPMISession(ctx, addr, sess, payload, encrypted)
@@ -480,9 +482,12 @@ func (s *Server) runSOLWorker(sessionID uint32, q chan solJob) {
 }
 
 // acceptInbound verifies one in-session packet's integrity and session
-// sequence window, recording the sender address on success. sess.ProcMu
-// must be held: the window check-then-set is only atomic under it.
-func acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint32, authenticated bool) bool {
+// sequence window, recording the sender address and refreshing the session's
+// inactivity clock on success. Only packets accepted here count as activity:
+// refreshing on lookup instead would let unvalidated packets keep a session
+// alive. sess.ProcMu must be held: the window check-then-set is only atomic
+// under it.
+func (s *Server) acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint32, authenticated bool) bool {
 	if !verifyRMCPPlusIntegrity(pkt, sess, authenticated) {
 		return false
 	}
@@ -491,6 +496,7 @@ func acceptInbound(sess *bmc.Session, pkt []byte, addr net.Addr, inboundSeq uint
 	}
 	sess.InboundSeq = inboundSeq
 	sess.SetAddr(addr)
+	s.bmc.Sessions.Touch(sess.BMCID)
 	return true
 }
 
@@ -510,7 +516,7 @@ func (s *Server) processSOLJob(sess *bmc.Session, job solJob, q chan solJob) {
 	// is the only SOL processor per session, and holding it would serialize
 	// the data plane against command responses of the same session.
 	sess.ProcMu.Lock()
-	accepted := acceptInbound(sess, job.pkt, job.addr, inboundSeq, authenticated)
+	accepted := s.acceptInbound(sess, job.pkt, job.addr, inboundSeq, authenticated)
 	sess.ProcMu.Unlock()
 	if !accepted {
 		if s.solDebug {
@@ -555,6 +561,8 @@ func (s *Server) dispatchIPMIPreSession(ctx context.Context, addr net.Addr, payl
 }
 
 // dispatchIPMISession handles IPMI commands within an authenticated session.
+// The caller must hold sess.ProcMu; this method reads and writes session fields
+// and dispatches session commands that may do the same.
 func (s *Server) dispatchIPMISession(ctx context.Context, addr net.Addr, sess *bmc.Session, payload []byte, encrypted bool) {
 	ipmiPayload, ok := decryptSessionPayload(sess, payload, encrypted)
 	if !ok {

--- a/pkg/server/server_v15.go
+++ b/pkg/server/server_v15.go
@@ -64,7 +64,14 @@ func (s *Server) dispatchIPMIv15SessionUnauth(addr net.Addr, pkt []byte, sess *t
 	}
 
 	v15Sess, err := s.bmc.V15Sessions.Get(hdr.SessionID)
-	if err != nil || v15Sess.State != bmc.V15SessionStateActive {
+	if err != nil {
+		return
+	}
+	// The seq window check and dispatch must be atomic per session: packets of
+	// one session are dispatched from per-packet goroutines.
+	v15Sess.ProcMu.Lock()
+	defer v15Sess.ProcMu.Unlock()
+	if v15Sess.State != bmc.V15SessionStateActive {
 		return
 	}
 
@@ -85,7 +92,7 @@ func (s *Server) dispatchIPMIv15SessionUnauth(addr net.Addr, pkt []byte, sess *t
 
 	ctx := context.Background()
 	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
-	s.bmc.V15Sessions.Touch(v15Sess)
+	s.bmc.V15Sessions.Touch(hdr.SessionID)
 
 	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
 	outboundSeq := v15Sess.NextOutboundSeq()
@@ -103,6 +110,12 @@ func (s *Server) dispatchIPMIv15Auth(addr net.Addr, pkt []byte, sess *types.Sess
 	if err != nil {
 		return
 	}
+	// Hold ProcMu across seq validate/accept, auth verify, dispatch (which may
+	// activate the session, taking the store lock in the allowed
+	// ProcMu-then-store order), activity update, outbound-seq allocation, and
+	// send.
+	v15Sess.ProcMu.Lock()
+	defer v15Sess.ProcMu.Unlock()
 
 	authType := bmc.V15AuthType(hdr.AuthType)
 	if authType != v15Sess.AuthType {
@@ -165,7 +178,10 @@ func (s *Server) dispatchIPMIv15Auth(addr net.Addr, pkt []byte, sess *types.Sess
 
 	ctx := context.Background()
 	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
-	s.bmc.V15Sessions.Touch(v15Sess)
+	// For a successful Activate Session this lookup misses, because the store
+	// just re-keyed the session to its permanent ID; that is fine, activation
+	// itself stamps the activity.
+	s.bmc.V15Sessions.Touch(hdr.SessionID)
 
 	ipmiResp := protocol.BuildIPMIResponse(netFn, cmd, seq, uint8(cc), respData)
 	outboundSeq := v15Sess.NextOutboundSeq()


### PR DESCRIPTION
Disclaimer: this was authored mainly by Claude Fable 5, and reviewed by myself and other models.

The server handles every incoming packet in its own goroutine, but some of the state those goroutines share was read and written without synchronization. Concurrent handshake messages for one session raced on its negotiation state and derived keys, legacy v1.5 sessions had no per-session serialization at all, user lookups handed out live references that raced against runtime user changes, and the cipher suite, authentication type, and key configuration was read on every session setup while being writable at runtime. Under load this is undefined behavior that can corrupt a session or crash a long-running BMC, and the race detector reports it.

The RMCP+ handshake handlers now serialize on the same per-session lock the in-session dispatch already uses, and v1.5 sessions get the same per-session serialization as v2.0 ones. User and channel lookups return copies rather than live references, and runtime user changes go through a guarded update path, which also covers the payload access table, so it no longer needs its own lock. The runtime-changeable configuration is read and written under a dedicated lock through accessors, with the underlying state hidden so every access provably goes through it.

Session activity is now refreshed only when a validated packet is processed, instead of on every lookup. Previously, any packet that merely named a session ID kept that session alive forever, even if it failed validation. Handshake messages deliberately do not refresh activity either, since they carry no authenticator - the inactivity budget granted at session creation bounds the whole handshake, which is more than enough for its three round trips. Additionally, completing a handshake for a session that was evicted in the meantime is now reported as an error to the console instead of producing a phantom session that no longer exists on the BMC.

Continuous integration now runs the test suite with the race detector, which was not exercised before, and regression tests cover each of the fixed races.

The scope is limited to the data races and the activity semantics. Protocol-correctness issues found during the audit, such as the handling of duplicate handshake messages and sequence number wraparound, are left for follow-up changes.
