### PR TITLE
feat(server): add user, LAN config, and session query commands

### DIFF
--- a/pkg/bmc/session.go
+++ b/pkg/bmc/session.go
@@ -53,6 +53,10 @@ type Session struct {
 	BMCID uint32
 	// ConsoleID is the session ID chosen by the remote console.
 	ConsoleID uint32
+	// Handle is the one-byte session handle Get Session Info reports
+	// (spec v2.0§22.20). Assigned at allocation, unique among the store's live
+	// sessions, never 0x00 ("no session") or the reserved 0xFF.
+	Handle uint8
 
 	State SessionState
 
@@ -124,6 +128,8 @@ type SessionStore struct {
 	max      int
 	timeout  time.Duration
 	clock    clock.Clock
+	// nextHandle seeds session handle assignment; see allocHandleLocked.
+	nextHandle uint8
 
 	// onRemove fires whenever a session leaves the store (Close or
 	// eviction). The BMC wires this to payload deactivation: when a session
@@ -213,6 +219,7 @@ func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integri
 	sess := &Session{
 		BMCID:        bmcID,
 		ConsoleID:    consoleID,
+		Handle:       s.allocHandleLocked(),
 		State:        SessionStatePending,
 		AuthAlg:      authAlg,
 		IntegrityAlg: integrityAlg,
@@ -224,6 +231,30 @@ func (s *SessionStore) Allocate(consoleID uint32, authAlg types.AuthAlg, integri
 	}
 	s.sessions[bmcID] = sess
 	return sess, nil
+}
+
+// allocHandleLocked returns the next free one-byte session handle: a rotating
+// counter skipping 0x00 ("no session"), the reserved 0xFF, and any handle a
+// live session holds. Two colliding handles would make Get Session Info
+// ambiguous about which session it describes. s.mu must be held; the store
+// capacity is far below 254, so a free value always exists.
+func (s *SessionStore) allocHandleLocked() uint8 {
+	for {
+		s.nextHandle++
+		if s.nextHandle == 0 || s.nextHandle == 0xFF {
+			s.nextHandle = 1
+		}
+		taken := false
+		for _, sess := range s.sessions {
+			if sess.Handle == s.nextHandle {
+				taken = true
+				break
+			}
+		}
+		if !taken {
+			return s.nextHandle
+		}
+	}
 }
 
 // Get returns the session for bmcID, or [ErrNoSession]. It is a pure lookup:
@@ -356,6 +387,14 @@ func (s *SessionStore) Count() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.sessions)
+}
+
+// Cap returns the maximum number of concurrent sessions the store can hold,
+// i.e. the number of slots in the session table.
+func (s *SessionStore) Cap() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.max
 }
 
 // InboundSeqValid checks whether seq is within the acceptable sliding window

