### PR TITLE
feat(server): add OpenIPMI VM protocol frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,12 +42,17 @@ _output
 # e2e binaries produced by `make build` (see test/e2e/common.sh)
 /_output/goipmi
 /_output/goipmi-server
+/_output/goipmi-vmprobe
 
 # local build artifacts under cmd/ (do not prefix with ./ — gitignore treats
 # the leading dot as a literal directory name and the pattern won't match)
 cmd/goipmi/goipmi
 cmd/goipmi/goipmi.exe
 cmd/testtools/
+# stray binaries from `go build ./cmd/<x>` without -o (land in repo root)
+/goipmi
+/goipmi-server
+/goipmi-vmprobe
 
 # local dist/ output of cross-built binaries
 /dist/

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,11 @@ test: fmt vet
 test-race:
 	go test -race -timeout 120s ./pkg/... ./cmd/...
 
-# Build goipmi and goipmi-server binaries
+# Build goipmi, goipmi-server, and goipmi-vmprobe binaries
 build: fmt vet
 	go build -ldflags "$(LDFLAGS)" -o $(OUTPUT_DIR)/goipmi ./cmd/goipmi
 	go build -o $(OUTPUT_DIR)/goipmi-server ./cmd/goipmi-server
+	go build -o $(OUTPUT_DIR)/goipmi-vmprobe ./cmd/goipmi-vmprobe
 
 # Cross compiler
 build-all: fmt vet
@@ -68,6 +69,7 @@ dependencies:
 #   make test-e2e-chassis-codec  — typed chassis codec / boot options
 #   make test-e2e-cipher         — RMCP+ cipher suite coverage
 #   make test-e2e-sol            — ipmitool sol activate → PTY console
+#   make test-e2e-vmproto        — goipmi-vmprobe → goipmi-server VM socket
 #   make test-e2e                — run all suites (CI uses this)
 
 test-e2e-client: build
@@ -88,4 +90,7 @@ test-e2e-cipher: build
 test-e2e-sol: build
 	./test/e2e/sol_test.sh
 
-test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec test-e2e-cipher test-e2e-sol
+test-e2e-vmproto: build
+	./test/e2e/vmproto_test.sh
+
+test-e2e: test-e2e-client test-e2e-server test-e2e-self test-e2e-chassis-codec test-e2e-cipher test-e2e-sol test-e2e-vmproto