--- a/pkg/bmc/session_v15.go
+++ b/pkg/bmc/session_v15.go
@@ -67,9 +67,9 @@ const (
 // lock while its caller holds ProcMu, so a reader under either lock observes a
 // consistent value (the Count* helpers read them under the store lock).
 // LastActivity is guarded by the store lock and refreshed via
-// [V15SessionStore.Touch]. TempSessionID, AuthType, Challenge, Channel, User,
-// and CreatedAt are set before the session is published and never written
-// again. ProcMu may be held while taking the store lock, never the reverse.
+// [V15SessionStore.Touch]. TempSessionID, Handle, AuthType, Challenge, Channel,
+// User, and CreatedAt are set before the session is published and never
+// written again. ProcMu may be held while taking the store lock, never the reverse.
 type V15Session struct {
 	// ProcMu serializes per-session packet processing. The server spawns a
 	// goroutine per inbound packet; without this lock, concurrent packets of
@@ -78,7 +78,11 @@ type V15Session struct {
 
 	TempSessionID uint32
 	SessionID     uint32
-	State         V15SessionState
+	// Handle is the one-byte session handle Get Session Info reports
+	// (spec v2.0§22.20). Assigned at creation, unique among the store's live
+	// sessions, never 0x00 ("no session") or the reserved 0xFF.
+	Handle uint8
+	State  V15SessionState
 
 	AuthType  V15AuthType
 	Challenge [16]byte
@@ -104,6 +108,8 @@ type V15SessionStore struct {
 	max      int
 	timeout  time.Duration
 	clock    clock.Clock
+	// nextHandle seeds session handle assignment; see allocHandleLocked.
+	nextHandle uint8
 }
 
 // NewV15SessionStore creates a V15SessionStore with the default limits.
@@ -145,6 +151,7 @@ func (s *V15SessionStore) CreatePending(authType V15AuthType, user *User, challe
 	now := s.clock.Now()
 	sess := &V15Session{
 		TempSessionID: tempID,
+		Handle:        s.allocHandleLocked(),
 		State:         V15SessionStatePending,
 		AuthType:      authType,
 		Challenge:     challenge,
@@ -155,6 +162,29 @@ func (s *V15SessionStore) CreatePending(authType V15AuthType, user *User, challe
 	}
 	s.sessions[tempID] = sess
 	return sess, nil
+}
+
+// allocHandleLocked returns the next free one-byte session handle: a rotating
+// counter skipping 0x00 ("no session"), the reserved 0xFF, and any handle a
+// live session holds. s.mu must be held; the store capacity is far below 254,
+// so a free value always exists.
+func (s *V15SessionStore) allocHandleLocked() uint8 {
+	for {
+		s.nextHandle++
+		if s.nextHandle == 0 || s.nextHandle == 0xFF {
+			s.nextHandle = 1
+		}
+		taken := false
+		for _, sess := range s.sessions {
+			if sess.Handle == s.nextHandle {
+				taken = true
+				break
+			}
+		}
+		if !taken {
+			return s.nextHandle
+		}
+	}
 }
 
 // Get returns a session by its current lookup ID. It is a pure lookup: activity
@@ -180,6 +210,14 @@ func (s *V15SessionStore) Touch(id uint32) {
 	if sess, ok := s.sessions[id]; ok {
 		sess.LastActivity = s.clock.Now()
 	}
+}
+
+// Cap returns the maximum number of concurrent v1.5 sessions the store can
+// hold, i.e. the number of slots in the session table.
+func (s *V15SessionStore) Cap() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.max
 }
 
 // CountActiveSessions returns the number of active v1.5 sessions.

--- a/pkg/bmc/user.go
+++ b/pkg/bmc/user.go
@@ -30,6 +30,10 @@ type UserChannelAccess struct {
 	CallbackOnly bool
 	// Enabled controls whether the user is allowed on this channel at all.
 	Enabled bool
+	// LinkAuth records the link-authentication enable bit (spec v2.0§22.26).
+	// Nothing enforces it on a LAN channel; it is stored so Get User Access
+	// round-trips what Set User Access accepted.
+	LinkAuth bool
 }
 
 // User represents a single BMC user account.
@@ -40,7 +44,12 @@ type User struct {
 	// Password is stored as a 20-byte padded value per the IPMI 2.0 spec.
 	// Index 0 is valid; a zero-length slice means no password is set.
 	Password [MaxPasswordLen]byte
-	Enabled  bool
+	// Password20 records whether the password was stored with the 20-byte size
+	// tag (spec v2.0§22.30). The size is part of the credential: a test with the
+	// other size must fail, and a 20-byte password exists only in IPMI 2.0, so
+	// it must not authenticate a v1.5 session.
+	Password20 bool
+	Enabled    bool
 
 	// ChannelAccess holds per-channel access settings keyed by channel number.
 	ChannelAccess map[uint8]UserChannelAccess
@@ -97,11 +106,15 @@ func (u *User) SetPayloadAccess(channel uint8, enable bool, standard1, oem1 uint
 	u.PayloadAccess[channel] = a
 }
 
-// SetPassword copies up to MaxPasswordLen bytes from raw into the User's password field.
+// SetPassword copies up to MaxPasswordLen bytes from raw into the User's
+// password field. The size class is inferred from the input length: anything
+// longer than 16 bytes is a 20-byte (IPMI 2.0 only) password. Pass the
+// wire-tagged length unmodified so the class survives trailing zero bytes.
 func (u *User) SetPassword(raw []byte) {
 	var p [MaxPasswordLen]byte
 	copy(p[:], raw)
 	u.Password = p
+	u.Password20 = len(raw) > 16
 }
 
 // PasswordV15Padded returns the user's password zero-padded to 16 bytes per
@@ -122,13 +135,41 @@ func (u *User) VerifyPassword(raw []byte) bool {
 
 // UserStore is a thread-safe registry of BMC users.
 type UserStore struct {
-	mu    sync.RWMutex
-	users map[uint8]*User
+	mu sync.RWMutex
+	// maxUsers is the highest user ID the store advertises (Get User Access
+	// byte 1, spec v2.0§22.27). It bounds the slot range enumerators walk and
+	// is immutable after construction, so it needs no locking.
+	maxUsers uint8
+	users    map[uint8]*User
+}
+
+// UserStoreOption configures a [UserStore] at construction time.
+type UserStoreOption func(*UserStore)
+
+// WithMaxUsers sets the highest user ID the store advertises via Get User
+// Access. n is clamped to the spec range 1..[MaxUsers]; the default is
+// [MaxUsers] (63).
+func WithMaxUsers(n uint8) UserStoreOption {
+	return func(s *UserStore) {
+		if n < 1 {
+			n = 1
+		}
+		if n > MaxUsers {
+			n = MaxUsers
+		}
+		s.maxUsers = n
+	}
 }
 
 // NewUserStore creates a UserStore with the mandatory anonymous user (ID 1).
-func NewUserStore() *UserStore {
-	s := &UserStore{users: make(map[uint8]*User, 4)}
+func NewUserStore(opts ...UserStoreOption) *UserStore {
+	s := &UserStore{
+		maxUsers: MaxUsers,
+		users:    make(map[uint8]*User, 4),
+	}
+	for _, o := range opts {
+		o(s)
+	}
 	// Slot 1 is always the anonymous/null user per spec section 6.9.1.
 	s.users[1] = &User{
 		ID:            1,
@@ -137,6 +178,13 @@ func NewUserStore() *UserStore {
 		ChannelAccess: make(map[uint8]UserChannelAccess),
 	}
 	return s
+}
+
+// MaxUserCount returns the highest user ID the store advertises (default
+// [MaxUsers]). Get User Access reports this so in-band enumerators know how many
+// slots to walk.
+func (s *UserStore) MaxUserCount() uint8 {
+	return s.maxUsers
 }
 
 // copyUser returns a deep copy of u: the struct value (Password is a value
@@ -156,10 +204,12 @@ func copyUser(u *User) *User {
 // Add creates a new user at the given ID and returns the live [*User] for
 // construction-time seeding. Mutating the returned pointer is only safe before
 // the server starts serving; use [UserStore.Update] for runtime changes.
-// Returns [ErrInvalidUserID] for IDs outside 1-63, or [ErrUsernameTaken] if
-// name is non-empty and already in use.
+// Returns [ErrInvalidUserID] for IDs outside the store's advertised range, or
+// [ErrUsernameTaken] if name is non-empty and already in use. Bounding by the
+// advertised maximum keeps the whole store consistent: no slot can exist that
+// enumerators cannot see but authentication still finds.
 func (s *UserStore) Add(id uint8, name string) (*User, error) {
-	if id < 1 || id > MaxUsers {
+	if id < 1 || id > s.maxUsers {
 		return nil, ErrInvalidUserID
 	}
 	s.mu.Lock()
@@ -196,24 +246,30 @@ func (s *UserStore) Get(id uint8) (*User, error) {
 
 // GetByName returns a snapshot copy of the user with the given name, or
 // [ErrUserNotFound]. An empty name matches the anonymous user (ID 1).
+//
+// Slots are scanned in ID order, so the lookup is deterministic even when
+// several slots share a name: user-management commands can create additional
+// empty-named slots at runtime, and iterating the map directly would make the
+// RAKP null-user lookup resolve to a random one of them.
 func (s *UserStore) GetByName(name string) (*User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, u := range s.users {
-		if u.Name == name {
+	for id := uint8(1); id <= s.maxUsers; id++ {
+		if u, ok := s.users[id]; ok && u.Name == name {
 			return copyUser(u), nil
 		}
 	}
 	return nil, fmt.Errorf("user %q: %w", name, ErrUserNotFound)
 }
 
-// FindEnabledByNameOnChannel scans user IDs 1..MaxUsers in order and returns a
+// FindEnabledByNameOnChannel scans user IDs in order up to the store maximum
+// and returns a
 // snapshot copy of the first enabled user with a matching name and channel
 // access (spec v1.5§18.24 / v2.0§22.27).
 func (s *UserStore) FindEnabledByNameOnChannel(name string, channel uint8) (*User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for id := uint8(1); id <= MaxUsers; id++ {
+	for id := uint8(1); id <= s.maxUsers; id++ {
 		u, ok := s.users[id]
 		if !ok || !u.Enabled {
 			continue
@@ -248,6 +304,43 @@ func (s *UserStore) Update(id uint8, fn func(*User) error) error {
 	return fn(u)
 }
 
+// Upsert applies fn to the user in slot id under a single write-lock hold,
+// creating the slot first (respecting the store max) when it does not exist.
+// This is the atomic create-or-mutate path handlers use so two concurrent
+// creates on the same empty slot cannot interleave and lose a field, which a
+// separate Add-then-Update sequence would allow.
+//
+// fn runs against a working copy, so a rejected mutation leaves stored state
+// untouched: the slot is committed only when fn returns nil and the resulting
+// non-empty name does not collide with a different slot. A colliding name is
+// rejected with [ErrUsernameTaken] to keep name-based session lookup
+// deterministic. Returns [ErrInvalidUserID] for an id outside 1..max.
+func (s *UserStore) Upsert(id uint8, fn func(*User) error) error {
+	if id < 1 || id > s.maxUsers {
+		return ErrInvalidUserID
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	next := &User{ID: id, ChannelAccess: make(map[uint8]UserChannelAccess)}
+	if cur, ok := s.users[id]; ok {
+		next = copyUser(cur)
+	}
+	if err := fn(next); err != nil {
+		return err
+	}
+	if next.Name != "" {
+		for otherID, u := range s.users {
+			if otherID != id && u.Name == next.Name {
+				return ErrUsernameTaken
+			}
+		}
+	}
+	next.ID = id
+	s.users[id] = next
+	return nil
+}
+
 // Delete removes a user by ID.  User 1 (anonymous) cannot be deleted.
 func (s *UserStore) Delete(id uint8) error {
 	if id == 1 {
@@ -267,6 +360,21 @@ func (s *UserStore) Count() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.users)
+}
+
+// CountEnabled returns the number of enabled users, in one pass under one read
+// lock. Get User Access reports this on every query, and counting through
+// per-slot snapshot lookups would deep-copy the whole table each time.
+func (s *UserStore) CountEnabled() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, u := range s.users {
+		if u.Enabled {
+			n++
+		}
+	}
+	return n
 }
 
 // PrivilegeLevel mirrors [types.PrivilegeLevel] so bmc stays free of wire-type

--- a/pkg/bmc/user_test.go
+++ b/pkg/bmc/user_test.go
@@ -102,6 +102,42 @@ func TestUserVerifyPassword(t *testing.T) {
 	}
 }
 
+// TestUserStoreUpsertConcurrent proves two concurrent upserts creating the same
+// empty slot do not lose an acknowledged field: one sets the name, the other
+// the password, and both survive because each read-modify-write happens under a
+// single lock hold. Run under -race. A non-atomic Add-then-Update sequence would
+// let the second create overwrite the first's field.
+func TestUserStoreUpsertConcurrent(t *testing.T) {
+	const id = 5
+
+	for iter := 0; iter < 200; iter++ {
+		s := NewUserStore()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = s.Upsert(id, func(u *User) error { u.Name = "alice"; return nil })
+		}()
+		go func() {
+			defer wg.Done()
+			_ = s.Upsert(id, func(u *User) error { u.SetPassword([]byte("secret")); return nil })
+		}()
+		wg.Wait()
+
+		u, err := s.Get(id)
+		if err != nil {
+			t.Fatalf("iter %d: slot %d missing after concurrent upsert: %v", iter, id, err)
+		}
+		if u.Name != "alice" {
+			t.Fatalf("iter %d: name lost: got %q, want alice", iter, u.Name)
+		}
+		if u.Password == [MaxPasswordLen]byte{} {
+			t.Fatalf("iter %d: password lost: slot has no password", iter)
+		}
+	}
+}
+
 // TestUserPayloadAccessConcurrent hammers one account's payload access table
 // from many goroutines through the store: two sessions authenticated as the
 // same user (or a session plus the SOL activation path) can issue Set/Get
@@ -147,5 +183,26 @@ func TestUserPayloadAccessConcurrent(t *testing.T) {
 	}
 	if !u.PayloadAccessFor(1).SOLEnabled() {
 		t.Fatal("SOL access bit lost under concurrency")
+	}
+}
+
+// TestGetByNameDeterministicWithEmptyNamedSlots proves the null-user lookup
+// always resolves to slot 1 even when runtime user management has created
+// additional empty-named slots: an ID-ordered scan, unlike map iteration,
+// cannot resolve to a random slot.
+func TestGetByNameDeterministicWithEmptyNamedSlots(t *testing.T) {
+	s := NewUserStore()
+	// Set User Access on an unset slot creates it with an empty name.
+	if err := s.Upsert(5, func(u *User) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		u, err := s.GetByName("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if u.ID != 1 {
+			t.Fatalf("iteration %d: empty name resolved to slot %d, want the anonymous user (1)", i, u.ID)
+		}
 	}
 }

--- a/pkg/client/server_v15_test.go
+++ b/pkg/client/server_v15_test.go
@@ -212,3 +212,46 @@ func newV15TestBMC(t *testing.T, username, password string) *bmc.BMC {
 	}
 	return b
 }
+
+// TestV15ConnectRejects20BytePassword drives a real IPMI v1.5 (-A MD5) session
+// against an account whose password was stored as a 20-byte password, and
+// proves the session cannot be established. Such a password is IPMI 2.0 only
+// (spec v2.0§22.30): allowing v1.5 here would verify the AuthCode against a
+// 16-byte truncation of the secret. The refusal surfaces at Activate Session,
+// not as an "invalid user name" at Get Session Challenge, since the name is
+// valid.
+func TestV15ConnectRejects20BytePassword(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "passwordlongerthan16" // 20 bytes -> stored as 20-byte password
+	)
+
+	b := newV15TestBMC(t, username, password)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	addr := pc.LocalAddr().(*net.UDPAddr) //nolint:forcetypeassert
+	srv := server.NewServer(b, udp.Wrap(pc))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.Serve(ctx) }()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLan).
+		WithTimeout(2 * time.Second).
+		WithRetry(0)
+	c.session.authType = types.AuthTypeMD5
+
+	if err := c.Connect(context.Background()); err == nil {
+		_ = c.Close(context.Background())
+		t.Fatal("v1.5 Connect succeeded for a 20-byte-password account, want failure")
+	}
+}

--- a/pkg/client/session_info_v15_test.go
+++ b/pkg/client/session_info_v15_test.go
@@ -1,0 +1,79 @@
+package client
+
+// End-to-end Get Session Info test over a real IPMI v1.5 (-A MD5) session,
+// proving the keepalive the client fires periodically also succeeds on the
+// v1.5 path and describes the caller's own session.
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/server"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGetCurrentSessionInfoV15(t *testing.T) {
+	const (
+		username = "ADMIN"
+		password = "ADMIN"
+	)
+
+	b := newV15TestBMC(t, username, password)
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	conn := udp.Wrap(pc)
+	addr := pc.LocalAddr().(*net.UDPAddr) //nolint:forcetypeassert
+	srv := server.NewServer(b, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.Serve(ctx) }()
+
+	c, err := NewClient(addr.IP.String(), addr.Port, username, password)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithInterface(InterfaceLan).
+		WithTimeout(2 * time.Second).
+		WithRetry(0)
+	c.session.authType = types.AuthTypeMD5
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect (v1.5): %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+
+	resp, err := c.GetCurrentSessionInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrentSessionInfo: %v", err)
+	}
+
+	if resp.SessionHandle == 0 {
+		t.Errorf("session handle must be non-zero")
+	}
+	// newV15TestBMC seeds the user in slot 2 on the LAN channel (1); the session
+	// negotiates as IPMI v1.5, so the auxiliary-data nibble is 0.
+	if resp.UserID != 2 {
+		t.Errorf("user id = %d, want 2", resp.UserID)
+	}
+	if resp.AuxiliaryData != 0 {
+		t.Errorf("auxiliary data = %d, want 0 (IPMI v1.5)", resp.AuxiliaryData)
+	}
+	if resp.ChannelNumber != 1 {
+		t.Errorf("channel number = %d, want 1", resp.ChannelNumber)
+	}
+	if want := uint8(b.V15Sessions.Cap()); resp.PossibleActiveSessions != want {
+		t.Errorf("possible active sessions = %d, want %d", resp.PossibleActiveSessions, want)
+	}
+	if resp.CurrentActiveSessions < 1 {
+		t.Errorf("current active sessions = %d, want >= 1", resp.CurrentActiveSessions)
+	}
+}

--- a/pkg/hal/hal.go
+++ b/pkg/hal/hal.go
@@ -108,6 +108,10 @@ type IPConfig struct {
 	Gateway [4]byte
 	MAC     [6]byte
 	DHCP    bool
+	// Port is the primary RMCP port the BMC listens on (Get LAN Configuration
+	// Parameters param #8). Zero means the standard 623; a non-zero value lets a
+	// BMC that listens on a non-standard port advertise it to in-band software.
+	Port uint16
 }
 
 // NetworkHAL configures the BMC's own network interface.

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 
+	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/types"
 )
 
@@ -32,6 +33,7 @@ func RegisterAppHandlers(r *Registry) {
 	r.RegisterFunc(types.CommandWarmReset, handleWarmReset)
 	r.RegisterFunc(types.CommandGetSelfTestResults, handleGetSelfTestResults)
 	r.RegisterFunc(types.CommandGetDeviceGUID, handleGetDeviceGUID)
+	r.RegisterFunc(types.CommandGetChannelInfo, handleGetChannelInfo)
 }
 
 // handleGetDeviceID implements Get Device ID (App 0x01).
@@ -108,4 +110,110 @@ func handleGetDeviceGUID(_ context.Context, hctx *HandlerContext, _ []byte) ([]b
 	resp := make([]byte, 16)
 	copy(resp, g[:])
 	return resp, types.CodeOK, nil
+}
+
+// ---------------------------------------------------------------------------
+// Get Channel Info
+// ---------------------------------------------------------------------------
+
+// Channel session-support encodings (response byte 4, bits [7:6]) per IPMI spec
+// Table 22-30. The full set is session-less (0), single-session (1),
+// multi-session (2) and session-based (3); the reference server only reports the
+// first and third.
+const (
+	channelSessionLess  uint8 = 0x00 // no sessions (e.g. the system interface)
+	channelMultiSession uint8 = 0x02 // multiple concurrent sessions (LAN)
+)
+
+// ipmiForumIANA is the IPMI-forum IANA enterprise number reported as the channel
+// protocol vendor for the standard IPMB protocol. It is sent LS-byte first as a
+// 3-byte field (0xF2 0x1B 0x00).
+const ipmiForumIANA uint32 = 7154
+
+// handleGetChannelInfo implements Get Channel Info (App 0x42).
+//
+// The response is built from the BMC's [bmc.ChannelStore] rather than from
+// hardcoded media or numbers, so it stays truthful as channels are reconfigured.
+// The channel-number request field may be 0x0E ("this channel"), which resolves
+// to the channel the request arrived on. An unknown channel returns
+// CodeRequestDataFieldInvalid. Response format follows Table 22-30 of the IPMI
+// 2.0 spec.
+//
+// Two fields are deliberate simplifications: the per-channel active-session
+// count is reported as 0 (session occupancy is deferred to Get Session Info),
+// and the protocol and session-support fields are derived from the channel
+// medium. That derivation is faithful for the modeled LAN and system-interface
+// channels but only approximate for other media a caller might configure.
+func handleGetChannelInfo(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 1 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+
+	chNum := req[0] & 0x0F
+	if chNum == types.ChannelNumberSelf {
+		// 0x0E means "the channel this request was received on". The server
+		// records that channel on the context; fall back to the LAN channel when
+		// it is absent (e.g. requests over the system interface in a bare setup).
+		if hctx.Channel != nil {
+			chNum = hctx.Channel.Number
+		} else {
+			chNum = lanChannelNumber
+		}
+	}
+
+	ch, err := hctx.BMC.Channels.Get(chNum)
+	if err != nil {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	resp := make([]byte, 9)
+	resp[0] = ch.Number
+	resp[1] = uint8(ch.Medium)
+	resp[2] = uint8(channelProtocolForMedium(ch.Medium))
+	// Byte 4: bits [7:6] session support, bits [5:0] active session count. All
+	// sessions live on the LAN channel (the only session-based channel this
+	// server models), so its count is both tables' occupancy; other channels
+	// are session-less and report zero. The RMCP+ table's occupancy stands in
+	// for its active count for the reason given in Get Session Info.
+	sessions := 0
+	if ch.Number == lanChannelNumber {
+		sessions = hctx.BMC.Sessions.Count() + hctx.BMC.V15Sessions.CountActiveSessions()
+	}
+	resp[3] = channelSessionSupportForMedium(ch.Medium)<<6 | clampSessionCount(sessions)
+	// Bytes 5:7: channel protocol vendor ID (IANA), LS-first.
+	resp[4] = uint8(ipmiForumIANA & 0xFF)
+	resp[5] = uint8((ipmiForumIANA >> 8) & 0xFF)
+	resp[6] = uint8((ipmiForumIANA >> 16) & 0xFF)
+	// Bytes 8:9: auxiliary channel info. For the system interface these carry
+	// the SMS and event-message-buffer interrupt types, where 0x00 means IRQ 0;
+	// 0xFF is the defined "no interrupt / unspecified" value (Table 22-24). For
+	// a LAN channel the bytes are unused and zero.
+	if ch.Medium == bmc.ChannelMediumSystemIF {
+		resp[7] = 0xFF
+		resp[8] = 0xFF
+	}
+	return resp, types.CodeOK, nil
+}
+
+// channelProtocolForMedium maps a channel medium to the message protocol it
+// speaks. LAN and IPMB-based channels carry IPMB-formatted messages; the system
+// interface uses KCS.
+func channelProtocolForMedium(m bmc.ChannelMedium) types.ChannelProtocol {
+	if m == bmc.ChannelMediumSystemIF {
+		return types.ChannelProtocolKCS
+	}
+	return types.ChannelProtocolIPMB
+}
+
+// channelSessionSupportForMedium reports whether a channel is session-based. LAN
+// channels support multiple concurrent sessions; other media (notably the
+// system interface) are session-less.
+func channelSessionSupportForMedium(m bmc.ChannelMedium) uint8 {
+	if m == bmc.ChannelMediumLAN {
+		return channelMultiSession
+	}
+	return channelSessionLess
 }

--- a/pkg/handlers/channel_info_test.go
+++ b/pkg/handlers/channel_info_test.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// wantChannelInfo asserts the common response invariants: the standard 9-byte
+// length and the IPMI-forum IANA (7154 = 0xF2 0x1B 0x00, LS-first).
+func wantChannelInfo(t *testing.T, resp []byte, cc types.CompletionCode) {
+	t.Helper()
+	if cc != types.CodeOK {
+		t.Fatalf("completion code = 0x%02x, want OK", uint8(cc))
+	}
+	if len(resp) != 9 {
+		t.Fatalf("response length = %d, want 9", len(resp))
+	}
+	if resp[4] != 0xF2 || resp[5] != 0x1B || resp[6] != 0x00 {
+		t.Errorf("vendor IANA = % x, want f2 1b 00 (7154 LS-first)", resp[4:7])
+	}
+}
+
+func TestHandleGetChannelInfoLAN(t *testing.T) {
+	b := newTestBMC()
+	// A concrete LAN channel arrival, so 0x0E must resolve to it.
+	ch, _ := b.Channels.Get(lanChannelNumber)
+	hctx := &HandlerContext{BMC: b, Channel: ch}
+
+	resp, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{lanChannelNumber})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChannelInfo(t, resp, cc)
+
+	if resp[0] != lanChannelNumber {
+		t.Errorf("channel number = %d, want %d", resp[0], lanChannelNumber)
+	}
+	if resp[1] != uint8(bmc.ChannelMediumLAN) {
+		t.Errorf("medium = 0x%02x, want 0x%02x (LAN)", resp[1], uint8(bmc.ChannelMediumLAN))
+	}
+	if resp[2] != uint8(types.ChannelProtocolIPMB) {
+		t.Errorf("protocol = 0x%02x, want 0x%02x (IPMB)", resp[2], uint8(types.ChannelProtocolIPMB))
+	}
+	if support := resp[3] >> 6; support != channelMultiSession {
+		t.Errorf("session support = %d, want %d (multi-session)", support, channelMultiSession)
+	}
+	if count := resp[3] & 0x3F; count != 0 {
+		t.Errorf("active session count = %d, want 0", count)
+	}
+}
+
+func TestHandleGetChannelInfoCurrentChannel(t *testing.T) {
+	b := newTestBMC()
+	ch, _ := b.Channels.Get(lanChannelNumber)
+	hctx := &HandlerContext{BMC: b, Channel: ch}
+
+	// 0x0E ("this channel") must resolve to the channel the request arrived on.
+	resp, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{types.ChannelNumberSelf})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChannelInfo(t, resp, cc)
+	if resp[0] != lanChannelNumber {
+		t.Errorf("resolved channel = %d, want %d", resp[0], lanChannelNumber)
+	}
+}
+
+func TestHandleGetChannelInfoCurrentChannelNoContext(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b} // no arrival channel recorded
+
+	// Without an arrival channel, 0x0E falls back to the LAN channel.
+	resp, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{types.ChannelNumberSelf})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChannelInfo(t, resp, cc)
+	if resp[0] != lanChannelNumber {
+		t.Errorf("resolved channel = %d, want %d", resp[0], lanChannelNumber)
+	}
+}
+
+func TestHandleGetChannelInfoSystemInterface(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+
+	resp, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{0x0F})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChannelInfo(t, resp, cc)
+	if resp[0] != 0x0F {
+		t.Errorf("channel number = %d, want 15", resp[0])
+	}
+	if resp[1] != uint8(bmc.ChannelMediumSystemIF) {
+		t.Errorf("medium = 0x%02x, want 0x%02x (system interface)", resp[1], uint8(bmc.ChannelMediumSystemIF))
+	}
+	if resp[2] != uint8(types.ChannelProtocolKCS) {
+		t.Errorf("protocol = 0x%02x, want 0x%02x (KCS)", resp[2], uint8(types.ChannelProtocolKCS))
+	}
+	if support := resp[3] >> 6; support != channelSessionLess {
+		t.Errorf("session support = %d, want %d (session-less)", support, channelSessionLess)
+	}
+}
+
+func TestHandleGetChannelInfoMediumFromStore(t *testing.T) {
+	b := newTestBMC()
+	// Reconfigure a channel's medium and confirm the handler reports it rather
+	// than a hardcoded value.
+	b.Channels.Set(&bmc.Channel{Number: 3, Medium: bmc.ChannelMediumSerial, AccessMode: bmc.ChannelAccessAlways})
+	hctx := &HandlerContext{BMC: b}
+
+	resp, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantChannelInfo(t, resp, cc)
+	if resp[1] != uint8(bmc.ChannelMediumSerial) {
+		t.Errorf("medium = 0x%02x, want 0x%02x (serial)", resp[1], uint8(bmc.ChannelMediumSerial))
+	}
+}
+
+func TestHandleGetChannelInfoErrors(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+
+	t.Run("truncated", func(t *testing.T) {
+		_, cc, err := handleGetChannelInfo(context.Background(), hctx, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cc != types.CodeRequestDataTruncated {
+			t.Fatalf("completion code = 0x%02x, want truncated", uint8(cc))
+		}
+	})
+
+	t.Run("unknown-channel", func(t *testing.T) {
+		_, cc, err := handleGetChannelInfo(context.Background(), hctx, []byte{0x07})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cc != types.CodeRequestDataFieldInvalid {
+			t.Fatalf("completion code = 0x%02x, want field invalid", uint8(cc))
+		}
+	})
+}

--- a/pkg/handlers/privilege.go
+++ b/pkg/handlers/privilege.go
@@ -39,7 +39,12 @@ func checkCommandPrivilege(hctx *HandlerContext, netFn, cmd uint8) types.Complet
 	}
 	priv, ok := sessionPrivilege(hctx)
 	if !ok {
-		return types.CodeOK
+		// No active session. Only the pre-session exempt commands above
+		// (channel-auth discovery and session setup) may run without one; every
+		// other command requires an authenticated session. This is what stops an
+		// unauthenticated LAN caller from invoking account management, chassis
+		// power, and the like by sending a session-less packet.
+		return types.CodeInsufficientPrivilege
 	}
 	if priv < MinimumPrivilege(netFn, cmd) {
 		return types.CodeInsufficientPrivilege

--- a/pkg/handlers/privilege_test.go
+++ b/pkg/handlers/privilege_test.go
@@ -61,3 +61,45 @@ func TestActivateSessionRejectsReservedPrivilegeZero(t *testing.T) {
 		t.Fatalf("want param out of range for privilege 0, got %02x", cc)
 	}
 }
+
+// TestPreSessionRejectsPrivilegedCommands proves an unauthenticated LAN packet
+// (no session) cannot invoke a privileged command such as Set User Password.
+// Without the gate a remote attacker could create an administrator account and
+// then log in normally. It drives the real registry so the check is exercised
+// through the same wrapper every dispatch path uses, and asserts no user slot
+// was created as a side effect.
+func TestPreSessionRejectsPrivilegedCommands(t *testing.T) {
+	b := newTestBMC()
+	reg := NewRegistry()
+	RegisterAllHandlers(reg)
+	ctx := context.Background()
+
+	setPassword := make([]byte, 18)
+	setPassword[0] = 4    // user slot
+	setPassword[1] = 0x02 // set password
+	copy(setPassword[2:], "attacker")
+
+	// Session-less (pre-session LAN): rejected, and the user store is untouched.
+	_, cc, _ := reg.Dispatch(ctx, &HandlerContext{BMC: b}, NetFnAppRequest, CmdSetUserPassword, setPassword)
+	if cc != types.CodeInsufficientPrivilege {
+		t.Errorf("pre-session Set User Password cc = 0x%02x, want insufficient privilege", uint8(cc))
+	}
+	if _, err := b.Users.Get(4); err == nil {
+		t.Error("pre-session Set User Password created a user slot")
+	}
+
+	// The pre-session exempt commands stay reachable without a session.
+	_, cc, _ = reg.Dispatch(ctx, &HandlerContext{BMC: b}, NetFnAppRequest, CmdGetChannelAuthCapabilities, []byte{0x0e, 0x04})
+	if cc != types.CodeOK {
+		t.Errorf("pre-session Get Channel Auth Caps cc = 0x%02x, want OK", uint8(cc))
+	}
+
+	// An authenticated Administrator session runs the command normally.
+	admin := &HandlerContext{BMC: b, Session: &bmc.Session{PrivilegeLevel: bmc.PrivilegeLevelAdministrator}}
+	if _, cc, _ := reg.Dispatch(ctx, admin, NetFnAppRequest, CmdSetUserPassword, setPassword); cc != types.CodeOK {
+		t.Errorf("admin-session Set User Password cc = 0x%02x, want OK", uint8(cc))
+	}
+	if _, err := b.Users.Get(4); err != nil {
+		t.Errorf("admin-session Set User Password did not create the slot: %v", err)
+	}
+}

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -72,6 +72,8 @@ func RegisterAllHandlers(r *Registry) {
 	RegisterStorageHandlers(r)
 	RegisterPayloadHandlers(r)
 	RegisterSOLHandlers(r)
+	RegisterUserHandlers(r)
+	RegisterTransportHandlers(r)
 }
 
 // Register adds or replaces the handler for c, whose NetFn must be the

--- a/pkg/handlers/registry_test.go
+++ b/pkg/handlers/registry_test.go
@@ -4,8 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/types"
 )
+
+// authedCtx is a HandlerContext with an active Administrator session, so the
+// privilege gate lets a privileged command through and these tests exercise
+// only the registry's dispatch plumbing. A session-less context would be
+// rejected before reaching the handler.
+func authedCtx() *HandlerContext {
+	return &HandlerContext{Session: &bmc.Session{PrivilegeLevel: bmc.PrivilegeLevelAdministrator}}
+}
 
 func TestRegistry_Dispatch(t *testing.T) {
 	tests := []struct {
@@ -60,7 +69,7 @@ func TestRegistry_Dispatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := NewRegistry()
 			tc.setup(r)
-			resp, cc, _ := r.Dispatch(context.Background(), &HandlerContext{}, tc.netFn, tc.cmd, nil)
+			resp, cc, _ := r.Dispatch(context.Background(), authedCtx(), tc.netFn, tc.cmd, nil)
 			if cc != tc.wantCC {
 				t.Errorf("cc: want %d, got %d", tc.wantCC, cc)
 			}
@@ -188,8 +197,8 @@ func TestRegistry_Merge(t *testing.T) {
 
 	a.Merge(b)
 
-	_, cc1, _ := a.Dispatch(context.Background(), &HandlerContext{}, 0x06, 0x01, nil)
-	_, cc2, _ := a.Dispatch(context.Background(), &HandlerContext{}, 0x06, 0x02, nil)
+	_, cc1, _ := a.Dispatch(context.Background(), authedCtx(), 0x06, 0x01, nil)
+	_, cc2, _ := a.Dispatch(context.Background(), authedCtx(), 0x06, 0x02, nil)
 
 	if cc1 != types.CodeOK || cc2 != types.CodeOK {
 		t.Errorf("after merge both keys should be present: cc1=%d cc2=%d", cc1, cc2)

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"net"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/rmcpplus"
@@ -28,6 +29,7 @@ func RegisterSessionHandlers(r *Registry) {
 	r.RegisterFunc(types.CommandGetChannelCipherSuites, handleGetChannelCipherSuites)
 	r.RegisterFunc(types.CommandSetSessionPrivilegeLevel, handleSetSessionPrivilegeLevel)
 	r.RegisterFunc(types.CommandCloseSession, handleCloseSession)
+	r.RegisterFunc(types.CommandGetSessionInfo, handleGetSessionInfo)
 	registerV15SessionHandlers(r)
 }
 
@@ -180,6 +182,130 @@ func handleCloseSession(_ context.Context, hctx *HandlerContext, req []byte) ([]
 		return nil, types.CodeParameterOutOfRange, nil
 	}
 	return nil, types.CodeOK, nil
+}
+
+// ---------------------------------------------------------------------------
+// Get Session Info
+// ---------------------------------------------------------------------------
+
+// Session-index request forms of Get Session Info (spec §22.20, request byte 1).
+const (
+	sessionIndexCurrent  uint8 = 0x00 // active session this command was received over
+	sessionIndexByHandle uint8 = 0xFE // look up by session handle
+	sessionIndexByID     uint8 = 0xFF // look up by session ID
+)
+
+// Session protocol auxiliary-data nibble (response byte 6, bits [7:4]) for an
+// 802.3 LAN channel: the IPMI version the session negotiated.
+const (
+	sessionAuxV15 uint8 = 0x00 // IPMI v1.5
+	sessionAuxV20 uint8 = 0x01 // IPMI v2.0 / RMCP+
+)
+
+// handleGetSessionInfo implements Get Session Info (App 0x3d).
+//
+// It answers the "current session" form (session index 0), which is what a
+// remote console's keepalive polls (see the client's GetCurrentSessionInfo).
+// The response carries the session handle, the total session-table capacity and
+// occupancy, and the current session's user ID, operating privilege level and
+// channel. Both RMCP+ and IPMI v1.5 sessions are supported.
+//
+// Lookup by session index N, by handle (0xFE) or by session ID (0xFF) is not
+// implemented and returns CodeRequestDataFieldInvalid; the reference server has
+// no need to describe sessions other than the caller's own.
+func handleGetSessionInfo(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 1 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	if req[0] != sessionIndexCurrent {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	var (
+		userID   uint8
+		privLvl  uint8
+		channel  uint8
+		aux      uint8
+		handle   uint8
+		possible int
+		active   int
+		lanAddr  net.Addr
+	)
+
+	// The server holds the current session's lock for the whole dispatch, so
+	// reading these session fields here needs no additional locking (see the
+	// HandlerContext concurrency contract). Possible and active sessions
+	// describe the caller's own session pool: the v2.0 and v1.5 tables are
+	// independent, so summing them would advertise slots the caller can never
+	// occupy. The RMCP+ store reports table occupancy (Count) as its active
+	// count because per-session state is guarded by the session lock rather
+	// than the store lock and so cannot be scanned race-free from here; outside
+	// an in-flight handshake every occupied slot is an active session.
+	switch {
+	case hctx.Session != nil:
+		aux = sessionAuxV20
+		channel = hctx.Session.Channel
+		privLvl = uint8(hctx.Session.PrivilegeLevel)
+		handle = hctx.Session.Handle
+		if hctx.Session.User != nil {
+			userID = hctx.Session.User.ID
+		}
+		possible = hctx.BMC.Sessions.Cap()
+		active = hctx.BMC.Sessions.Count()
+		lanAddr = hctx.Session.GetAddr()
+	case hctx.V15Session != nil:
+		aux = sessionAuxV15
+		channel = hctx.V15Session.Channel
+		privLvl = uint8(hctx.V15Session.PrivilegeLevel)
+		handle = hctx.V15Session.Handle
+		if hctx.V15Session.User != nil {
+			userID = hctx.V15Session.User.ID
+		}
+		possible = hctx.BMC.V15Sessions.Cap()
+		active = hctx.BMC.V15Sessions.CountActiveSessions()
+	default:
+		// Received over the system interface: there is no current session to
+		// describe.
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	resp := []byte{
+		handle,
+		clampSessionCount(possible),
+		clampSessionCount(active),
+		userID,
+		privLvl,
+		aux<<4 | channel&0x0F,
+	}
+	// 802.3 LAN trailer (Table 22-26 bytes 7-18): remote console IP, MAC, and
+	// port. The emulator knows the console's UDP address; the MAC is not
+	// tracked and real BMCs commonly zero it. The v1.5 path does not record the
+	// console address, and clients tolerate the short response there.
+	if ua, ok := lanAddr.(*net.UDPAddr); ok {
+		if ip4 := ua.IP.To4(); ip4 != nil {
+			resp = append(resp, ip4...)
+			resp = append(resp, 0, 0, 0, 0, 0, 0) // MAC, not tracked
+			resp = append(resp, uint8(ua.Port&0xFF), uint8(ua.Port>>8))
+		}
+	}
+	return resp, types.CodeOK, nil
+}
+
+// clampSessionCount saturates a session count to the 6-bit field the Get
+// Session Info response carries for possible/active sessions (spec Table 22-26;
+// the high two bits are reserved), so an over-large count cannot bleed into
+// them.
+func clampSessionCount(n int) uint8 {
+	if n < 0 {
+		return 0
+	}
+	if n > 0x3F {
+		return 0x3F
+	}
+	return uint8(n)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/handlers/session_info_test.go
+++ b/pkg/handlers/session_info_test.go
@@ -1,0 +1,180 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// activeRMCPSession builds an active RMCP+ session owned by an enabled user and
+// returns it ready to hang off a HandlerContext.
+func activeRMCPSession(t *testing.T, b *bmc.BMC, userID uint8, priv bmc.PrivilegeLevel) *bmc.Session {
+	t.Helper()
+	user, err := b.Users.Add(userID, "operator")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.Enabled = true
+
+	sess, err := b.Sessions.Allocate(0x01020304, types.AuthAlg_HMAC_SHA1, types.IntegrityAlg_HMAC_SHA1_96, types.CryptAlg_AES_CBC_128, priv, lanChannelNumber)
+	if err != nil {
+		t.Fatalf("allocate session: %v", err)
+	}
+	sess.State = bmc.SessionStateActive
+	sess.User = user
+	sess.PrivilegeLevel = priv
+	return sess
+}
+
+func TestHandleGetSessionInfoCurrentRMCP(t *testing.T) {
+	b := newTestBMC()
+	sess := activeRMCPSession(t, b, 5, bmc.PrivilegeLevelAdministrator)
+	hctx := &HandlerContext{BMC: b, Session: sess}
+
+	resp, cc, err := handleGetSessionInfo(context.Background(), hctx, []byte{sessionIndexCurrent})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != types.CodeOK {
+		t.Fatalf("completion code = 0x%02x, want OK", uint8(cc))
+	}
+	if len(resp) != 6 {
+		t.Fatalf("response length = %d, want 6", len(resp))
+	}
+	if resp[0] == 0 {
+		t.Errorf("session handle must be non-zero")
+	}
+	if want := uint8(b.Sessions.Cap()); resp[1] != want {
+		t.Errorf("possible sessions = %d, want %d", resp[1], want)
+	}
+	// The RMCP+ store holds exactly this one session.
+	if resp[2] != 1 {
+		t.Errorf("active sessions = %d, want 1", resp[2])
+	}
+	if resp[3] != 5 {
+		t.Errorf("user id = %d, want 5", resp[3])
+	}
+	if resp[4] != uint8(bmc.PrivilegeLevelAdministrator) {
+		t.Errorf("privilege level = 0x%02x, want 0x%02x", resp[4], uint8(bmc.PrivilegeLevelAdministrator))
+	}
+	if aux := resp[5] >> 4; aux != sessionAuxV20 {
+		t.Errorf("auxiliary data = 0x%x, want IPMI v2.0 (0x%x)", aux, sessionAuxV20)
+	}
+	if ch := resp[5] & 0x0F; ch != lanChannelNumber {
+		t.Errorf("channel = %d, want %d", ch, lanChannelNumber)
+	}
+}
+
+func TestHandleGetSessionInfoCurrentV15(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(3, "operator")
+	if err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	user.Enabled = true
+
+	sess, err := b.V15Sessions.CreatePending(bmc.V15AuthTypeMD5, user, [16]byte{}, lanChannelNumber)
+	if err != nil {
+		t.Fatalf("create v1.5 session: %v", err)
+	}
+	sess.SessionID = 0xAABBCCDD
+	sess.State = bmc.V15SessionStateActive
+	sess.PrivilegeLevel = bmc.PrivilegeLevelOperator
+
+	hctx := &HandlerContext{BMC: b, V15Session: sess}
+
+	resp, cc, err := handleGetSessionInfo(context.Background(), hctx, []byte{sessionIndexCurrent})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != types.CodeOK {
+		t.Fatalf("completion code = 0x%02x, want OK", uint8(cc))
+	}
+	if len(resp) != 6 {
+		t.Fatalf("response length = %d, want 6", len(resp))
+	}
+	if resp[0] != sess.Handle {
+		t.Errorf("session handle = 0x%02x, want 0x%02x", resp[0], sess.Handle)
+	}
+	if resp[0] == 0 || resp[0] == 0xFF {
+		t.Errorf("session handle = 0x%02x, want neither 0x00 (no session) nor reserved 0xFF", resp[0])
+	}
+	if resp[2] != 1 {
+		t.Errorf("active sessions = %d, want 1", resp[2])
+	}
+	if resp[3] != 3 {
+		t.Errorf("user id = %d, want 3", resp[3])
+	}
+	if resp[4] != uint8(bmc.PrivilegeLevelOperator) {
+		t.Errorf("privilege level = 0x%02x, want 0x%02x", resp[4], uint8(bmc.PrivilegeLevelOperator))
+	}
+	if aux := resp[5] >> 4; aux != sessionAuxV15 {
+		t.Errorf("auxiliary data = 0x%x, want IPMI v1.5 (0x%x)", aux, sessionAuxV15)
+	}
+	if ch := resp[5] & 0x0F; ch != lanChannelNumber {
+		t.Errorf("channel = %d, want %d", ch, lanChannelNumber)
+	}
+}
+
+func TestHandleGetSessionInfoRejectsUnsupportedForms(t *testing.T) {
+	b := newTestBMC()
+	sess := activeRMCPSession(t, b, 5, bmc.PrivilegeLevelAdministrator)
+	hctx := &HandlerContext{BMC: b, Session: sess}
+
+	for _, tc := range []struct {
+		name string
+		req  []byte
+		want types.CompletionCode
+	}{
+		{"empty", nil, types.CodeRequestDataTruncated},
+		{"by-index", []byte{0x02}, types.CodeRequestDataFieldInvalid},
+		{"by-handle", []byte{sessionIndexByHandle, 0x01}, types.CodeRequestDataFieldInvalid},
+		{"by-id", []byte{sessionIndexByID, 0x01, 0x02, 0x03, 0x04}, types.CodeRequestDataFieldInvalid},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cc, err := handleGetSessionInfo(context.Background(), hctx, tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cc != tc.want {
+				t.Fatalf("completion code = 0x%02x, want 0x%02x", uint8(cc), uint8(tc.want))
+			}
+		})
+	}
+}
+
+func TestHandleGetSessionInfoNoCurrentSession(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+
+	_, cc, err := handleGetSessionInfo(context.Background(), hctx, []byte{sessionIndexCurrent})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != types.CodeRequestDataFieldInvalid {
+		t.Fatalf("completion code = 0x%02x, want field invalid", uint8(cc))
+	}
+}
+
+func TestSessionHandlesUnique(t *testing.T) {
+	// Handles are assigned at allocation and must be unique among live
+	// sessions and never 0x00 ("no session") or the reserved 0xFF, so Get
+	// Session Info is unambiguous about which session it describes.
+	b := newTestBMC()
+	seen := map[uint8]bool{}
+	for i := 0; i < 4; i++ {
+		sess, err := b.Sessions.Allocate(uint32(0x100+i), types.AuthAlg_None, types.IntegrityAlg_None, types.CryptAlg_None, bmc.PrivilegeLevelAdministrator, lanChannelNumber)
+		if err != nil {
+			t.Fatalf("allocate session %d: %v", i, err)
+		}
+		if sess.Handle == 0 || sess.Handle == 0xFF {
+			t.Errorf("session %d: handle = 0x%02x, want neither 0x00 nor 0xFF", i, sess.Handle)
+		}
+		if seen[sess.Handle] {
+			t.Errorf("session %d: handle 0x%02x already assigned to a live session", i, sess.Handle)
+		}
+		seen[sess.Handle] = true
+	}
+}

--- a/pkg/handlers/session_v15.go
+++ b/pkg/handlers/session_v15.go
@@ -159,7 +159,23 @@ func lookupV15User(b *bmc.BMC, username []byte, channel uint8) (*bmc.User, types
 	if err != nil {
 		return nil, ccV15InvalidUserName, false
 	}
+	// The 20-byte-password rejection (spec v2.0§22.30) is not applied here:
+	// this command validates the user name and channel access only, both of
+	// which are fine. The credential class is enforced where the v1.5 AuthCode
+	// is actually verified (see [V15Usable] and its caller), so the failure
+	// surfaces as an authentication failure at Activate Session rather than a
+	// misleading "invalid user name" here.
 	return user, types.CodeOK, true
+}
+
+// V15Usable reports whether user may authenticate an IPMI v1.5 session. A
+// password stored with the 20-byte size tag exists only in IPMI 2.0
+// (spec v2.0§22.30), so it cannot: v1.5 carries a 16-byte password, and
+// authenticating a 20-byte-password account over v1.5 would verify against a
+// 16-byte truncation of the secret. Enforced at the point the v1.5 AuthCode is
+// verified, so it covers both named and null (User 1) accounts.
+func V15Usable(user *bmc.User) bool {
+	return user != nil && !user.Password20
 }
 
 func trimV15Username(username []byte) string {

--- a/pkg/handlers/session_v15_policy.go
+++ b/pkg/handlers/session_v15_policy.go
@@ -17,21 +17,33 @@ func MinimumPrivilege(netFn, cmd uint8) bmc.PrivilegeLevel {
 		}
 	case NetFnAppRequest:
 		switch cmd {
-		case CmdColdReset, CmdWarmReset:
+		case CmdColdReset, CmdWarmReset,
+			CmdSetUserAccess, CmdSetUsername, CmdSetUserPassword:
+			// Resetting the BMC and writing user configuration require
+			// Administrator (spec Appendix G). Set User Password in particular
+			// must never be reachable from a lesser-privileged session.
 			return bmc.PrivilegeLevelAdministrator
 		case 0x4c: // Set User Payload Access (§24.6, Table 24-8): user administration
 			return bmc.PrivilegeLevelAdministrator
+		case CmdGetUserAccess, CmdGetUsername:
+			// Reading user configuration requires Operator (spec Appendix G).
+			return bmc.PrivilegeLevelOperator
 		default:
 			return bmc.PrivilegeLevelUser
 		}
 	case NetFnTransportRequest:
-		// Set SOL Configuration Parameters (§26.2) is a configuration write
-		// like Set LAN Configuration Parameters; the Activate Payload
-		// privilege itself comes from SOL parameter #2 (Table 26-5).
-		if cmd == 0x21 { // Set SOL Configuration Parameters
+		switch cmd {
+		case 0x21:
+			// Set SOL Configuration Parameters (§26.2) is a configuration write
+			// like Set LAN Configuration Parameters; the Activate Payload
+			// privilege itself comes from SOL parameter #2 (Table 26-5).
 			return bmc.PrivilegeLevelAdministrator
+		case CmdGetLanConfigParam:
+			// Get LAN Configuration Parameters requires Operator (spec Appendix G).
+			return bmc.PrivilegeLevelOperator
+		default:
+			return bmc.PrivilegeLevelUser
 		}
-		return bmc.PrivilegeLevelUser
 	default:
 		return bmc.PrivilegeLevelUser
 	}

--- a/pkg/handlers/session_v15_test.go
+++ b/pkg/handlers/session_v15_test.go
@@ -214,3 +214,82 @@ func TestV15InboundSeqDuplicateRejected(t *testing.T) {
 		t.Fatal("duplicate seq should be rejected")
 	}
 }
+
+// TestLookupV15UserValidatesNameOnly proves Get Session Challenge's user
+// lookup succeeds for a valid, enabled name regardless of the stored password
+// size: it validates the name and channel access, not the credential class.
+// The 20-byte-password rejection (spec v2.0§22.30) is enforced later, at the
+// AuthCode verification during Activate Session, so it does not masquerade here
+// as an "invalid user name".
+func TestLookupV15UserValidatesNameOnly(t *testing.T) {
+	b := newTestBMC()
+	user, err := b.Users.Add(2, "op20")
+	if err != nil {
+		t.Fatal(err)
+	}
+	user.SetPassword([]byte("abcdefghijklmnopqrst")) // 20 bytes -> Password20
+	user.Enabled = true
+	user.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+		MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+		Enabled:      true,
+	}
+
+	uname := make([]byte, 16)
+	copy(uname, "op20")
+	if _, cc, ok := lookupV15User(b, uname, lanChannelNumber); !ok {
+		t.Fatalf("valid name rejected at lookup, cc=0x%02x", cc)
+	}
+}
+
+// TestLookupV15NullUserCoveredByCredentialGate guards the null-user (User 1)
+// path, the case the fix's second half is about. A null username resolves to
+// User 1 and the lookup accepts it (the anonymous name is valid), so the
+// 20-byte rejection cannot live in the lookup; it must come from the shared
+// credential gate. This asserts both halves: the null lookup returns User 1,
+// and [V15Usable] rejects that User 1 when it carries a 20-byte password, which
+// is exactly what the single auth chokepoint applies to the session's user.
+func TestLookupV15NullUserCoveredByCredentialGate(t *testing.T) {
+	b := newTestBMC()
+	if err := b.Users.Update(1, func(u *bmc.User) error {
+		u.SetPassword([]byte("abcdefghijklmnopqrst")) // 20 bytes -> Password20
+		u.Enabled = true
+		u.ChannelAccess[lanChannelNumber] = bmc.UserChannelAccess{
+			MaxPrivilege: bmc.PrivilegeLevelAdministrator,
+			Enabled:      true,
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	nullName := make([]byte, 16) // all zeros = null user (User 1)
+	user, cc, ok := lookupV15User(b, nullName, lanChannelNumber)
+	if !ok {
+		t.Fatalf("null-user lookup rejected, cc=0x%02x", cc)
+	}
+	if user.ID != 1 {
+		t.Fatalf("null user resolved to slot %d, want User 1", user.ID)
+	}
+	if V15Usable(user) {
+		t.Fatal("null User 1 with a 20-byte password must not be v1.5-usable")
+	}
+}
+
+// TestV15Usable pins the v1.5 credential-class gate: a 20-byte-password account
+// (and a nil user) cannot authenticate a v1.5 session, a 16-byte one can.
+func TestV15Usable(t *testing.T) {
+	if V15Usable(nil) {
+		t.Error("nil user must not be v1.5-usable")
+	}
+
+	u := &bmc.User{}
+	u.SetPassword([]byte("s3cr3t")) // <=16 bytes: 16-byte class
+	if !V15Usable(u) {
+		t.Error("16-byte-password user must be v1.5-usable")
+	}
+
+	u.SetPassword([]byte("abcdefghijklmnopqrst")) // >16 bytes: 20-byte class
+	if V15Usable(u) {
+		t.Error("20-byte-password user must not be v1.5-usable")
+	}
+}

--- a/pkg/handlers/transport.go
+++ b/pkg/handlers/transport.go
@@ -1,0 +1,233 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// CmdGetLanConfigParam is the Get LAN Configuration Parameters command byte,
+// referenced by the privilege table. The Transport request NetFn is declared
+// with the payload handlers.
+const CmdGetLanConfigParam uint8 = 0x02
+
+// LAN configuration parameter revision reported for every supported parameter.
+// The high nibble is the "oldest revision supported" and the low nibble the
+// "present revision"; 0x11 is the value real BMCs report (spec §23.2).
+const lanParamRevision uint8 = 0x11
+
+// standardPrimaryRMCPPort is the IANA-assigned RMCP port (623) used for IPMI
+// over LAN. It is reported for param #8 unless the NetworkHAL advertises a
+// non-zero port, which lets a BMC listening on a non-standard port make in-band
+// software discover it.
+const standardPrimaryRMCPPort uint16 = 623
+
+// RegisterTransportHandlers adds all Transport (LAN) command handlers to r.
+func RegisterTransportHandlers(r *Registry) {
+	r.RegisterFunc(types.CommandGetLanConfigParam, handleGetLanConfigParam)
+}
+
+// handleGetLanConfigParam implements Get LAN Configuration Parameters
+// (Transport 0x02, spec §23.2), the command in-band software and the metal
+// agent use to discover the BMC's own network address.
+//
+// The request body is:
+//
+//	byte 1: [7] get parameter revision only, [3:0] channel number
+//	byte 2: parameter selector
+//	byte 3: set selector (block-based parameters only)
+//	byte 4: block selector (block-based parameters only)
+//
+// The channel is validated to be a configured LAN channel (0x0E resolves to the
+// arrival channel), but the reference BMC models a single NIC, so every LAN
+// channel resolves to the same NetworkHAL configuration. The set/block
+// selectors are not used by the parameters this handler serves. When bit 7 of
+// the channel byte is set the caller wants only the parameter revision, so the
+// data field is omitted (spec §23.2).
+//
+// The address-family parameters (IP, IP source, MAC, subnet, default gateway)
+// are backed by [hal.NetworkHAL]; when Network() is nil the BMC has no NIC to
+// describe and the command returns CannotExecuteCommandNotSupported. The set-in
+// progress, authentication-type support and primary RMCP port parameters are
+// static and answer without a NIC. Any other selector returns
+// ParameterNotSupported (spec Table 23-4 permits a BMC to implement a subset).
+//
+// Only Get is implemented; Set LAN Configuration Parameters is out of scope.
+func handleGetLanConfigParam(ctx context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	// The command's request is 4 bytes (channel, parameter selector, set
+	// selector, block selector); the bundled client always packs all four.
+	if len(req) < 4 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+
+	revisionOnly := req[0]&0x80 != 0
+	param := types.LanConfigParamSelector(req[1])
+
+	// Validate the requested channel before anything else: it must be a
+	// configured LAN channel, so channel 0x0F (system interface) or an unknown
+	// channel does not return channel 1's NIC configuration.
+	if !lanChannelValid(hctx, req[0]&0x0f) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// Resolve the parameter before honoring a revision-only query, so
+	// revision-only for an unsupported selector still returns the
+	// parameter-not-supported code rather than a spurious success. The data of
+	// a revision-only query is discarded; the only cost is a NetworkHAL read.
+	data, cc := lanParamData(ctx, hctx, param)
+	if cc != types.CodeOK {
+		return nil, cc, nil
+	}
+	if revisionOnly {
+		return []byte{lanParamRevision}, types.CodeOK, nil
+	}
+	return lanParamResponse(data...), types.CodeOK, nil
+}
+
+// lanParamData returns the raw data bytes for one LAN configuration parameter.
+// Its default arm is the single authority on which selectors are supported.
+func lanParamData(ctx context.Context, hctx *HandlerContext, param types.LanConfigParamSelector) ([]byte, types.CompletionCode) {
+	switch param {
+	case types.LanConfigParamSelector_SetInProgress:
+		// Report "set complete": the reference server has no in-progress LAN
+		// configuration transaction.
+		return []byte{byte(types.SetInProgress_SetComplete)}, types.CodeOK
+
+	case types.LanConfigParamSelector_AuthTypeSupport:
+		// Read-only bitmask (spec Table 23-4 param #1). Advertise the same v1.5
+		// authentication types Get Channel Auth Capabilities reports, so the two
+		// commands cannot contradict a v1.5-disabled or MD5-only deployment.
+		return lanAuthTypeSupport(hctx.BMC).Pack(), types.CodeOK
+
+	case types.LanConfigParamSelector_PrimaryRMCPPort:
+		// 2-byte port, LS-first (spec Table 23-4 param #8). Reported from the
+		// NetworkHAL configuration when it advertises a non-zero port, otherwise
+		// the standard 623; this stays answerable without a NIC. A NetworkHAL read
+		// error maps to the HAL completion code, like the address parameters,
+		// rather than silently reporting 623.
+		port := standardPrimaryRMCPPort
+
+		if network := hctx.BMC.HAL().Network(); network != nil {
+			cfg, err := network.GetConfig(ctx)
+			if err != nil {
+				return nil, codeFromHalErr(err)
+			}
+
+			if cfg.Port != 0 {
+				port = cfg.Port
+			}
+		}
+
+		out := make([]byte, 2)
+		binary.LittleEndian.PutUint16(out, port)
+
+		return out, types.CodeOK
+
+	case types.LanConfigParamSelector_IP,
+		types.LanConfigParamSelector_IPSource,
+		types.LanConfigParamSelector_MAC,
+		types.LanConfigParamSelector_SubnetMask,
+		types.LanConfigParamSelector_DefaultGatewayIP:
+		return lanAddressParamData(ctx, hctx, param)
+
+	default:
+		return nil, types.CodeParameterNotSupported
+	}
+}
+
+// lanAddressParamData answers the address-family LAN parameters from the
+// NetworkHAL configuration. The raw bytes it emits match what the client's
+// GetLanConfigParamFor decoder expects (spec Table 23-4): 4 octets for the IPv4
+// address, subnet mask and default gateway; 6 octets for the MAC; a single
+// source byte for the IP address source.
+func lanAddressParamData(ctx context.Context, hctx *HandlerContext, param types.LanConfigParamSelector) ([]byte, types.CompletionCode) {
+	network := hctx.BMC.HAL().Network()
+	if network == nil {
+		return nil, types.CodeNotSupported
+	}
+
+	cfg, err := network.GetConfig(ctx)
+	if err != nil {
+		return nil, codeFromHalErr(err)
+	}
+
+	switch param {
+	case types.LanConfigParamSelector_IP:
+		return cfg.IP[:], types.CodeOK
+
+	case types.LanConfigParamSelector_IPSource:
+		source := types.IPAddressSourceStatic
+		if cfg.DHCP {
+			source = types.IPAddressSourceDHCP
+		}
+		return []byte{byte(source)}, types.CodeOK
+
+	case types.LanConfigParamSelector_MAC:
+		return cfg.MAC[:], types.CodeOK
+
+	case types.LanConfigParamSelector_SubnetMask:
+		return cfg.Mask[:], types.CodeOK
+
+	case types.LanConfigParamSelector_DefaultGatewayIP:
+		return cfg.Gateway[:], types.CodeOK
+
+	default:
+		// Unreachable: the caller only routes the parameters handled above.
+		return nil, types.CodeParameterNotSupported
+	}
+}
+
+// lanChannelValid resolves the request's channel nibble (0x0E means "this
+// channel") and reports whether it names a configured LAN channel. Non-LAN and
+// unknown channels are rejected so the command never describes the wrong NIC.
+func lanChannelValid(hctx *HandlerContext, nibble uint8) bool {
+	channel := nibble
+	if channel == types.ChannelNumberSelf {
+		if hctx.Channel != nil {
+			channel = hctx.Channel.Number
+		} else {
+			channel = lanChannelNumber
+		}
+	}
+	ch, err := hctx.BMC.Channels.Get(channel)
+	if err != nil {
+		return false
+	}
+	return ch.Medium == bmc.ChannelMediumLAN
+}
+
+// lanAuthTypeSupport derives the auth-type-support bitmask from the BMC's
+// resolved v1.5 authentication types, the same source Get Channel Auth
+// Capabilities uses. When v1.5 LAN is disabled no type is advertised.
+func lanAuthTypeSupport(b *bmc.BMC) *types.LanConfigParam_AuthTypeSupport {
+	support := &types.LanConfigParam_AuthTypeSupport{}
+	if b == nil || !b.V15LANEnabled() {
+		return support
+	}
+	for _, t := range b.ResolvedV15AuthTypes() {
+		switch t {
+		case bmc.V15AuthTypeNone:
+			support.None = true
+		case bmc.V15AuthTypeMD2:
+			support.MD2 = true
+		case bmc.V15AuthTypeMD5:
+			support.MD5 = true
+		case bmc.V15AuthTypePassword:
+			support.Password = true
+		case bmc.V15AuthTypeOEM:
+			support.OEM = true
+		}
+	}
+	return support
+}
+
+// lanParamResponse frames parameter data as a Get LAN Configuration Parameters
+// response: the parameter revision byte followed by the parameter data.
+func lanParamResponse(data ...byte) []byte {
+	return append([]byte{lanParamRevision}, data...)
+}

--- a/pkg/handlers/transport_test.go
+++ b/pkg/handlers/transport_test.go
@@ -1,0 +1,341 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// testIPConfig is a representative BMC NIC configuration used across the LAN
+// parameter tests.
+var testIPConfig = hal.IPConfig{
+	IP:      [4]byte{192, 168, 1, 50},
+	Mask:    [4]byte{255, 255, 255, 0},
+	Gateway: [4]byte{192, 168, 1, 1},
+	MAC:     [6]byte{0x52, 0x54, 0x00, 0x12, 0x34, 0x56},
+	DHCP:    false,
+}
+
+// newTestBMCWithNetwork builds a BMC whose mock NetworkHAL reports cfg.
+func newTestBMCWithNetwork(t *testing.T, cfg hal.IPConfig, opts ...bmc.Option) *bmc.BMC {
+	t.Helper()
+	m := mock.New()
+	b := bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, m, append([]bmc.Option{bmc.WithClock(clock.Real)}, opts...)...)
+	if err := b.HAL().Network().SetConfig(context.Background(), &cfg); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	return b
+}
+
+// getLanParam dispatches Get LAN Configuration Parameters for one selector on
+// channel 1 with zero set/block selectors, returning the raw response.
+func getLanParam(t *testing.T, b *bmc.BMC, param types.LanConfigParamSelector) ([]byte, types.CompletionCode) {
+	t.Helper()
+	hctx := &HandlerContext{BMC: b}
+	resp, cc, err := handleGetLanConfigParam(context.Background(), hctx, []byte{0x01, byte(param), 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("handleGetLanConfigParam(%s): unexpected error: %v", param, err)
+	}
+	return resp, cc
+}
+
+// unpackParamData asserts a success response, checks the parameter revision, and
+// feeds the parameter data through the given typed parameter's own decoder, the
+// same path the real client takes. This proves the response bytes match what a
+// console decodes.
+func unpackParamData(t *testing.T, resp []byte, cc types.CompletionCode, param types.LanConfigParameter) {
+	t.Helper()
+	if cc != types.CodeOK {
+		t.Fatalf("completion code = 0x%02x, want OK", uint8(cc))
+	}
+	if len(resp) < 1 {
+		t.Fatalf("response too short: %d bytes", len(resp))
+	}
+	if resp[0] != lanParamRevision {
+		t.Errorf("parameter revision = 0x%02x, want 0x%02x", resp[0], lanParamRevision)
+	}
+	if err := param.Unpack(resp[1:]); err != nil {
+		t.Fatalf("decode parameter data % x: %v", resp[1:], err)
+	}
+}
+
+func TestHandleGetLanConfigParamAddresses(t *testing.T) {
+	b := newTestBMCWithNetwork(t, testIPConfig)
+
+	t.Run("ip", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_IP)
+		var p types.LanConfigParam_IP
+		unpackParamData(t, resp, cc, &p)
+		if got := p.IP.String(); got != "192.168.1.50" {
+			t.Errorf("IP = %s, want 192.168.1.50", got)
+		}
+	})
+
+	t.Run("subnet", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_SubnetMask)
+		var p types.LanConfigParam_SubnetMask
+		unpackParamData(t, resp, cc, &p)
+		if got := p.SubnetMask.String(); got != "255.255.255.0" {
+			t.Errorf("subnet = %s, want 255.255.255.0", got)
+		}
+	})
+
+	t.Run("gateway", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_DefaultGatewayIP)
+		var p types.LanConfigParam_DefaultGatewayIP
+		unpackParamData(t, resp, cc, &p)
+		if got := p.IP.String(); got != "192.168.1.1" {
+			t.Errorf("gateway = %s, want 192.168.1.1", got)
+		}
+	})
+
+	t.Run("mac", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_MAC)
+		var p types.LanConfigParam_MAC
+		unpackParamData(t, resp, cc, &p)
+		if got := p.MAC.String(); got != "52:54:00:12:34:56" {
+			t.Errorf("MAC = %s, want 52:54:00:12:34:56", got)
+		}
+	})
+}
+
+func TestHandleGetLanConfigParamIPSource(t *testing.T) {
+	t.Run("static", func(t *testing.T) {
+		b := newTestBMCWithNetwork(t, testIPConfig)
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_IPSource)
+		var p types.LanConfigParam_IPSource
+		unpackParamData(t, resp, cc, &p)
+		if p.Source != types.IPAddressSourceStatic {
+			t.Errorf("source = %s, want static", p.Source)
+		}
+	})
+
+	t.Run("dhcp", func(t *testing.T) {
+		cfg := testIPConfig
+		cfg.DHCP = true
+		b := newTestBMCWithNetwork(t, cfg)
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_IPSource)
+		var p types.LanConfigParam_IPSource
+		unpackParamData(t, resp, cc, &p)
+		if p.Source != types.IPAddressSourceDHCP {
+			t.Errorf("source = %s, want DHCP", p.Source)
+		}
+	})
+}
+
+func TestHandleGetLanConfigParamStatic(t *testing.T) {
+	b := newTestBMCWithNetwork(t, testIPConfig)
+
+	t.Run("set-in-progress", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_SetInProgress)
+		var p types.LanConfigParam_SetInProgress
+		unpackParamData(t, resp, cc, &p)
+		if p.Value != types.SetInProgress_SetComplete {
+			t.Errorf("set in progress = %s, want set complete", p.Value)
+		}
+	})
+
+	t.Run("auth-type-support", func(t *testing.T) {
+		// Configure a known set of v1.5 auth types and assert the parameter
+		// reflects exactly them, the same source Get Channel Auth Caps uses.
+		bb := newTestBMCWithNetwork(t, testIPConfig, bmc.WithV15AuthTypes([]bmc.V15AuthType{bmc.V15AuthTypeMD5, bmc.V15AuthTypePassword}))
+		resp, cc := getLanParam(t, bb, types.LanConfigParamSelector_AuthTypeSupport)
+		var p types.LanConfigParam_AuthTypeSupport
+		unpackParamData(t, resp, cc, &p)
+		if !p.MD5 || !p.Password {
+			t.Errorf("auth type support = %+v, want MD5 and Password advertised", p)
+		}
+		if p.MD2 || p.OEM || p.None {
+			t.Errorf("auth type support = %+v, want only MD5 and Password", p)
+		}
+	})
+
+	t.Run("auth-type-support-v15-disabled", func(t *testing.T) {
+		// With v1.5 LAN disabled the parameter must not advertise any v1.5 auth
+		// type, matching Get Channel Auth Caps rather than contradicting it.
+		bb := newTestBMCWithNetwork(t, testIPConfig, bmc.WithV15Disabled())
+		resp, cc := getLanParam(t, bb, types.LanConfigParamSelector_AuthTypeSupport)
+		var p types.LanConfigParam_AuthTypeSupport
+		unpackParamData(t, resp, cc, &p)
+		if p.MD5 || p.Password || p.MD2 || p.OEM || p.None {
+			t.Errorf("auth type support = %+v, want none advertised", p)
+		}
+	})
+
+	t.Run("primary-rmcp-port", func(t *testing.T) {
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_PrimaryRMCPPort)
+		var p types.LanConfigParam_PrimaryRMCPPort
+		unpackParamData(t, resp, cc, &p)
+		if p.Port != standardPrimaryRMCPPort {
+			t.Errorf("primary RMCP port = %d, want %d", p.Port, standardPrimaryRMCPPort)
+		}
+	})
+}
+
+func TestHandleGetLanConfigParamRevisionOnly(t *testing.T) {
+	b := newTestBMCWithNetwork(t, testIPConfig)
+	hctx := &HandlerContext{BMC: b}
+
+	// Bit 7 of the channel byte requests the parameter revision only, so the
+	// response carries just the revision byte and no parameter data.
+	resp, cc, err := handleGetLanConfigParam(context.Background(), hctx, []byte{0x81, byte(types.LanConfigParamSelector_IP), 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != types.CodeOK {
+		t.Fatalf("completion code = 0x%02x, want OK", uint8(cc))
+	}
+	if len(resp) != 1 || resp[0] != lanParamRevision {
+		t.Errorf("response = % x, want just the revision byte 0x%02x", resp, lanParamRevision)
+	}
+}
+
+func TestHandleGetLanConfigParamErrors(t *testing.T) {
+	b := newTestBMCWithNetwork(t, testIPConfig)
+	hctx := &HandlerContext{BMC: b}
+
+	t.Run("truncated", func(t *testing.T) {
+		// The request is 4 bytes; anything shorter (including the 2- and 3-byte
+		// forms) is rejected rather than treating the missing selectors as zero.
+		for _, req := range [][]byte{
+			{0x01},
+			{0x01, byte(types.LanConfigParamSelector_IP)},
+			{0x01, byte(types.LanConfigParamSelector_IP), 0x00},
+		} {
+			_, cc, err := handleGetLanConfigParam(context.Background(), hctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cc != types.CodeRequestDataTruncated {
+				t.Fatalf("%d-byte request: completion code = 0x%02x, want truncated", len(req), uint8(cc))
+			}
+		}
+	})
+
+	t.Run("unsupported-selector", func(t *testing.T) {
+		// Community string (param 16) is not implemented by the reference server.
+		_, cc := getLanParam(t, b, types.LanConfigParamSelector_CommunityString)
+		if cc != types.CodeParameterNotSupported {
+			t.Fatalf("completion code = 0x%02x, want parameter not supported", uint8(cc))
+		}
+	})
+
+	t.Run("revision-only-unsupported-selector", func(t *testing.T) {
+		// Revision-only must validate the selector first, so an unsupported one
+		// returns parameter-not-supported instead of a spurious success.
+		_, cc, err := handleGetLanConfigParam(context.Background(), hctx,
+			[]byte{0x81, byte(types.LanConfigParamSelector_CommunityString), 0x00, 0x00})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cc != types.CodeParameterNotSupported {
+			t.Fatalf("completion code = 0x%02x, want parameter not supported", uint8(cc))
+		}
+	})
+
+	t.Run("non-lan-channel", func(t *testing.T) {
+		// Channel 0x0F is the system interface, not a LAN channel, so it must not
+		// return channel 1's NIC configuration.
+		_, cc, err := handleGetLanConfigParam(context.Background(), hctx,
+			[]byte{0x0F, byte(types.LanConfigParamSelector_IP), 0x00, 0x00})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cc != types.CodeRequestDataFieldInvalid {
+			t.Fatalf("completion code = 0x%02x, want field invalid", uint8(cc))
+		}
+	})
+
+	t.Run("unknown-channel", func(t *testing.T) {
+		_, cc, err := handleGetLanConfigParam(context.Background(), hctx,
+			[]byte{0x07, byte(types.LanConfigParamSelector_IP), 0x00, 0x00})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cc != types.CodeRequestDataFieldInvalid {
+			t.Fatalf("completion code = 0x%02x, want field invalid", uint8(cc))
+		}
+	})
+}
+
+// noNetworkHAL wraps a HAL but reports no NIC, so address-family LAN parameters
+// have nothing to describe.
+type noNetworkHAL struct {
+	hal.HAL
+}
+
+func (noNetworkHAL) Network() hal.NetworkHAL { return nil }
+
+func TestHandleGetLanConfigParamNoNetwork(t *testing.T) {
+	b := bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, noNetworkHAL{mock.New()}, bmc.WithClock(clock.Real))
+	hctx := &HandlerContext{BMC: b}
+
+	// Address-family parameters require a NIC and must report the command as
+	// unsupported when Network() is nil.
+	for _, param := range []types.LanConfigParamSelector{
+		types.LanConfigParamSelector_IP,
+		types.LanConfigParamSelector_IPSource,
+		types.LanConfigParamSelector_MAC,
+		types.LanConfigParamSelector_SubnetMask,
+		types.LanConfigParamSelector_DefaultGatewayIP,
+	} {
+		_, cc, err := handleGetLanConfigParam(context.Background(), hctx, []byte{0x01, byte(param), 0x00, 0x00})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", param, err)
+		}
+		if cc != types.CodeNotSupported {
+			t.Errorf("%s: completion code = 0x%02x, want command not supported", param, uint8(cc))
+		}
+	}
+
+	// The static parameters do not depend on a NIC and still answer.
+	_, cc, err := handleGetLanConfigParam(context.Background(), hctx, []byte{0x01, byte(types.LanConfigParamSelector_PrimaryRMCPPort), 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("primary RMCP port: unexpected error: %v", err)
+	}
+	if cc != types.CodeOK {
+		t.Errorf("primary RMCP port without NIC: completion code = 0x%02x, want OK", uint8(cc))
+	}
+}
+
+// TestHandleGetLanConfigParamPrimaryRMCPPort proves param #8 reports a
+// non-standard RMCP port from the NetworkHAL configuration and falls back to
+// 623 when none is configured. This is how an emulated BMC listening on an
+// OS-assigned port makes in-band software discover it.
+func TestHandleGetLanConfigParamPrimaryRMCPPort(t *testing.T) {
+	t.Run("custom port from config", func(t *testing.T) {
+		cfg := testIPConfig
+		cfg.Port = 62345
+
+		b := newTestBMCWithNetwork(t, cfg)
+
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_PrimaryRMCPPort)
+
+		var param types.LanConfigParam_PrimaryRMCPPort
+
+		unpackParamData(t, resp, cc, &param)
+
+		if param.Port != 62345 {
+			t.Errorf("port = %d, want 62345", param.Port)
+		}
+	})
+
+	t.Run("zero config port falls back to 623", func(t *testing.T) {
+		b := newTestBMCWithNetwork(t, testIPConfig) // Port left zero
+
+		resp, cc := getLanParam(t, b, types.LanConfigParamSelector_PrimaryRMCPPort)
+
+		var param types.LanConfigParam_PrimaryRMCPPort
+
+		unpackParamData(t, resp, cc, &param)
+
+		if param.Port != 623 {
+			t.Errorf("port = %d, want 623", param.Port)
+		}
+	})
+}

--- a/pkg/handlers/user.go
+++ b/pkg/handlers/user.go
@@ -1,0 +1,334 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// User-management command bytes (App netfn, spec v2.0§22.26 through §22.30).
+// The privilege table (MinimumPrivilege) references these to gate the Set
+// commands at Administrator and the Get commands at Operator.
+const (
+	CmdSetUserAccess   uint8 = 0x43
+	CmdGetUserAccess   uint8 = 0x44
+	CmdSetUsername     uint8 = 0x45
+	CmdGetUsername     uint8 = 0x46
+	CmdSetUserPassword uint8 = 0x47
+)
+
+// Set User Password operations (spec v2.0§22.30 Table 22-42).
+const (
+	passwordOpDisableUser  uint8 = 0x00
+	passwordOpEnableUser   uint8 = 0x01
+	passwordOpSetPassword  uint8 = 0x02
+	passwordOpTestPassword uint8 = 0x03
+)
+
+// RegisterUserHandlers adds the user-management command set backed by
+// [bmc.UserStore] (spec v2.0§22.26 through §22.30).
+//
+// The behavioral contract is dictated by real in-band consumers such as the
+// bougou client's own GetUsers enumerator:
+//   - Get User Access must succeed for every slot from 1 to the reported
+//     maximum, populated or not, because enumerators abort on any nonzero
+//     completion code.
+//   - Get User Name on an empty slot must fail with exactly
+//     [types.CodeRequestDataFieldInvalid] (0xCC), the code enumerators
+//     interpret as "no such user".
+func RegisterUserHandlers(r *Registry) {
+	r.RegisterFunc(types.CommandGetUserAccess, handleGetUserAccess)
+	r.RegisterFunc(types.CommandSetUserAccess, handleSetUserAccess)
+	r.RegisterFunc(types.CommandGetUsername, handleGetUsername)
+	r.RegisterFunc(types.CommandSetUsername, handleSetUsername)
+	r.RegisterFunc(types.CommandSetUserPassword, handleSetUserPassword)
+}
+
+// handleGetUserAccess implements Get User Access (App 0x44, spec v2.0§22.27).
+func handleGetUserAccess(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 2 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	store := hctx.BMC.Users
+	channel := resolveUserChannel(hctx, req[0]&0x0f)
+	userID := req[1] & 0x3f
+	if !validUserID(store, userID) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// Enabled-user count is reported globally rather than per-channel. Spec
+	// §22.27 byte 3 defines it as the number of enabled users on the queried
+	// channel; per-channel counting is deferred as no in-band consumer relies on
+	// the distinction.
+	enabledCount := clampCount(store.CountEnabled())
+
+	// Byte 1 [7:6]: enable status of the queried user. 01b enabled via Set User
+	// Password, 10b disabled, 00b unspecified. Default to disabled for an
+	// unpopulated slot.
+	enableStatus := uint8(0b10)
+	// Byte 3 access flags for the queried user's access on this channel.
+	access := uint8(0)
+	if u, err := store.Get(userID); err == nil {
+		if u.Enabled {
+			enableStatus = 0b01
+		}
+		if ca, ok := u.ChannelAccess[channel]; ok {
+			if ca.CallbackOnly {
+				access |= 1 << 6
+			}
+			if ca.LinkAuth {
+				access |= 1 << 5
+			}
+			if ca.Enabled {
+				access |= 1 << 4 // IPMI messaging enabled
+			}
+			access |= uint8(ca.MaxPrivilege) & 0x0f
+		} else {
+			// No access record on this channel: privilege 0x0F ("no access",
+			// Table 22-28). 0x00 is reserved and ipmitool renders it as unknown.
+			access |= 0x0f
+		}
+	} else {
+		access |= 0x0f
+	}
+
+	return []byte{
+		store.MaxUserCount() & 0x3f,
+		enableStatus<<6 | enabledCount&0x3f,
+		// Fixed-name count: only User 1 (the permanently-associated null user,
+		// spec §6.9.1) has a name that cannot be reassigned. 1-based per §22.27.
+		0x01,
+		access,
+	}, types.CodeOK, nil
+}
+
+// handleSetUserAccess implements Set User Access (App 0x43, spec v2.0§22.26).
+func handleSetUserAccess(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 3 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	store := hctx.BMC.Users
+
+	changeAccess := req[0]&(1<<7) != 0
+	callbackOnly := req[0]&(1<<6) != 0
+	linkAuth := req[0]&(1<<5) != 0
+	ipmiMessaging := req[0]&(1<<4) != 0
+	channel := resolveUserChannel(hctx, req[0]&0x0f)
+	userID := req[1] & 0x3f
+	maxPriv := bmc.PrivilegeLevel(req[2] & 0x0f)
+
+	if !validUserID(store, userID) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// Byte 4 (optional): user session limit. Per-user session limits are not
+	// supported, and the spec (§22.26) requires 0xCC for a nonzero request
+	// rather than acknowledging a setting that has no effect.
+	if len(req) >= 4 && req[3]&0x0f != 0 {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// Byte 1 bit 7 gates only the byte-1 access flags (callback / link-auth /
+	// IPMI-messaging); the byte-3 privilege limit always applies (spec §22.26).
+	// Read-modify-write through the atomic upsert so a clear change bit preserves
+	// the existing flags while still updating the privilege limit.
+	err := store.Upsert(userID, func(u *bmc.User) error {
+		ca := u.ChannelAccess[channel]
+		ca.MaxPrivilege = maxPriv
+		if changeAccess {
+			ca.CallbackOnly = callbackOnly
+			ca.LinkAuth = linkAuth
+			ca.Enabled = ipmiMessaging
+		}
+		u.ChannelAccess[channel] = ca
+		return nil
+	})
+	if err != nil {
+		return nil, types.CodeUnspecifiedError, err
+	}
+	return nil, types.CodeOK, nil
+}
+
+// handleGetUsername implements Get User Name (App 0x46, spec v2.0§22.29).
+func handleGetUsername(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 1 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	store := hctx.BMC.Users
+	userID := req[0] & 0x3f
+	if !validUserID(store, userID) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// User 1 is the permanent null user (spec §6.9.1): its name is defined as
+	// all zeros and reading it succeeds, unlike an unset regular slot.
+	if userID == 1 {
+		return make([]byte, bmc.MaxUserNameLen), types.CodeOK, nil
+	}
+
+	u, err := store.Get(userID)
+	if err != nil || u.Name == "" {
+		// Empty/unset slot: exactly 0xCC, the code in-band enumerators read as
+		// "no such user".
+		return nil, types.CodeRequestDataFieldInvalid, nil //nolint:nilerr // reported as a completion code
+	}
+
+	name := make([]byte, bmc.MaxUserNameLen)
+	copy(name, u.Name)
+	return name, types.CodeOK, nil
+}
+
+// handleSetUsername implements Set User Name (App 0x45, spec v2.0§22.28).
+func handleSetUsername(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 1+bmc.MaxUserNameLen {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	store := hctx.BMC.Users
+	userID := req[0] & 0x3f
+	name := string(bytes.TrimRight(req[1:1+bmc.MaxUserNameLen], "\x00"))
+
+	if !validUserID(store, userID) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// User 1 is the permanent null user with a fixed all-zeros name
+	// (spec §§6.9.1, 22.28), and Get User Access advertises exactly one
+	// fixed-name user; renaming it would contradict both.
+	if userID == 1 {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	// Real BMCs let Set User Name populate a previously empty slot. A name
+	// already held by a different slot is rejected so name-based session lookup
+	// (RAKP GetByName) stays deterministic.
+	err := store.Upsert(userID, func(u *bmc.User) error {
+		u.Name = name
+		return nil
+	})
+	if errors.Is(err, bmc.ErrUsernameTaken) {
+		return nil, types.CodeRequestDataFieldInvalid, nil //nolint:nilerr // reported as a completion code
+	}
+	if err != nil {
+		return nil, types.CodeUnspecifiedError, err
+	}
+	return nil, types.CodeOK, nil
+}
+
+// handleSetUserPassword implements Set User Password (App 0x47, spec v2.0§22.30).
+func handleSetUserPassword(_ context.Context, hctx *HandlerContext, req []byte) ([]byte, types.CompletionCode, error) {
+	if len(req) < 2 {
+		return nil, types.CodeRequestDataTruncated, nil
+	}
+	if hctx == nil || hctx.BMC == nil {
+		return nil, types.CodeNotSupported, nil
+	}
+	store := hctx.BMC.Users
+	userID := req[0] & 0x3f
+	stored20 := req[0]&(1<<7) != 0
+	operation := req[1] & 0x03
+
+	if !validUserID(store, userID) {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
+	passwordLen := 16
+	if stored20 {
+		passwordLen = 20
+	}
+
+	var password []byte
+	if operation == passwordOpSetPassword || operation == passwordOpTestPassword {
+		if len(req) < 2+passwordLen {
+			return nil, types.CodeRequestDataTruncated, nil
+		}
+		password = req[2 : 2+passwordLen]
+	}
+
+	switch operation {
+	case passwordOpTestPassword:
+		// Read-only comparison; must not create a slot.
+		u, err := store.Get(userID)
+		if err != nil {
+			return nil, types.CodeRequestDataFieldInvalid, nil //nolint:nilerr // reported as a completion code
+		}
+		// The size tag is part of the credential (spec §22.30): testing a
+		// password with the other size fails with the dedicated code before any
+		// byte comparison.
+		if stored20 != u.Password20 {
+			return nil, types.CodeSetUserPasswordWrongSize, nil
+		}
+		// Compare against the full stored 20-byte secret (constant time); the
+		// store zero-pads both sides to the same length.
+		if !u.VerifyPassword(password) {
+			return nil, types.CodeSetUserPasswordDataMismatch, nil
+		}
+		return nil, types.CodeOK, nil
+
+	case passwordOpSetPassword:
+		// Only Set Password may create a slot, matching real BMCs. The password
+		// is stored with its wire-tagged length so the size class is retained.
+		err := store.Upsert(userID, func(u *bmc.User) error {
+			u.SetPassword(password)
+			return nil
+		})
+		if err != nil {
+			return nil, types.CodeUnspecifiedError, err
+		}
+		return nil, types.CodeOK, nil
+
+	default: // enable / disable: must not create a slot.
+		err := store.Update(userID, func(u *bmc.User) error {
+			u.Enabled = operation == passwordOpEnableUser
+			return nil
+		})
+		if errors.Is(err, bmc.ErrUserNotFound) {
+			return nil, types.CodeRequestDataFieldInvalid, nil //nolint:nilerr // reported as a completion code
+		}
+		if err != nil {
+			return nil, types.CodeUnspecifiedError, err
+		}
+		return nil, types.CodeOK, nil
+	}
+}
+
+// validUserID reports whether id is a usable slot (1..store max).
+func validUserID(store *bmc.UserStore, id uint8) bool {
+	return id >= 1 && id <= store.MaxUserCount()
+}
+
+// resolveUserChannel resolves the channel nibble of a Get/Set User Access
+// request. 0x0E ("this channel") resolves to the request's arrival channel when
+// known, else the LAN channel, matching how Get Channel Info resolves it.
+func resolveUserChannel(hctx *HandlerContext, nibble uint8) uint8 {
+	if nibble == types.ChannelNumberSelf {
+		if hctx != nil && hctx.Channel != nil {
+			return hctx.Channel.Number
+		}
+		return lanChannelNumber
+	}
+	return nibble
+}
+
+// clampCount saturates a user count to the 6-bit field of the Get User Access
+// response.
+func clampCount(n int) uint8 {
+	if n > 0x3f {
+		return 0x3f
+	}
+	return uint8(n)
+}

--- a/pkg/handlers/user_test.go
+++ b/pkg/handlers/user_test.go
@@ -1,0 +1,317 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// setUsernameReq builds a Set User Name request body (userID + 16-byte name).
+func setUsernameReq(userID uint8, name string) []byte {
+	req := make([]byte, 1+bmc.MaxUserNameLen)
+	req[0] = userID
+	copy(req[1:], name)
+	return req
+}
+
+// setPasswordReq builds a Set User Password request body.
+func setPasswordReq(userID, operation uint8, stored20 bool, password string) []byte {
+	b0 := userID & 0x3f
+	plen := 16
+	if stored20 {
+		b0 |= 1 << 7
+		plen = 20
+	}
+	req := []byte{b0, operation & 0x03}
+	if operation == passwordOpSetPassword || operation == passwordOpTestPassword {
+		pw := make([]byte, plen)
+		copy(pw, password)
+		req = append(req, pw...)
+	}
+	return req
+}
+
+func TestHandleGetUserAccess(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	// Populate slot 2 on channel 1 as an enabled operator with IPMI messaging.
+	if _, err := b.Users.Add(2, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Users.Update(2, func(u *bmc.User) error {
+		u.Enabled = true
+		u.ChannelAccess[1] = bmc.UserChannelAccess{
+			MaxPrivilege: bmc.PrivilegeLevelOperator,
+			Enabled:      true,
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, cc, err := handleGetUserAccess(ctx, hctx, []byte{0x01, 0x02})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc != types.CodeOK {
+		t.Fatalf("cc = 0x%02x, want OK", cc)
+	}
+	if len(resp) != 4 {
+		t.Fatalf("resp len = %d, want 4", len(resp))
+	}
+	if resp[0] != bmc.MaxUsers {
+		t.Errorf("max user count = %d, want %d", resp[0], bmc.MaxUsers)
+	}
+	if got := resp[1] >> 6; got != 0b01 {
+		t.Errorf("enable status = 0b%02b, want 0b01 (enabled)", got)
+	}
+	// Slot 1 (anonymous) is enabled by default, plus the operator we added.
+	if got := resp[1] & 0x3f; got != 2 {
+		t.Errorf("enabled user count = %d, want 2", got)
+	}
+	// bit4 IPMI messaging + operator privilege (0x03).
+	if resp[3]&(1<<4) == 0 {
+		t.Errorf("IPMI messaging bit not set: 0x%02x", resp[3])
+	}
+	if got := resp[3] & 0x0f; got != uint8(bmc.PrivilegeLevelOperator) {
+		t.Errorf("max priv = 0x%x, want 0x%x", got, uint8(bmc.PrivilegeLevelOperator))
+	}
+}
+
+// TestHandleGetUserAccessEnumerable proves every slot 1..max answers OK, the
+// property in-band enumerators depend on.
+func TestHandleGetUserAccessEnumerable(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	for id := uint8(1); id <= b.Users.MaxUserCount(); id++ {
+		_, cc, err := handleGetUserAccess(ctx, hctx, []byte{0x01, id})
+		if err != nil || cc != types.CodeOK {
+			t.Fatalf("slot %d: cc=0x%02x err=%v, want OK", id, cc, err)
+		}
+	}
+
+	// Out-of-range slot must be rejected. At the default maximum of 63 the
+	// user ID field's 6-bit mask makes a larger value unrepresentable, so the
+	// upper bound is only testable with a lowered store maximum.
+	b.Users = bmc.NewUserStore(bmc.WithMaxUsers(8))
+	_, cc, _ := handleGetUserAccess(ctx, hctx, []byte{0x01, 9})
+	if cc != types.CodeRequestDataFieldInvalid {
+		t.Errorf("out-of-range slot cc = 0x%02x, want 0xCC", cc)
+	}
+
+	// Truncated request.
+	_, cc, _ = handleGetUserAccess(ctx, hctx, []byte{0x01})
+	if cc != types.CodeRequestDataTruncated {
+		t.Errorf("truncated cc = 0x%02x, want 0xC6", cc)
+	}
+}
+
+func TestHandleGetUsernameEmptySlotReturnsCC(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	// Slot 5 is unset -> exactly 0xCC.
+	_, cc, _ := handleGetUsername(ctx, hctx, []byte{0x05})
+	if cc != types.CodeRequestDataFieldInvalid {
+		t.Fatalf("empty slot cc = 0x%02x, want 0xCC", cc)
+	}
+
+	// Set a name, then read it back null-padded.
+	if _, cc, err := handleSetUsername(ctx, hctx, setUsernameReq(5, "alice")); err != nil || cc != types.CodeOK {
+		t.Fatalf("set username: cc=0x%02x err=%v", cc, err)
+	}
+	resp, cc, err := handleGetUsername(ctx, hctx, []byte{0x05})
+	if err != nil || cc != types.CodeOK {
+		t.Fatalf("get username: cc=0x%02x err=%v", cc, err)
+	}
+	if len(resp) != bmc.MaxUserNameLen {
+		t.Fatalf("name len = %d, want %d", len(resp), bmc.MaxUserNameLen)
+	}
+	if got := string(bytes.TrimRight(resp, "\x00")); got != "alice" {
+		t.Errorf("name = %q, want %q", got, "alice")
+	}
+}
+
+func TestHandleSetUserPassword(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	const secret = "s3cr3t"
+
+	// Enable/disable/test on a missing slot must not create it and returns 0xCC.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpEnableUser, false, "")); cc != types.CodeRequestDataFieldInvalid {
+		t.Errorf("enable missing slot cc = 0x%02x, want 0xCC", cc)
+	}
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpTestPassword, false, secret)); cc != types.CodeRequestDataFieldInvalid {
+		t.Errorf("test missing slot cc = 0x%02x, want 0xCC", cc)
+	}
+	if _, err := b.Users.Get(7); err == nil {
+		t.Fatalf("slot 7 was created by a non-set operation")
+	}
+
+	// Set Password creates the slot (16-byte form).
+	if _, cc, err := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpSetPassword, false, secret)); err != nil || cc != types.CodeOK {
+		t.Fatalf("set password: cc=0x%02x err=%v", cc, err)
+	}
+
+	// Test Password matches with the size the password was stored with.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpTestPassword, false, secret)); cc != types.CodeOK {
+		t.Errorf("test 16-byte cc = 0x%02x, want OK", cc)
+	}
+	// The size tag is part of the credential (spec §22.30): testing the same
+	// secret with the other size fails with the dedicated wrong-size code.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpTestPassword, true, secret)); cc != types.CodeSetUserPasswordWrongSize {
+		t.Errorf("test 20-byte cc = 0x%02x, want 0x81 (wrong size)", cc)
+	}
+
+	// Wrong password fails with the command-specific 0x80.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpTestPassword, false, "wrong")); cc != types.CodeSetUserPasswordDataMismatch {
+		t.Errorf("test wrong cc = 0x%02x, want 0x80", cc)
+	}
+
+	// Enable then disable now works on the existing slot.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpEnableUser, false, "")); cc != types.CodeOK {
+		t.Errorf("enable cc = 0x%02x, want OK", cc)
+	}
+	if u, _ := b.Users.Get(7); !u.Enabled {
+		t.Errorf("user not enabled after enable op")
+	}
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(7, passwordOpDisableUser, false, "")); cc != types.CodeOK {
+		t.Errorf("disable cc = 0x%02x, want OK", cc)
+	}
+	if u, _ := b.Users.Get(7); u.Enabled {
+		t.Errorf("user still enabled after disable op")
+	}
+}
+
+func TestHandleSetUserAccess(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	// Change bit clear still applies the byte-3 privilege limit (spec §22.26 bit
+	// 7 gates only the byte-1 access flags), so it creates/updates the slot with
+	// the operator limit while leaving the access flags at their defaults.
+	if _, cc, _ := handleSetUserAccess(ctx, hctx, []byte{0x01, 0x03, uint8(bmc.PrivilegeLevelOperator)}); cc != types.CodeOK {
+		t.Errorf("change-bit-clear cc = 0x%02x, want OK", cc)
+	}
+	u, err := b.Users.Get(3)
+	if err != nil {
+		t.Fatalf("slot 3 not created by change-bit-clear privilege-limit set: %v", err)
+	}
+	if ca := u.ChannelAccess[1]; ca.MaxPrivilege != bmc.PrivilegeLevelOperator {
+		t.Errorf("priv limit = 0x%x, want operator", uint8(ca.MaxPrivilege))
+	} else if ca.CallbackOnly || ca.Enabled {
+		t.Errorf("change-bit-clear altered access flags: %+v", ca)
+	}
+
+	// Change bit set on channel 1: callback-only + IPMI messaging + admin priv.
+	flags := uint8(1<<7 | 1<<6 | 1<<4 | 0x01)
+	if _, cc, _ := handleSetUserAccess(ctx, hctx, []byte{flags, 0x03, uint8(bmc.PrivilegeLevelAdministrator)}); cc != types.CodeOK {
+		t.Fatalf("set access cc = 0x%02x, want OK", cc)
+	}
+	u, err = b.Users.Get(3)
+	if err != nil {
+		t.Fatalf("slot 3 not found: %v", err)
+	}
+	if ca := u.ChannelAccess[1]; !ca.CallbackOnly || !ca.Enabled || ca.MaxPrivilege != bmc.PrivilegeLevelAdministrator {
+		t.Errorf("channel access = %+v, want callback+enabled+admin", ca)
+	}
+
+	// A later change-bit-clear updates only the privilege limit (read-modify-
+	// write), preserving the byte-1 flags set above.
+	if _, cc, _ := handleSetUserAccess(ctx, hctx, []byte{0x01, 0x03, uint8(bmc.PrivilegeLevelUser)}); cc != types.CodeOK {
+		t.Fatalf("change-bit-clear update cc = 0x%02x, want OK", cc)
+	}
+	u, _ = b.Users.Get(3)
+	if ca := u.ChannelAccess[1]; !ca.CallbackOnly || !ca.Enabled {
+		t.Errorf("change-bit-clear cleared existing access flags: %+v", ca)
+	} else if ca.MaxPrivilege != bmc.PrivilegeLevelUser {
+		t.Errorf("priv limit = 0x%x, want user", uint8(ca.MaxPrivilege))
+	}
+}
+
+// TestHandleSetUserAccessResolvesCurrentChannel proves channel nibble 0x0E
+// ("this channel") resolves to the request's arrival channel for both Set and
+// Get User Access, rather than being used as literal pseudo-channel 14.
+func TestHandleSetUserAccessResolvesCurrentChannel(t *testing.T) {
+	b := newTestBMC()
+	ch, _ := b.Channels.Get(lanChannelNumber)
+	hctx := &HandlerContext{BMC: b, Channel: ch}
+	ctx := context.Background()
+
+	flags := uint8(1<<7 | 1<<4 | 0x0e) // change bit + IPMI messaging + channel 0x0E
+	if _, cc, _ := handleSetUserAccess(ctx, hctx, []byte{flags, 0x04, uint8(bmc.PrivilegeLevelOperator)}); cc != types.CodeOK {
+		t.Fatalf("set access cc = 0x%02x, want OK", cc)
+	}
+	u, _ := b.Users.Get(4)
+	if _, ok := u.ChannelAccess[0x0e]; ok {
+		t.Errorf("access wrongly stored under pseudo-channel 14")
+	}
+	if ca, ok := u.ChannelAccess[lanChannelNumber]; !ok || !ca.Enabled || ca.MaxPrivilege != bmc.PrivilegeLevelOperator {
+		t.Errorf("channel %d access = %+v ok=%v, want enabled operator", lanChannelNumber, ca, ok)
+	}
+
+	// Get User Access for 0x0E must read the same resolved channel back.
+	resp, cc, _ := handleGetUserAccess(ctx, hctx, []byte{0x0e, 0x04})
+	if cc != types.CodeOK {
+		t.Fatalf("get access cc = 0x%02x, want OK", cc)
+	}
+	if resp[3]&(1<<4) == 0 || resp[3]&0x0f != uint8(bmc.PrivilegeLevelOperator) {
+		t.Errorf("get access byte 3 = 0x%02x, want IPMI messaging + operator for resolved channel", resp[3])
+	}
+}
+
+// TestHandleSetUsernameRejectsDuplicate proves Set User Name refuses to give a
+// second slot a name already held by another, keeping name-based session lookup
+// deterministic.
+func TestHandleSetUsernameRejectsDuplicate(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	if _, cc, err := handleSetUsername(ctx, hctx, setUsernameReq(3, "alice")); err != nil || cc != types.CodeOK {
+		t.Fatalf("set name slot 3: cc=0x%02x err=%v", cc, err)
+	}
+	if _, cc, _ := handleSetUsername(ctx, hctx, setUsernameReq(4, "alice")); cc != types.CodeRequestDataFieldInvalid {
+		t.Errorf("duplicate name cc = 0x%02x, want 0xCC", cc)
+	}
+	if _, err := b.Users.Get(4); err == nil {
+		t.Errorf("slot 4 created despite duplicate-name rejection")
+	}
+	// Re-setting the same name on the same slot stays allowed (idempotent).
+	if _, cc, _ := handleSetUsername(ctx, hctx, setUsernameReq(3, "alice")); cc != types.CodeOK {
+		t.Errorf("idempotent rename cc = 0x%02x, want OK", cc)
+	}
+}
+
+// TestHandleSetUserPassword20ByteNoPrefixMatch proves a 16-byte Test cannot
+// match a genuine 20-byte password on its first 16 bytes.
+func TestHandleSetUserPassword20ByteNoPrefixMatch(t *testing.T) {
+	b := newTestBMC()
+	hctx := &HandlerContext{BMC: b}
+	ctx := context.Background()
+
+	const full20 = "abcdefghijklmnopqrst" // exactly 20 bytes
+	if _, cc, err := handleSetUserPassword(ctx, hctx, setPasswordReq(8, passwordOpSetPassword, true, full20)); err != nil || cc != types.CodeOK {
+		t.Fatalf("set 20-byte password: cc=0x%02x err=%v", cc, err)
+	}
+	// A 16-byte Test carrying only the first 16 bytes must fail: the size tag
+	// differs before any byte comparison happens.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(8, passwordOpTestPassword, false, full20[:16])); cc != types.CodeSetUserPasswordWrongSize {
+		t.Errorf("16-byte prefix test cc = 0x%02x, want 0x81 (wrong size)", cc)
+	}
+	// The genuine full 20-byte secret still matches.
+	if _, cc, _ := handleSetUserPassword(ctx, hctx, setPasswordReq(8, passwordOpTestPassword, true, full20)); cc != types.CodeOK {
+		t.Errorf("full 20-byte test cc = 0x%02x, want OK", cc)
+	}
+}