--- a/cmd/goipmi-server/config.go
+++ b/cmd/goipmi-server/config.go
@@ -21,6 +21,11 @@ type runtimeConfig struct {
 	V15Disabled  bool
 	Trace        bool
 
+	// VMSocket is a unix socket path on which to also serve the OpenIPMI VM
+	// protocol (QEMU's ipmi-bmc-extern), sharing one BMC with the network
+	// server. Empty = VM protocol not served.
+	VMSocket string
+
 	// Console selects the SOL console backend: ""/none = no console (SOL
 	// unadvertised), "pty" = allocate a PTY pair, otherwise a device path.
 	Console string
@@ -35,6 +40,7 @@ func loadRuntimeConfig() (runtimeConfig, error) {
 		Port:     envOr("GOIPMI_SERVER_PORT", "623"),
 		User:     envOr("GOIPMI_SERVER_USER", "ADMIN"),
 		Password: envOr("GOIPMI_SERVER_PASS", "ADMIN"),
+		VMSocket: envOr("GOIPMI_SERVER_VM_SOCKET", ""),
 		Console:  envOr("GOIPMI_SERVER_CONSOLE", ""),
 	}
 	// "none" is the documented spelling of "no console" (see Console); the
@@ -109,6 +115,9 @@ func printRuntimeBanner(cfg runtimeConfig, b *bmc.BMC, consoleDesc string) {
 		fmt.Printf("goipmi-server: IPMI v1.5 (lan) auth types: %s\n", bmc.FormatV15AuthTypes(b.ResolvedV15AuthTypes()))
 	} else {
 		fmt.Println("goipmi-server: IPMI v1.5 (lan) disabled")
+	}
+	if cfg.VMSocket != "" {
+		fmt.Printf("goipmi-server: OpenIPMI VM protocol on unix socket %s\n", cfg.VMSocket)
 	}
 	if consoleDesc != "" {
 		fmt.Printf("goipmi-server: console %s\n", consoleDesc)

--- a/cmd/goipmi-server/main.go
+++ b/cmd/goipmi-server/main.go
@@ -12,6 +12,8 @@
 //	GOIPMI_SERVER_CIPHER_SUITES   – RMCP+ cipher suite IDs, comma-separated (default: 3,17)
 //	GOIPMI_SERVER_V15_AUTH_TYPES  – v1.5 auth types: none,md2,md5,password,oem (default: md5)
 //	GOIPMI_SERVER_V15             – set to 0/false to disable v1.5 while keeping lanplus (default: 1)
+//	GOIPMI_SERVER_VM_SOCKET       – unix socket to also serve the OpenIPMI VM protocol
+//	                                (QEMU ipmi-bmc-extern), sharing one BMC; unset = off
 //	GOIPMI_SERVER_TRACE           – set to 1/true to log every dispatched command to stderr (default: 0)
 //	GOIPMI_SERVER_CONSOLE         – SOL console backend: "pty" allocates a PTY pair (linux),
 //	                                a path opens that device (e.g. /dev/ttyS0); unset = no SOL
@@ -24,17 +26,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/bougou/go-ipmi/pkg/bmc"
 	"github.com/bougou/go-ipmi/pkg/clock"
 	"github.com/bougou/go-ipmi/pkg/hal"
 	"github.com/bougou/go-ipmi/pkg/hal/mock"
+	"github.com/bougou/go-ipmi/pkg/handlers"
 	"github.com/bougou/go-ipmi/pkg/server"
 	"github.com/bougou/go-ipmi/pkg/transport/udp"
 	"github.com/bougou/go-ipmi/pkg/types"
+	"github.com/bougou/go-ipmi/pkg/vmproto"
 )
 
 func main() {
@@ -102,9 +108,14 @@ func run() error {
 	}
 	defer conn.Close()
 
+	// One registry shared by both frontends when tracing, so VM-protocol
+	// commands are traced too (the trace contract is "every dispatched
+	// command"). It is read-only during dispatch, so sharing it is safe.
+	var traceReg *handlers.Registry
 	var opts []server.ServerOption
 	if cfg.Trace {
-		opts = append(opts, server.WithHandlerRegistry(tracingRegistry()), server.WithSOLDebug())
+		traceReg = tracingRegistry()
+		opts = append(opts, server.WithHandlerRegistry(traceReg), server.WithSOLDebug())
 	}
 	srv := server.NewServer(b, conn, opts...)
 
@@ -116,12 +127,63 @@ func run() error {
 		srv.Close()
 	}()
 
+	// Optionally serve the OpenIPMI VM protocol on a unix socket alongside the
+	// network server, sharing one BMC so an in-band (QEMU) client and an
+	// out-of-band (LAN) client observe the same state.
+	if cfg.VMSocket != "" {
+		if err := prepareVMSocket(cfg.VMSocket); err != nil {
+			return err
+		}
+		ln, err := net.Listen("unix", cfg.VMSocket)
+		if err != nil {
+			return fmt.Errorf("listen vm socket %s: %w", cfg.VMSocket, err)
+		}
+		defer ln.Close()
+		defer os.Remove(cfg.VMSocket) //nolint:errcheck
+
+		var vmOpts []vmproto.VMServerOption
+		if traceReg != nil {
+			vmOpts = append(vmOpts, vmproto.WithVMHandlerRegistry(traceReg))
+		}
+		vmSrv := vmproto.NewVMServer(b, vmOpts...)
+		go func() {
+			if err := vmSrv.Serve(ctx, ln); err != nil && !errors.Is(err, context.Canceled) {
+				fmt.Fprintf(os.Stderr, "goipmi-server: vm protocol serve: %v\n", err)
+			}
+		}()
+	}
+
 	printRuntimeBanner(cfg, b, consoleDesc)
 
 	if err := srv.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("serve: %w", err)
 	}
 	fmt.Println("goipmi-server: stopped")
+	return nil
+}
+
+// prepareVMSocket clears a stale unix socket at path so the server can bind it,
+// but refuses to touch anything else: a typo must not delete a regular file,
+// and a second server must not unlink a live socket and hijack its pathname.
+func prepareVMSocket(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil // nothing in the way
+	}
+	if err != nil {
+		return fmt.Errorf("stat vm socket %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("vm socket path %s exists and is not a socket, refusing to overwrite", path)
+	}
+	// It is a socket: if a server is listening, refuse; otherwise it is stale.
+	if conn, derr := net.DialTimeout("unix", path, 200*time.Millisecond); derr == nil {
+		conn.Close() //nolint:errcheck
+		return fmt.Errorf("vm socket %s is already in use", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove stale vm socket %s: %w", path, err)
+	}
 	return nil
 }
 

--- a/cmd/goipmi-vmprobe/main.go
+++ b/cmd/goipmi-vmprobe/main.go
@@ -1,0 +1,94 @@
+// goipmi-vmprobe is a minimal OpenIPMI VM protocol client for development and
+// E2E testing: it connects to a stream socket served by goipmi-server's VM
+// protocol mode (GOIPMI_SERVER_VM_SOCKET), sends one IPMI command, and reports
+// the completion code and response. It stands in for QEMU's ipmi-bmc-extern or
+// the in-guest OpenIPMI driver, which are the real consumers of that socket.
+//
+// Usage:
+//
+//	goipmi-vmprobe -socket /tmp/vm.sock                      # Get Device ID (default)
+//	goipmi-vmprobe -socket /tmp/vm.sock -netfn 6 -cmd 1
+//	goipmi-vmprobe -socket /tmp/vm.sock -netfn 0 -cmd 2 -data 1  # Chassis Control power up
+//
+// Exit status is 0 only when a response arrives with completion code 0x00.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/vmproto"
+)
+
+// parseDataBytes parses a comma-separated list of request data bytes, each in
+// decimal or 0x-hex, rejecting anything that is not a byte in 0..255. An empty
+// string is no data.
+func parseDataBytes(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]byte, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		// Exactly "decimal or 0x-hex": base 16 only for a 0x/0X prefix, base 10
+		// otherwise. Not base 0, which would read a leading zero as octal
+		// (010 -> 8) and accept 0b/0o/underscores, none of which are meant here.
+		base, num := 10, p
+		if len(p) > 2 && (p[0:2] == "0x" || p[0:2] == "0X") {
+			base, num = 16, p[2:]
+		}
+		v, err := strconv.ParseUint(num, base, 8) // 8 bits bounds 0..255
+		if err != nil {
+			return nil, fmt.Errorf("invalid byte %q: want a value 0..255 (decimal or 0x-hex)", p)
+		}
+		out = append(out, byte(v))
+	}
+	return out, nil
+}
+
+func main() {
+	socket := flag.String("socket", "", "unix socket path served by goipmi-server VM protocol mode")
+	netFn := flag.Uint("netfn", 0x06, "request NetFn (default App)")
+	cmd := flag.Uint("cmd", 0x01, "command byte (default Get Device ID)")
+	dataStr := flag.String("data", "", "comma-separated request data bytes, decimal or 0x-hex (e.g. 1 or 0x01,0xff)")
+	network := flag.String("net", "unix", "socket network: unix or tcp")
+	timeout := flag.Duration("timeout", 5*time.Second, "response timeout")
+	flag.Parse()
+
+	if *socket == "" {
+		fmt.Fprintln(os.Stderr, "goipmi-vmprobe: -socket is required")
+		os.Exit(2)
+	}
+
+	data, err := parseDataBytes(*dataStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "goipmi-vmprobe: -data: %v\n", err)
+		os.Exit(2)
+	}
+
+	conn, err := net.DialTimeout(*network, *socket, *timeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "goipmi-vmprobe: dial %s %s: %v\n", *network, *socket, err)
+		os.Exit(1)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	cc, resp, err := vmproto.NewClient(conn, *timeout).Command(byte(*netFn), byte(*cmd), data...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "goipmi-vmprobe: command: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("completion code: 0x%02x\n", cc)
+	fmt.Printf("response (%d bytes): % x\n", len(resp), resp)
+	if cc != 0x00 {
+		os.Exit(1)
+	}
+}