--- a/pkg/server/channel_info_test.go
+++ b/pkg/server/channel_info_test.go
@@ -1,0 +1,41 @@
+package server
+
+// End-to-end Get Channel Info test driven through the real pkg/client, proving a
+// remote console can read the LAN channel description from the reference server.
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGetChannelInfoLAN(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	admin := adminClient(t, ctx, port)
+	defer admin.Close(ctx) //nolint:errcheck
+
+	// 0x0E asks for "this channel", which the session arrived on: the LAN channel.
+	resp, err := admin.GetChannelInfo(ctx, types.ChannelNumberSelf)
+	if err != nil {
+		t.Fatalf("GetChannelInfo: %v", err)
+	}
+
+	if resp.ActualChannelNumber != 1 {
+		t.Errorf("channel number = %d, want 1", resp.ActualChannelNumber)
+	}
+	if resp.ChannelMedium != types.ChannelMediumLAN {
+		t.Errorf("medium = %s, want 802.3 LAN", resp.ChannelMedium)
+	}
+	if resp.ChannelProtocol != types.ChannelProtocolIPMB {
+		t.Errorf("protocol = %s, want IPMB", resp.ChannelProtocol)
+	}
+	if resp.SessionSupport != 0x02 {
+		t.Errorf("session support = %d, want 2 (multi-session)", resp.SessionSupport)
+	}
+	if resp.VendorID != 7154 {
+		t.Errorf("vendor IANA = %d, want 7154", resp.VendorID)
+	}
+}