--- a/pkg/bmc/channel.go
+++ b/pkg/bmc/channel.go
@@ -36,7 +36,13 @@ const (
 
 // Channel holds the configuration for a single IPMI channel.
 type Channel struct {
-	Number     uint8
+	Number uint8
+	// Medium is the channel's physical medium. It is security-relevant: the
+	// handler privilege check treats a session-less request on a
+	// [ChannelMediumSystemIF] channel as locally authorized (the system
+	// interface is inherently local), so labeling a network-reachable channel
+	// as the system interface, or attaching a session to the system-interface
+	// channel, would grant unauthenticated callers full privilege.
 	Medium     ChannelMedium
 	AccessMode ChannelAccessMode
 	// MaxPrivilege is the maximum privilege level allowed on this channel.

--- a/pkg/bmc/session_v15.go
+++ b/pkg/bmc/session_v15.go
@@ -220,6 +220,14 @@ func (s *V15SessionStore) Cap() int {
 	return s.max
 }
 
+// Count returns the number of sessions currently in the store, pending or
+// active, mirroring [SessionStore.Count].
+func (s *V15SessionStore) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sessions)
+}
+
 // CountActiveSessions returns the number of active v1.5 sessions.
 func (s *V15SessionStore) CountActiveSessions() int {
 	s.mu.Lock()

--- a/pkg/handlers/privilege.go
+++ b/pkg/handlers/privilege.go
@@ -39,11 +39,17 @@ func checkCommandPrivilege(hctx *HandlerContext, netFn, cmd uint8) types.Complet
 	}
 	priv, ok := sessionPrivilege(hctx)
 	if !ok {
-		// No active session. Only the pre-session exempt commands above
-		// (channel-auth discovery and session setup) may run without one; every
-		// other command requires an authenticated session. This is what stops an
-		// unauthenticated LAN caller from invoking account management, chassis
-		// power, and the like by sending a session-less packet.
+		// No active session. The system interface is inherently local (physical
+		// access is the authorization) and carries no session, so an in-band
+		// request runs at full privilege the way real hardware treats its KCS/BT
+		// interface. Every other session-less request is a pre-session LAN
+		// packet: only the exempt commands above (channel-auth discovery and
+		// session setup) may run there, so account management, chassis power,
+		// and the like are rejected rather than executed for an unauthenticated
+		// remote caller.
+		if hctx != nil && hctx.Channel != nil && hctx.Channel.Medium == bmc.ChannelMediumSystemIF {
+			return types.CodeOK
+		}
 		return types.CodeInsufficientPrivilege
 	}
 	if priv < MinimumPrivilege(netFn, cmd) {

--- a/pkg/handlers/privilege_test.go
+++ b/pkg/handlers/privilege_test.go
@@ -103,3 +103,37 @@ func TestPreSessionRejectsPrivilegedCommands(t *testing.T) {
 		t.Errorf("admin-session Set User Password did not create the slot: %v", err)
 	}
 }
+
+// TestCheckCommandPrivilegeSessionless pins the session-less authorization
+// boundary directly, since the sibling PR's tightening and the VM frontend's
+// carve-out both depend on it. A session-less request is authorized only on the
+// inherently-local system interface; on a LAN or unspecified channel a
+// non-exempt command is rejected, which is what stops an unauthenticated remote
+// caller from reaching account management or chassis power. An exempt
+// pre-session command runs regardless.
+func TestCheckCommandPrivilegeSessionless(t *testing.T) {
+	sysIF := &bmc.Channel{Number: 0x0F, Medium: bmc.ChannelMediumSystemIF}
+	lan := &bmc.Channel{Number: lanChannelNumber, Medium: bmc.ChannelMediumLAN}
+
+	tests := []struct {
+		name  string
+		hctx  *HandlerContext
+		netFn uint8
+		cmd   uint8
+		want  types.CompletionCode
+	}{
+		{"in-band non-exempt allowed", &HandlerContext{Channel: sysIF}, NetFnAppRequest, CmdSetUserPassword, types.CodeOK},
+		{"lan non-exempt rejected", &HandlerContext{Channel: lan}, NetFnAppRequest, CmdSetUserPassword, types.CodeInsufficientPrivilege},
+		{"no-channel non-exempt rejected", &HandlerContext{}, NetFnAppRequest, CmdSetUserPassword, types.CodeInsufficientPrivilege},
+		{"lan chassis control rejected", &HandlerContext{Channel: lan}, NetFnChassisRequest, CmdChassisControl, types.CodeInsufficientPrivilege},
+		{"exempt command allowed pre-session", &HandlerContext{Channel: lan}, NetFnAppRequest, CmdGetChannelAuthCapabilities, types.CodeOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if cc := checkCommandPrivilege(tc.hctx, tc.netFn, tc.cmd); cc != tc.want {
+				t.Errorf("cc = 0x%02x, want 0x%02x", uint8(cc), uint8(tc.want))
+			}
+		})
+	}
+}

--- a/pkg/handlers/session_v15.go
+++ b/pkg/handlers/session_v15.go
@@ -33,6 +33,17 @@ func handleGetSessionChallenge(_ context.Context, hctx *HandlerContext, req []by
 		return nil, types.CodeUnspecifiedError, nil
 	}
 
+	// Session establishment is a LAN-channel command. A request arriving on any
+	// other channel (the context channel is nil for genuine pre-session LAN
+	// packets and set only by session-less frontends such as the system
+	// interface) must not allocate LAN session slots: the pending-session table
+	// evicts its oldest entry under pressure, so in-band software could
+	// otherwise evict a remote console's in-flight handshake at will. Real BMCs
+	// do not serve session-establishment commands on the system interface.
+	if hctx.Channel != nil && hctx.Channel.Medium != bmc.ChannelMediumLAN {
+		return nil, types.CodeRequestDataFieldInvalid, nil
+	}
+
 	authType := bmc.V15AuthType(req[0] & 0x0F)
 	if !hctx.BMC.V15AuthTypeEnabled(authType) {
 		return nil, types.CodeParameterOutOfRange, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -154,13 +154,10 @@ func WithV15Disabled() ServerOption {
 // A default [handlers.Registry] populated with all standard commands is used
 // unless overridden via [WithHandlerRegistry].
 func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Server {
-	reg := handlers.NewRegistry()
-	handlers.RegisterAllHandlers(reg)
-
 	s := &Server{
 		bmc:       b,
 		conn:      conn,
-		reg:       reg,
+		reg:       newDefaultRegistry(),
 		clk:       b.Clock(),
 		bufSize:   defaultBufferSize,
 		solQueues: make(map[uint32]chan solJob),
@@ -200,6 +197,16 @@ func NewServer(b *bmc.BMC, conn transport.PacketConn, opts ...ServerOption) *Ser
 		}
 	})
 	return s
+}
+
+// newDefaultRegistry builds a [handlers.Registry] populated with every standard
+// command handler. It is the registry each server frontend uses unless the
+// caller overrides it, so the RMCP+ and VM protocol frontends dispatch through
+// an identical command set.
+func newDefaultRegistry() *handlers.Registry {
+	reg := handlers.NewRegistry()
+	handlers.RegisterAllHandlers(reg)
+	return reg
 }
 
 // Serve reads packets from the transport and dispatches them until ctx is