--- a/pkg/server/server_v15.go
+++ b/pkg/server/server_v15.go
@@ -117,6 +117,22 @@ func (s *Server) dispatchIPMIv15Auth(addr net.Addr, pkt []byte, sess *types.Sess
 	v15Sess.ProcMu.Lock()
 	defer v15Sess.ProcMu.Unlock()
 
+	// A 20-byte-password account cannot authenticate over v1.5 (spec v2.0§22.30):
+	// v1.5 carries only 16 bytes. Reject before any path that emits an
+	// authenticated response, and respond UNauthenticated, so no v1.5 AuthCode
+	// is ever generated from a truncation of the 20-byte secret (straight
+	// password would send the truncated bytes outright; MD2/MD5 would hand out
+	// an offline verifier for them). This is the sole v1.5 activation
+	// chokepoint, so it covers named and null (User 1) accounts alike. The name
+	// itself is valid, so Get Session Challenge accepted it; the refusal
+	// surfaces here, at authentication.
+	if !handlers.V15Usable(v15Sess.User) {
+		if v15Sess.State == bmc.V15SessionStatePending && cmd == handlers.CmdActivateSession {
+			s.sendIPMIv15CommandCC(addr, pkt, v15Sess, netFn, cmd, seq, handlers.CCV15InvalidSessionID, false)
+		}
+		return
+	}
+
 	authType := bmc.V15AuthType(hdr.AuthType)
 	if authType != v15Sess.AuthType {
 		if v15Sess.State == bmc.V15SessionStatePending && cmd == handlers.CmdActivateSession {

--- a/pkg/server/server_v15_test.go
+++ b/pkg/server/server_v15_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+	"github.com/bougou/go-ipmi/pkg/protocol"
+	"github.com/bougou/go-ipmi/pkg/transport/udp"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestV15Reject20BytePasswordUnauthenticated is a raw-packet regression test
+// for the security-critical property of the 20-byte-password rejection: the
+// refusal response must NOT be authenticated, because an authenticated v1.5
+// response computes its AuthCode from the 16-byte truncation of the secret
+// (the straight-password AuthCode IS those bytes; MD2/MD5 make it an offline
+// verifier). It drives a real Activate Session for a 20-byte-password account
+// and asserts the reply is AuthType=None with no AuthCode and completion code
+// 0x85. Flipping the rejection back to an authenticated response would restore
+// the leak and fail here.
+func TestV15Reject20BytePasswordUnauthenticated(t *testing.T) {
+	b := bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, mock.New(), bmc.WithClock(clock.Real))
+	user, err := b.Users.Add(2, "op20")
+	if err != nil {
+		t.Fatal(err)
+	}
+	user.SetPassword([]byte("passwordlongerthan16")) // 20 bytes -> Password20
+	user.Enabled = true
+	user.ChannelAccess[1] = bmc.UserChannelAccess{MaxPrivilege: bmc.PrivilegeLevelAdministrator, Enabled: true}
+
+	// Pre-create the pending session directly, standing in for a completed Get
+	// Session Challenge (which now accepts the valid name). The gate fires
+	// before AuthCode verification, so the Activate packet needs no valid
+	// crypto.
+	var challenge [16]byte
+	sess, err := b.V15Sessions.CreatePending(bmc.V15AuthTypeMD5, user, challenge, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+	srv := NewServer(b, udp.Wrap(pc))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.Serve(ctx) }()
+
+	// Activate Session IPMI request (App 0x3A). IPMB request framing:
+	// rsAddr, netFn<<2, csum1, rqAddr, rqSeq<<2, cmd, data..., csum2.
+	req := []byte{0x20, handlers.NetFnAppRequest << 2, 0x00, 0x81, 0x00, handlers.CmdActivateSession}
+	activateData := make([]byte, 22)
+	activateData[0] = uint8(bmc.V15AuthTypeMD5)
+	activateData[1] = uint8(bmc.PrivilegeLevelAdministrator)
+	req = append(req, activateData...)
+	req = append(req, 0x00) // trailing checksum (server does not verify it)
+
+	hdr := types.SessionHeader15{
+		AuthType:      types.AuthTypeMD5,
+		Sequence:      0,
+		SessionID:     sess.TempSessionID,
+		AuthCode:      make([]byte, 16), // bogus: rejected before it is checked
+		PayloadLength: uint8(len(req)),
+	}
+	v15 := append(hdr.Pack(), req...)
+	pkt := append([]byte{0x06, 0x00, 0xff, 0x07}, v15...) // RMCP header + v1.5 session
+
+	client, err := net.DialUDP("udp", nil, pc.LocalAddr().(*net.UDPAddr)) //nolint:forcetypeassert
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if _, err := client.Write(pkt); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 512)
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("no rejection response (must reply, unauthenticated): %v", err)
+	}
+
+	var resp types.Session15
+	if err := resp.Unpack(buf[4:n]); err != nil { // strip RMCP header
+		t.Fatalf("unpack v1.5 response: %v", err)
+	}
+	if resp.SessionHeader15.AuthType != types.AuthTypeNone {
+		t.Errorf("response AuthType = 0x%02x, want None (0x00) — an authenticated reply leaks the truncated secret", uint8(resp.SessionHeader15.AuthType))
+	}
+	if len(resp.SessionHeader15.AuthCode) != 0 {
+		t.Errorf("response carries a %d-byte AuthCode, want none", len(resp.SessionHeader15.AuthCode))
+	}
+	if _, _, data, _, ok := protocol.ParseIPMIRequest(resp.Payload); !ok || len(data) < 0 {
+		t.Fatalf("unparseable response payload")
+	}
+	// Completion code is the byte after rsAddr/netfn/csum/rqAddr/rqSeq/cmd.
+	if len(resp.Payload) < 7 || resp.Payload[6] != uint8(handlers.CCV15InvalidSessionID) {
+		t.Errorf("completion code = 0x%02x, want 0x85", resp.Payload[6])
+	}
+}