--- a/pkg/vmproto/client.go
+++ b/pkg/vmproto/client.go
@@ -1,0 +1,95 @@
+package vmproto
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// Client speaks the console side of the OpenIPMI VM protocol (QEMU's
+// ipmi-bmc-extern wire format) over a byte stream, the counterpart to
+// [VMServer]. QEMU and the in-guest OpenIPMI driver are the real consumers of
+// the server; this client stands in for them in simulation and end-to-end
+// testing.
+type Client struct {
+	conn    net.Conn
+	timeout time.Duration
+	msgID   byte
+}
+
+// NewClient wraps conn, a stream connection to a [VMServer] listener, as a
+// VM-protocol client. timeout bounds each response read; pass 0 for no
+// deadline.
+func NewClient(conn net.Conn, timeout time.Duration) *Client {
+	return &Client{conn: conn, timeout: timeout}
+}
+
+// Command sends one IPMI request over the VM protocol and returns the response
+// completion code and data. The system interface carries one transaction at a
+// time, so it writes the request and reads the matching response.
+func (c *Client) Command(netFn, cmd byte, data ...byte) (cc byte, resp []byte, err error) {
+	c.msgID++
+
+	msg := append([]byte{c.msgID, netFn << 2, cmd}, data...)
+	msg = append(msg, -vmChecksum(msg))
+	if _, err := c.conn.Write(vmEncode(msg)); err != nil {
+		return 0, nil, fmt.Errorf("write request: %w", err)
+	}
+
+	reply, err := c.readMessage()
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(reply) < 5 {
+		return 0, nil, fmt.Errorf("short response: % x", reply)
+	}
+	if reply[0] != c.msgID {
+		return 0, nil, fmt.Errorf("response message ID %d, want %d", reply[0], c.msgID)
+	}
+	// The response NetFn is the request NetFn with the low bit set (§5.1).
+	if got := reply[1] >> 2; got != netFn|1 {
+		return 0, nil, fmt.Errorf("response NetFn %#x, want %#x", got, netFn|1)
+	}
+	if reply[2] != cmd {
+		return 0, nil, fmt.Errorf("response command %#x, want %#x", reply[2], cmd)
+	}
+	return reply[3], reply[4 : len(reply)-1], nil
+}
+
+// readMessage reads one unescaped, checksum-verified message from the stream.
+func (c *Client) readMessage() ([]byte, error) {
+	if c.timeout > 0 {
+		if err := c.conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+			return nil, err
+		}
+	}
+
+	var (
+		acc      []byte
+		inEscape bool
+		buf      = make([]byte, 1)
+	)
+	for {
+		if _, err := c.conn.Read(buf); err != nil {
+			return nil, fmt.Errorf("read response: %w", err)
+		}
+		switch b := buf[0]; b {
+		case vmMsgChar:
+			if len(acc) < 4 {
+				return nil, fmt.Errorf("response too short: % x", acc)
+			}
+			if vmChecksum(acc) != 0 {
+				return nil, fmt.Errorf("response checksum mismatch: % x", acc)
+			}
+			return acc, nil
+		case vmEscapeChar:
+			inEscape = true
+		default:
+			if inEscape {
+				b &^= 0x10
+				inEscape = false
+			}
+			acc = append(acc, b)
+		}
+	}
+}

--- a/pkg/vmproto/vmproto.go
+++ b/pkg/vmproto/vmproto.go
@@ -1,0 +1,250 @@
+// Package vmproto implements a BMC server frontend that speaks QEMU's OpenIPMI
+// VM protocol (the ipmi-bmc-extern wire format), a sibling to the RMCP+ UDP
+// server in pkg/server. It exists so an emulated machine's in-band system
+// interface and an out-of-band LAN client can drive one shared [bmc.BMC], which
+// is what the library's simulation / end-to-end use targets: a guest kernel and
+// a userland agent talk to the BMC over the VM protocol while tooling talks to
+// the same BMC over LAN, and both observe the same state.
+//
+// Unlike the RMCP+ frontend, the VM protocol is a byte stream, not datagrams,
+// so it is built on a [net.Listener] rather than a transport.PacketConn. The
+// system interface is unauthenticated by design (there is no session), so
+// messages dispatch with a session-less [handlers.HandlerContext] whose channel
+// is the system interface, which the handler privilege check treats as locally
+// authorized.
+//
+// [Client] is the console side of the same protocol, standing in for QEMU or
+// the in-guest OpenIPMI driver in simulation and end-to-end testing.
+package vmproto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/handlers"
+)
+
+// systemInterfaceChannel is the channel number of the in-band system interface
+// (spec §6.13.1). The VM protocol is that interface, so requests dispatched
+// through it are attributed to this channel.
+const systemInterfaceChannel uint8 = 0x0F
+
+// OpenIPMI VM protocol framing (QEMU ipmi-bmc-extern wire format).
+const (
+	vmMsgChar    = 0xA0 // ends an IPMI message
+	vmCmdChar    = 0xA1 // ends a control command
+	vmEscapeChar = 0xAA // escape: the next byte has bit 4 set and must be cleared
+
+	// vmMaxMsgSize caps an accumulated message so a peer cannot grow the buffer
+	// without bound; an over-long frame is dropped rather than truncated.
+	vmMaxMsgSize = 4096
+
+	vmReadBufferSize = 4096
+)
+
+// VMServer serves QEMU's OpenIPMI VM protocol on a stream listener, dispatching
+// each in-band IPMI message through the same handler registry as the RMCP+
+// [Server] against the same [bmc.BMC].
+//
+// Construct one with [NewVMServer] sharing the [bmc.BMC] you gave [NewServer],
+// then call [VMServer.Serve]. It is a distinct frontend from [Server]: the VM
+// protocol is a byte stream, so it takes a [net.Listener], and the system
+// interface is unauthenticated, so messages carry no session.
+type VMServer struct {
+	bmc *bmc.BMC
+	reg *handlers.Registry
+}
+
+// VMServerOption configures a [VMServer].
+type VMServerOption func(*VMServer)
+
+// WithVMHandlerRegistry replaces the default handler registry. Pass the same
+// registry the RMCP+ [Server] uses to guarantee the two frontends dispatch an
+// identical command set. All registration must be complete before
+// [VMServer.Serve] is called; the registry is read-only during dispatch.
+func WithVMHandlerRegistry(r *handlers.Registry) VMServerOption {
+	return func(s *VMServer) { s.reg = r }
+}
+
+// NewVMServer creates a VM protocol frontend over the BMC state b.
+//
+// Share b with the [Server] created by [NewServer] so in-band (VM protocol) and
+// out-of-band (LAN) requests operate on the same BMC. By default it builds its
+// own copy of the standard registry, identical to the RMCP+ server's; override
+// it with [WithVMHandlerRegistry], for example to share a single registry
+// instance or to add OEM commands.
+func NewVMServer(b *bmc.BMC, opts ...VMServerOption) *VMServer {
+	reg := handlers.NewRegistry()
+	handlers.RegisterAllHandlers(reg)
+	s := &VMServer{
+		bmc: b,
+		reg: reg,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Serve accepts connections on ln and serves each until ctx is canceled or ln
+// is closed. Each accepted connection is one QEMU process; every guest power
+// cycle is a fresh QEMU process reconnecting to the same listener, so the loop
+// accepts forever. Connections are served one at a time, matching QEMU's single
+// ipmi-bmc-extern link.
+func (s *VMServer) Serve(ctx context.Context, ln net.Listener) error {
+	// Close the listener to unblock Accept when ctx is canceled. Deriving a
+	// child context canceled on return guarantees this goroutine exits even when
+	// Serve returns for another reason (e.g. the caller closed the listener), so
+	// it cannot leak past the server's lifetime.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("accept VM connection: %w", err)
+		}
+
+		s.serveConn(ctx, conn)
+	}
+}
+
+// serveConn runs the framing decoder for one connection, dispatching each
+// message synchronously. It returns when the peer disconnects or ctx is
+// canceled. The VM protocol (KCS/ipmi-bmc-extern) carries one outstanding
+// transaction at a time and in-band handlers never block on slow hardware, so
+// there is no need to dispatch off the read loop.
+func (s *VMServer) serveConn(ctx context.Context, conn net.Conn) {
+	// Close the connection when the parent context is canceled so a blocked Read
+	// unwinds on shutdown. The goroutine is bound to this connection's context
+	// and exits on return, so it does not leak per past connection.
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		<-connCtx.Done()
+		_ = conn.Close()
+	}()
+
+	var (
+		acc      []byte
+		inEscape bool
+		overflow bool
+		buf      = make([]byte, vmReadBufferSize)
+	)
+
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+
+		for _, ch := range buf[:n] {
+			switch ch {
+			case vmMsgChar:
+				if !inEscape && !overflow && len(acc) > 0 {
+					// The VM protocol is the in-band system interface (channel
+					// 0x0F). Attribute the request to it so "this channel"
+					// (0x0E) resolves to the system interface rather than
+					// falling back to LAN, resolving per message so a channel
+					// table reconfigured mid-connection is observed. A missing
+					// channel leaves the context channel nil and downstream
+					// handlers fall back gracefully.
+					sysCh, _ := s.bmc.Channels.Get(systemInterfaceChannel)
+					s.handleMessage(connCtx, conn, sysCh, acc)
+				}
+				acc, inEscape, overflow = acc[:0], false, false
+			case vmCmdChar:
+				// Control command (QEMU's version and capability announcements
+				// on connect). These carry no BMC state, and the BMC never
+				// sends hardware control commands back: power authority stays
+				// with the hardware layer, so the frame is consumed and
+				// ignored.
+				acc, inEscape, overflow = acc[:0], false, false
+			case vmEscapeChar:
+				inEscape = true
+			default:
+				if inEscape {
+					ch &^= 0x10
+					inEscape = false
+				}
+				if len(acc) >= vmMaxMsgSize {
+					overflow = true
+				}
+				if !overflow {
+					acc = append(acc, ch)
+				}
+			}
+		}
+	}
+}
+
+// handleMessage decodes one IPMI request (msgID, netfn<<2|lun, cmd, data...,
+// IPMB checksum), dispatches it with an unauthenticated system-interface
+// context attributed to ch, and writes the response framed the same way with a
+// completion code after the command byte. Malformed frames are dropped,
+// matching the RMCP+ frontend's treatment of unparseable packets.
+//
+// It runs synchronously on the read loop, so msg (the decoder's accumulation
+// buffer) is stable for the whole call and handlers must not retain the request
+// slice past return, per the [handlers.Handler] contract; there is no need to
+// copy it. Being synchronous also means only one write happens at a time per
+// connection, so no write lock is needed.
+func (s *VMServer) handleMessage(ctx context.Context, conn net.Conn, ch *bmc.Channel, msg []byte) {
+	// msgID + netfn/lun + cmd + checksum is the shortest valid message.
+	if len(msg) < 4 || vmChecksum(msg) != 0 {
+		return
+	}
+
+	msgID := msg[0]
+	netFn := msg[1] >> 2
+	lun := msg[1] & 0x03
+	cmd := msg[2]
+	data := msg[3 : len(msg)-1]
+
+	hctx := &handlers.HandlerContext{BMC: s.bmc, Channel: ch}
+	respData, cc, _ := s.reg.Dispatch(ctx, hctx, netFn, cmd, data)
+
+	resp := make([]byte, 0, 4+len(respData)+1)
+	resp = append(resp, msgID, (netFn|1)<<2|lun, cmd, uint8(cc))
+	resp = append(resp, respData...)
+	resp = append(resp, -vmChecksum(resp))
+
+	_, _ = conn.Write(vmEncode(resp))
+}
+
+// vmChecksum is the IPMB two's-complement checksum: a well-formed message,
+// trailing checksum included, sums to zero.
+func vmChecksum(bs []byte) byte {
+	var sum byte
+	for _, b := range bs {
+		sum += b
+	}
+	return sum
+}
+
+// vmEncode escapes the framing bytes in bs and appends the end-of-message
+// marker, producing the on-wire form of one IPMI message.
+func vmEncode(bs []byte) []byte {
+	out := make([]byte, 0, len(bs)+8)
+	for _, b := range bs {
+		switch b {
+		case vmMsgChar, vmCmdChar, vmEscapeChar:
+			out = append(out, vmEscapeChar, b|0x10)
+		default:
+			out = append(out, b)
+		}
+	}
+	return append(out, vmMsgChar)
+}