--- a/pkg/server/session_info_test.go
+++ b/pkg/server/session_info_test.go
@@ -1,0 +1,50 @@
+package server
+
+// End-to-end Get Session Info test driven through the real pkg/client, proving
+// the RMCP+ keepalive (GetCurrentSessionInfo) the client fires periodically
+// succeeds against the reference server and reports the caller's own session.
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGetCurrentSessionInfoRMCP(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	admin := adminClient(t, ctx, port)
+	defer admin.Close(ctx) //nolint:errcheck
+
+	resp, err := admin.GetCurrentSessionInfo(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentSessionInfo: %v", err)
+	}
+
+	if resp.SessionHandle == 0 {
+		t.Errorf("session handle must be non-zero")
+	}
+	// raceNewBMC seeds the admin in slot 2, and it connects at administrator
+	// privilege over the LAN channel (1) as an RMCP+ (v2.0) session.
+	if resp.UserID != 2 {
+		t.Errorf("user id = %d, want 2", resp.UserID)
+	}
+	if resp.OperatingPrivilegeLevel != types.PrivilegeLevel(bmc.PrivilegeLevelAdministrator) {
+		t.Errorf("privilege level = %d, want administrator", resp.OperatingPrivilegeLevel)
+	}
+	if resp.AuxiliaryData != 1 {
+		t.Errorf("auxiliary data = %d, want 1 (IPMI v2.0/RMCP+)", resp.AuxiliaryData)
+	}
+	if resp.ChannelNumber != 1 {
+		t.Errorf("channel number = %d, want 1", resp.ChannelNumber)
+	}
+	if want := uint8(b.Sessions.Cap()); resp.PossibleActiveSessions != want {
+		t.Errorf("possible active sessions = %d, want %d", resp.PossibleActiveSessions, want)
+	}
+	if resp.CurrentActiveSessions < 1 {
+		t.Errorf("current active sessions = %d, want >= 1", resp.CurrentActiveSessions)
+	}
+}

--- a/pkg/server/transport_test.go
+++ b/pkg/server/transport_test.go
@@ -1,0 +1,52 @@
+package server
+
+// End-to-end Get LAN Configuration Parameters test driven through the real
+// pkg/client, proving a remote console (and the metal agent) can read the BMC's
+// own IPv4 address and RMCP port from the reference server.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/hal"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestGetLanConfigParamOverClient(t *testing.T) {
+	b := raceNewBMC(t)
+	if err := b.HAL().Network().SetConfig(context.Background(), &hal.IPConfig{
+		IP:      [4]byte{192, 168, 1, 50},
+		Mask:    [4]byte{255, 255, 255, 0},
+		Gateway: [4]byte{192, 168, 1, 1},
+		MAC:     [6]byte{0x52, 0x54, 0x00, 0x12, 0x34, 0x56},
+	}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	admin := adminClient(t, ctx, port)
+	defer admin.Close(ctx) //nolint:errcheck
+
+	// Channel 1 is the LAN channel the admin session arrived on.
+	const lanChannel = 1
+
+	// Param 3: the agent's hard requirement, the BMC's own IPv4 address.
+	ip := &types.LanConfigParam_IP{}
+	if err := admin.GetLanConfigParamFor(ctx, lanChannel, ip); err != nil {
+		t.Fatalf("GetLanConfigParamFor(IP): %v", err)
+	}
+	if got := ip.IP.String(); got != "192.168.1.50" {
+		t.Errorf("IP = %s, want 192.168.1.50", got)
+	}
+
+	// Param 8: the primary RMCP port, reported as the standard 623.
+	rmcp := &types.LanConfigParam_PrimaryRMCPPort{}
+	if err := admin.GetLanConfigParamFor(ctx, lanChannel, rmcp); err != nil {
+		t.Fatalf("GetLanConfigParamFor(PrimaryRMCPPort): %v", err)
+	}
+	if rmcp.Port != 623 {
+		t.Errorf("primary RMCP port = %d, want 623", rmcp.Port)
+	}
+}

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -1,0 +1,202 @@
+package server
+
+// End-to-end user-management tests driven through the real pkg/client, proving
+// the create-then-authenticate round trip the metal-agent relies on and that
+// the client's GetUsers enumerator walks every slot without error.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/client"
+	"github.com/bougou/go-ipmi/pkg/command/app"
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// adminClient returns a connected admin client against the server on port.
+func adminClient(t *testing.T, ctx context.Context, port int) *client.Client {
+	t.Helper()
+	cl, err := client.NewClient("127.0.0.1", port, raceUser, racePass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl = cl.WithTimeout(2 * time.Second).WithCipherSuiteID(types.CipherSuiteID3)
+	if err := cl.Connect(ctx); err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	return cl
+}
+
+// createUser provisions an enabled admin-level user on channel 1 via the client
+// command set (Set User Name, Set User Access, Set User Password, Enable User).
+func createUser(t *testing.T, ctx context.Context, cl *client.Client, id uint8, name, pass string, stored20 bool) {
+	t.Helper()
+	if _, err := cl.SetUsername(ctx, id, name); err != nil {
+		t.Fatalf("SetUsername: %v", err)
+	}
+	if _, err := cl.SetUserAccess(ctx, &app.SetUserAccessRequest{
+		EnableChanging:      true,
+		EnableIPMIMessaging: true,
+		ChannelNumber:       1,
+		UserID:              id,
+		MaxPrivLevel:        uint8(bmc.PrivilegeLevelAdministrator),
+	}); err != nil {
+		t.Fatalf("SetUserAccess: %v", err)
+	}
+	if _, err := cl.SetUserPassword(ctx, id, pass, stored20); err != nil {
+		t.Fatalf("SetUserPassword: %v", err)
+	}
+	if err := cl.EnableUser(ctx, id); err != nil {
+		t.Fatalf("EnableUser: %v", err)
+	}
+}
+
+// authAs opens a fresh RMCP+ (suite 3) session as the given user and returns any
+// connect error.
+func authAs(ctx context.Context, port int, name, pass string) error {
+	cl, err := client.NewClient("127.0.0.1", port, name, pass)
+	if err != nil {
+		return err
+	}
+	cl = cl.WithTimeout(2 * time.Second).WithCipherSuiteID(types.CipherSuiteID3)
+	if err := cl.Connect(ctx); err != nil {
+		return err
+	}
+	return cl.Close(ctx)
+}
+
+// TestUserCreateThenAuthenticate creates a user over the client command set and
+// then authenticates a brand-new RMCP+ session as that user. It runs the round
+// trip for both the 16-byte and 20-byte password-set forms of the same secret,
+// which must authenticate identically because RAKP derives keys from the
+// 20-byte padded password.
+func TestUserCreateThenAuthenticate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		stored20 bool
+	}{
+		{"password16", false},
+		{"password20", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := raceNewBMC(t)
+			port, ctx, stop := raceStartServer(t, b)
+			defer stop()
+
+			admin := adminClient(t, ctx, port)
+			defer admin.Close(ctx) //nolint:errcheck
+
+			const (
+				newUser = "operator"
+				newPass = "operatorpass"
+			)
+			createUser(t, ctx, admin, 3, newUser, newPass, tc.stored20)
+
+			if err := authAs(ctx, port, newUser, newPass); err != nil {
+				t.Fatalf("authenticate as new user: %v", err)
+			}
+
+			// A wrong password must still be rejected.
+			if err := authAs(ctx, port, newUser, "wrongpassword"); err == nil {
+				t.Fatalf("authentication succeeded with wrong password")
+			}
+		})
+	}
+}
+
+// TestUserSetCommandsRequireAdministrator is the privilege-escalation
+// regression: an Operator-privilege session must be rejected from all three Set
+// User* commands (security-restriction completion code), while Get User Access
+// and Get User Name stay reachable at Operator.
+func TestUserSetCommandsRequireAdministrator(t *testing.T) {
+	b := raceNewBMC(t)
+
+	// Seed an operator-limited user (construction-time seeding, before Serve).
+	op, err := b.Users.Add(3, "operator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	op.SetPassword([]byte("operatorpass1234"))
+	op.Enabled = true
+	op.ChannelAccess[1] = bmc.UserChannelAccess{MaxPrivilege: bmc.PrivilegeLevelOperator, Enabled: true}
+
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	cl, err := client.NewClient("127.0.0.1", port, "operator", "operatorpass1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl = cl.WithTimeout(2 * time.Second).WithCipherSuiteID(types.CipherSuiteID3).
+		WithMaxPrivilegeLevel(types.PrivilegeLevelOperator)
+	if err := cl.Connect(ctx); err != nil {
+		t.Fatalf("operator connect: %v", err)
+	}
+	defer cl.Close(ctx) //nolint:errcheck
+
+	wantRestricted := func(name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: succeeded at operator privilege, want security restriction", name)
+		}
+		respErr, ok := types.IsResponseError(err)
+		if !ok {
+			t.Fatalf("%s: err = %v, want IPMI response error", name, err)
+		}
+		if respErr.CompletionCode() != types.CodeInsufficientPrivilege {
+			t.Fatalf("%s: cc = 0x%02x, want 0xD4 (security restriction)", name, uint8(respErr.CompletionCode()))
+		}
+	}
+
+	_, err = cl.SetUserPassword(ctx, 4, "irrelevant", false)
+	wantRestricted("Set User Password", err)
+
+	_, err = cl.SetUsername(ctx, 4, "evil")
+	wantRestricted("Set User Name", err)
+
+	_, err = cl.SetUserAccess(ctx, &app.SetUserAccessRequest{
+		EnableChanging:      true,
+		EnableIPMIMessaging: true,
+		ChannelNumber:       1,
+		UserID:              4,
+		MaxPrivLevel:        uint8(bmc.PrivilegeLevelAdministrator),
+	})
+	wantRestricted("Set User Access", err)
+
+	// Get User Access / Get User Name require only Operator, so they succeed.
+	if _, err := cl.GetUserAccess(ctx, 1, 3); err != nil {
+		t.Errorf("Get User Access at operator privilege: %v", err)
+	}
+	if _, err := cl.GetUsername(ctx, 3); err != nil {
+		t.Errorf("Get User Name at operator privilege: %v", err)
+	}
+}
+
+// TestGetUsersEnumerates proves the bougou client's own GetUsers walks every
+// slot from 1 to the reported maximum without error, returning empty names for
+// unpopulated slots (Get User Name answers 0xCC there).
+func TestGetUsersEnumerates(t *testing.T) {
+	b := raceNewBMC(t)
+	port, ctx, stop := raceStartServer(t, b)
+	defer stop()
+
+	admin := adminClient(t, ctx, port)
+	defer admin.Close(ctx) //nolint:errcheck
+
+	users, err := admin.GetUsers(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetUsers: %v", err)
+	}
+	if got := len(users); got != int(bmc.MaxUsers) {
+		t.Fatalf("enumerated %d users, want %d", got, bmc.MaxUsers)
+	}
+	// Slot 2 is the seeded admin; an unpopulated slot reports an empty name.
+	if users[1].Name != raceUser {
+		t.Errorf("slot 2 name = %q, want %q", users[1].Name, raceUser)
+	}
+	if users[9].Name != "" {
+		t.Errorf("empty slot name = %q, want empty", users[9].Name)
+	}
+}


### PR DESCRIPTION
Disclaimer: this was authored mainly by Claude Fable 5, and reviewed by myself and other models.

Builds on top of #87, so its commit shows in the diff until that one merges.

Software running inside a managed machine provisions its BMC out-of-band access in band: it enumerates the user table, creates a user with a password and per-channel access, and reads the BMC's LAN configuration to discover the management address. Remote consoles additionally keep long-lived sessions alive by periodically querying information about the current session. The server answered none of these commands.

This adds the missing handlers:

- The standard user management commands, backed by the existing user store: read and set a user's name, set or test a user's password, enable or disable a user, and read and set a user's per-channel access and privilege. Reading succeeds for every slot up to the reported maximum, and reading the name of an empty slot returns the dedicated "no such user" completion code, so a client can enumerate the user table without aborting. Enabling, disabling, or testing a password on an absent slot is rejected, while setting a name or password creates the slot, as real BMCs do. The password size is part of the credential: testing a password with the other size fails with the dedicated wrong-size code, and a password stored as twenty bytes exists only in IPMI 2.0, so it does not authenticate a v1.5 session. User 1 is the fixed null user, so reading its name succeeds with the all-zeros name and renaming it is rejected. The user store also carries a configurable maximum user count, defaulting to the spec maximum, and every lookup, creation, and authentication scan respects it, so no slot can exist that enumerators cannot see.
- Get LAN Configuration Parameters, sourcing the address, source, MAC, subnet, and gateway from the network hardware abstraction, reporting whether the address is static or from DHCP, and advertising the supported authentication types. The advertised primary RMCP port is configurable, so a BMC listening on a non-standard port can be discovered in band, falling back to the standard port when unset. Address parameters are reported as unsupported when the BMC has no network interface configured. Only reading is supported, changing the LAN configuration is out of scope.
- Get Session Info for the current-session form, for both IPMI 2.0 and 1.5 sessions, reporting a real one-byte session handle assigned at session creation, the possible and active session counts of the caller's own session pool, the requesting session's user, privilege level, and channel, and, for IPMI 2.0 LAN sessions, the remote console's address and port. This is the query the client in this repository sends periodically to keep a LAN session alive, so a long-lived session against this server looked unanswered before.
- Get Channel Info, built from the configured channel table rather than hardcoded values, so it reflects whatever channels the BMC actually has, including the channel's live session count.

Runtime user changes made over the wire go through the store's guarded update path introduced with the concurrency fixes, so they are safe against concurrent session authentication.