--- a/pkg/vmproto/vmproto_test.go
+++ b/pkg/vmproto/vmproto_test.go
@@ -1,0 +1,389 @@
+package vmproto
+
+// Tests for the OpenIPMI VM protocol frontend, driven by a fake QEMU client
+// that speaks the ipmi-bmc-extern codec: single-byte control commands on
+// connect, then IPMI messages framed with the 0xA0/0xA1/0xAA bytes and an IPMB
+// checksum. They prove Get Device ID succeeds, an unknown command answers 0xC1
+// without dropping the connection, the escape path round-trips, and a fresh
+// QEMU process can reconnect.
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bougou/go-ipmi/pkg/bmc"
+	"github.com/bougou/go-ipmi/pkg/clock"
+	"github.com/bougou/go-ipmi/pkg/hal/mock"
+)
+
+const (
+	vmTestUser = "admin"
+	vmTestPass = "adminpass1234567"
+)
+
+// newTestBMC builds a BMC with an enabled admin user on the LAN channel, the
+// same shape the RMCP+ server tests use.
+func newTestBMC(t *testing.T) *bmc.BMC {
+	t.Helper()
+
+	b := bmc.New(bmc.DeviceInfo{IPMIVersion: 0x20}, [16]byte{}, mock.New(), bmc.WithClock(clock.Real))
+
+	admin, err := b.Users.Add(2, vmTestUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin.SetPassword([]byte(vmTestPass))
+	admin.Enabled = true
+	admin.ChannelAccess[1] = bmc.UserChannelAccess{MaxPrivilege: bmc.PrivilegeLevelAdministrator, Enabled: true}
+
+	return b
+}
+
+// vmClient speaks the QEMU side of the OpenIPMI VM protocol, the way
+// ipmi-bmc-extern forwards guest KCS transactions.
+type vmClient struct {
+	conn  net.Conn
+	msgID byte
+}
+
+func dialVM(t *testing.T, addr string) *vmClient {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial VM listener: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return &vmClient{conn: conn}
+}
+
+// sendControl sends a single-byte control command (version, capabilities),
+// terminated by the end-of-command marker instead of end-of-message.
+// Control command bytes QEMU sends on connect; the server consumes and ignores
+// them, and these tests prove that leaves the connection usable.
+const (
+	vmTestCmdVersion      = 0xFF
+	vmTestCmdCapabilities = 0x08
+)
+
+func (c *vmClient) sendControl(t *testing.T, data ...byte) {
+	t.Helper()
+
+	out := vmEncodeTest(data)
+	out[len(out)-1] = vmCmdChar
+
+	if _, err := c.conn.Write(out); err != nil {
+		t.Fatalf("write control: %v", err)
+	}
+}
+
+// request performs one IPMI transaction and returns (completionCode, data).
+func (c *vmClient) request(t *testing.T, netFn, cmd byte, data ...byte) (byte, []byte) {
+	t.Helper()
+
+	c.msgID++
+
+	msg := append([]byte{c.msgID, netFn << 2, cmd}, data...)
+	msg = append(msg, -sum8(msg))
+
+	if _, err := c.conn.Write(vmEncodeTest(msg)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp := c.readMessage(t)
+
+	if resp[0] != c.msgID {
+		t.Fatalf("response msgID mismatch: got %d want %d", resp[0], c.msgID)
+	}
+	if got := resp[1] >> 2; got != netFn|1 {
+		t.Fatalf("response netfn mismatch: got %#x want %#x", got, netFn|1)
+	}
+	if resp[2] != cmd {
+		t.Fatalf("response cmd mismatch: got %#x want %#x", resp[2], cmd)
+	}
+
+	return resp[3], resp[4 : len(resp)-1]
+}
+
+// readMessage reads one unescaped, checksum-verified message from the stream.
+func (c *vmClient) readMessage(t *testing.T) []byte {
+	t.Helper()
+
+	if err := c.conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	var (
+		acc      []byte
+		inEscape bool
+		buf      = make([]byte, 1)
+	)
+
+	for {
+		if _, err := c.conn.Read(buf); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+
+		switch ch := buf[0]; ch {
+		case vmMsgChar:
+			if len(acc) < 5 {
+				t.Fatalf("message too short: % x", acc)
+			}
+			if sum8(acc) != 0 {
+				t.Fatalf("checksum mismatch: % x", acc)
+			}
+			return acc
+		case vmEscapeChar:
+			inEscape = true
+		default:
+			if inEscape {
+				ch &^= 0x10
+				inEscape = false
+			}
+			acc = append(acc, ch)
+		}
+	}
+}
+
+func sum8(bs []byte) byte {
+	var s byte
+	for _, b := range bs {
+		s += b
+	}
+	return s
+}
+
+// vmEncodeTest is the client-side encoder: escape framing bytes, append the
+// end-of-message marker.
+func vmEncodeTest(bs []byte) []byte {
+	out := make([]byte, 0, len(bs)+8)
+	for _, b := range bs {
+		if b == vmMsgChar || b == vmCmdChar || b == vmEscapeChar {
+			out = append(out, vmEscapeChar, b|0x10)
+			continue
+		}
+		out = append(out, b)
+	}
+	return append(out, vmMsgChar)
+}
+
+// startVM starts s on a loopback TCP listener and returns its address.
+func startVM(t *testing.T, s *VMServer) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		if serveErr := s.Serve(ctx, ln); serveErr != nil {
+			t.Errorf("serve VM: %v", serveErr)
+		}
+	}()
+
+	t.Cleanup(func() { cancel(); <-done })
+
+	return ln.Addr().String()
+}
+
+// TestVMGetDeviceID replays the QEMU connect handshake and proves the kernel's
+// Get Device ID probe succeeds over the VM protocol.
+func TestVMGetDeviceID(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+	vm := dialVM(t, addr)
+
+	// QEMU connect handshake: version + capabilities announcements.
+	vm.sendControl(t, vmTestCmdVersion, 1)
+	vm.sendControl(t, vmTestCmdCapabilities, 0x3F)
+
+	cc, data := vm.request(t, 0x06, 0x01)
+	if cc != 0 {
+		t.Fatalf("get device ID: cc=%#x", cc)
+	}
+	if len(data) < 11 {
+		t.Fatalf("get device ID: short response len=%d", len(data))
+	}
+}
+
+// TestVMGetChannelInfoSystemInterface proves an in-band Get Channel Info for
+// 0x0E ("this channel") over the VM frontend reports the system interface
+// (channel 0x0F, medium system-interface), not LAN. The VM dispatch must
+// attribute the request to the system-interface channel for 0x0E to resolve
+// correctly.
+func TestVMGetChannelInfoSystemInterface(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+	vm := dialVM(t, addr)
+
+	vm.sendControl(t, vmTestCmdVersion, 1)
+
+	// Get Channel Info (App 0x42) for channel 0x0E.
+	cc, data := vm.request(t, 0x06, 0x42, 0x0E)
+	if cc != 0 {
+		t.Fatalf("get channel info: cc=%#x", cc)
+	}
+	if len(data) < 2 {
+		t.Fatalf("get channel info: short response len=%d", len(data))
+	}
+	if data[0] != 0x0F {
+		t.Errorf("channel number = %#x, want 0x0F (system interface)", data[0])
+	}
+	if data[1] != uint8(bmc.ChannelMediumSystemIF) {
+		t.Errorf("medium = %#x, want %#x (system interface)", data[1], uint8(bmc.ChannelMediumSystemIF))
+	}
+}
+
+// TestVMUnknownCommand proves an unimplemented command answers 0xC1 (Invalid
+// Command) and the connection survives to serve the next request.
+func TestVMUnknownCommand(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+	vm := dialVM(t, addr)
+
+	vm.sendControl(t, vmTestCmdVersion, 1)
+
+	// DCMI Get Capabilities: not implemented by the default registry.
+	if cc, _ := vm.request(t, 0x2c, 0x01, 0x00); cc != 0xC1 {
+		t.Fatalf("unknown command: cc=%#x, want 0xC1", cc)
+	}
+
+	// The connection must still work.
+	if cc, _ := vm.request(t, 0x06, 0x01); cc != 0 {
+		t.Fatalf("get device ID after unknown command: cc=%#x", cc)
+	}
+}
+
+// TestVMEscapeRoundTrip forces a framing byte into the request wire form so the
+// server's decoder must reverse an escape sequence to validate the checksum and
+// parse the command. msgID 0x3D makes the Get Device ID request checksum 0xAA
+// (an escape byte); if the server mis-decoded the escape, the checksum would
+// fail and the message would be dropped, timing out the read below.
+func TestVMEscapeRoundTrip(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+	vm := dialVM(t, addr)
+
+	vm.sendControl(t, vmTestCmdVersion, 1)
+
+	vm.msgID = 0x3C // next request uses 0x3D
+	cc, _ := vm.request(t, 0x06, 0x01)
+	if cc != 0 {
+		t.Fatalf("get device ID over escaped request: cc=%#x", cc)
+	}
+}
+
+// TestVMEncodeUnit checks the server encoder escapes every framing byte and
+// that the codec round-trips a payload containing all three of them, covering
+// the response-side escape path deterministically.
+func TestVMEncodeUnit(t *testing.T) {
+	payload := []byte{0x01, vmMsgChar, 0x02, vmCmdChar, 0x03, vmEscapeChar, 0x04}
+
+	encoded := vmEncode(payload)
+	if encoded[len(encoded)-1] != vmMsgChar {
+		t.Fatalf("encoded frame not terminated by 0x%02x", vmMsgChar)
+	}
+
+	// Decode by the same rules the client and server read loops use.
+	var (
+		got      []byte
+		inEscape bool
+	)
+	for _, ch := range encoded[:len(encoded)-1] {
+		switch ch {
+		case vmEscapeChar:
+			inEscape = true
+		default:
+			if inEscape {
+				ch &^= 0x10
+				inEscape = false
+			}
+			got = append(got, ch)
+		}
+	}
+
+	if string(got) != string(payload) {
+		t.Fatalf("round-trip mismatch: got % x want % x", got, payload)
+	}
+}
+
+// TestVMReconnect proves a fresh QEMU process (every guest power cycle is one)
+// can reconnect to the same listener and keep working.
+func TestVMReconnect(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+
+	for i := range 3 {
+		vm := dialVM(t, addr)
+		vm.sendControl(t, vmTestCmdVersion, 1)
+
+		if cc, _ := vm.request(t, 0x06, 0x01); cc != 0 {
+			t.Fatalf("connection %d: get device ID cc=%#x", i, cc)
+		}
+
+		_ = vm.conn.Close()
+		// Give the accept loop a moment to observe the close and loop back to
+		// Accept before the next dial.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestVMGetSessionChallengeRejected proves the system interface does not serve
+// LAN session establishment: an in-band Get Session Challenge must be rejected
+// without allocating a pending v1.5 session, because the pending-session table
+// evicts its oldest entry under pressure and in-band software could otherwise
+// evict a remote console's in-flight handshake at will.
+func TestVMGetSessionChallengeRejected(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+	vm := dialVM(t, addr)
+
+	vm.sendControl(t, vmTestCmdVersion, 1)
+
+	// Get Session Challenge (App 0x39): auth type MD5 + 16-byte username.
+	data := make([]byte, 17)
+	data[0] = 0x02 // MD5
+	copy(data[1:], vmTestUser)
+	cc, _ := vm.request(t, 0x06, 0x39, data...)
+	if cc == 0 {
+		t.Fatal("in-band Get Session Challenge succeeded, want rejection")
+	}
+	if got := b.V15Sessions.Count(); got != 0 {
+		t.Fatalf("in-band Get Session Challenge allocated %d pending v1.5 session(s), want 0", got)
+	}
+}
+
+// TestClientRoundTrip drives the exported [Client] against a real VMServer,
+// proving the client/server pair round-trips a Get Device ID over the VM
+// protocol. This is the same exchange the goipmi-server VM socket demo and its
+// e2e use.
+func TestClientRoundTrip(t *testing.T) {
+	b := newTestBMC(t)
+	addr := startVM(t, NewVMServer(b))
+
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	c := NewClient(conn, 5*time.Second)
+	cc, data, err := c.Command(0x06, 0x01) // Get Device ID
+	if err != nil {
+		t.Fatalf("Command: %v", err)
+	}
+	if cc != 0 {
+		t.Fatalf("completion code = %#x, want 0", cc)
+	}
+	if len(data) < 11 {
+		t.Fatalf("Get Device ID short response: %d bytes", len(data))
+	}
+}

--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -4,6 +4,7 @@
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GOIPMI="${E2E_DIR}/../../_output/goipmi"
 SERVER_BIN="${E2E_DIR}/../../_output/goipmi-server"
+VMPROBE_BIN="${E2E_DIR}/../../_output/goipmi-vmprobe"
 
 e2e_init() {
 	RED='\033[0;31m'

--- a/test/e2e/vmproto_test.sh
+++ b/test/e2e/vmproto_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# vmproto_test.sh — E2E test for go-ipmi's OpenIPMI VM protocol server.
+#
+# Starts goipmi-server with both its network port and its VM protocol mode (on a
+# unix socket), sharing one BMC, then proves the two frontends share state: a
+# chassis power action taken in band (goipmi-vmprobe over the VM socket, the
+# stand-in for QEMU's ipmi-bmc-extern / the in-guest OpenIPMI driver) is observed
+# out of band over LAN (goipmi chassis power status). This is the VM-protocol
+# counterpart of self_test.sh.
+#
+# Requires: make build  (or: make test-e2e-vmproto)
+#
+# Usage:
+#   ./test/e2e/vmproto_test.sh
+
+set -euo pipefail
+
+# shellcheck source=test/e2e/common.sh
+source "$(dirname "$0")/common.sh"
+e2e_init
+
+# The other e2e suites' random port ranges span roughly 9700-12299 (and the CI
+# ipmi-simulator uses 9623); pick a base above all of them so a future parallel
+# `make -j test-e2e` cannot collide with a sibling suite. CI runs the suites
+# sequentially, so this is belt-and-suspenders.
+PORT="${GOIPMI_SERVER_PORT:-$((12300 + RANDOM % 1000))}"
+USER="${GOIPMI_USER:-ADMIN}"
+PASS="${GOIPMI_PASS:-ADMIN}"
+# Short, unique socket path: unix socket paths are length-limited (~104 bytes),
+# and this avoids the GNU/BSD differences in `mktemp -t`.
+SOCK="${TMPDIR:-/tmp}/goipmi-vm-$$.sock"
+SOCK="${SOCK//\/\//\/}"
+
+cleanup() {
+	if [ -n "${SERVER_PID:-}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo "==> Stopping goipmi-server (pid ${SERVER_PID}) ..."
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+	rm -f "${SOCK}"
+}
+trap cleanup EXIT
+
+echo "==> Starting goipmi-server on :${PORT} with VM protocol on ${SOCK} ..."
+env \
+	GOIPMI_SERVER_PORT="${PORT}" \
+	GOIPMI_SERVER_USER="${USER}" \
+	GOIPMI_SERVER_PASS="${PASS}" \
+	GOIPMI_SERVER_VM_SOCKET="${SOCK}" \
+	"${SERVER_BIN}" &
+SERVER_PID=$!
+
+# The VM socket is created after the UDP bind, so its appearance means both
+# frontends are ready.
+for _ in $(seq 1 50); do
+	[ -S "${SOCK}" ] && break
+	if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+		echo -e "${RED}ERROR: goipmi-server exited before creating the VM socket${NC}" >&2
+		exit 1
+	fi
+	sleep 0.1
+done
+if [ ! -S "${SOCK}" ]; then
+	echo -e "${RED}ERROR: VM socket ${SOCK} was not created${NC}" >&2
+	exit 1
+fi
+
+# In-band Chassis Control (NetFn 0x00, cmd 0x02) over the system interface;
+# no session, no credentials, by design. data 1 = power up, 0 = power down.
+vm_chassis_power() {
+	"${VMPROBE_BIN}" -socket "${SOCK}" -netfn 0 -cmd 2 -data "$1" >/dev/null
+}
+
+# Out-of-band power state over LAN. `chassis power status` prints exactly one
+# line ("Chassis Power is on"/"...off"), so an exact-string check is stable.
+lan_power_is() {
+	local out
+	out="$("${GOIPMI}" -H 127.0.0.1 -p "${PORT}" -U "${USER}" -P "${PASS}" -I lanplus chassis power status 2>/dev/null)"
+	[ "${out}" = "Chassis Power is $1" ]
+}
+
+echo ""
+echo "========================================"
+echo " VM protocol E2E: goipmi-vmprobe → goipmi-server (${SOCK}), shared with LAN (:${PORT})"
+echo "========================================"
+
+failures=0
+
+# Basic wiring: an in-band Get Device ID round-trips over the VM socket.
+e2e_run_test "vm get device id" "${VMPROBE_BIN}" -socket "${SOCK}" -netfn 6 -cmd 1 \
+	|| ((failures++)) || true
+
+# Shared state: power on in band, then observe it over LAN, then off, then LAN.
+# Power on first — the mock BMC boots powered off, so on-then-verify proves a
+# real transition rather than the initial state.
+e2e_run_test "vm power on (in band)" vm_chassis_power 1 || ((failures++)) || true
+e2e_run_test "lan sees power on" lan_power_is on || ((failures++)) || true
+e2e_run_test "vm power off (in band)" vm_chassis_power 0 || ((failures++)) || true
+e2e_run_test "lan sees power off" lan_power_is off || ((failures++)) || true
+
+e2e_report "VM protocol E2E" "${failures}"


### PR DESCRIPTION
Disclaimer: this was authored mainly by Claude Fable 5, and reviewed by myself and other models.

Builds on top of #88 (and through it, #87), so their commits show in the diff until they merge.

The server could only be reached over the network. A machine emulator such as QEMU exposes an in-band IPMI interface to its guest over a byte-stream side channel using the OpenIPMI VM protocol, and there was no way to serve that, so a guest could not talk to this BMC through its own system interface the way it would on real hardware.

This adds a second server frontend that speaks the OpenIPMI VM protocol over a stream listener, alongside the existing network server. It accepts one emulator connection at a time and tolerates reconnection across guest power cycles, decodes the framed in-band messages, and dispatches them through the same command set as the network server against the same shared BMC state, so a user created or a power action taken in band is visible out of band and vice versa. In-band requests arrive on the system interface with no session, matching how a real host talks to its BMC. It is intended for simulation and end-to-end testing.

Session establishment stays a LAN-only concern: a session-setup request arriving on the system interface is rejected instead of allocating a LAN session slot, since the pending-session table evicts its oldest entry under pressure and in-band software could otherwise evict a remote console's in-flight handshake. Real BMCs do not serve session establishment on the system interface either.
