### PR TITLE
fix(client): handle SOL output sequencing

### DIFF
--- a/pkg/client/sol_stream.go
+++ b/pkg/client/sol_stream.go
@@ -21,6 +21,9 @@ type SOLStreamOptions struct {
 const (
 	defaultSOLTransmitRetryCount    = 3
 	defaultSOLTransmitRetryInterval = 100 * time.Millisecond
+	solSequenceMask                 = 0x0f
+	solStatusDeactivating           = 1 << 4 // IPMI v2.0 Table 15-2, status bit 4
+	solStatusTransmitOverrun        = 1 << 3 // IPMI v2.0 Table 15-2, status bit 3
 )
 
 // SOLStream exchanges console data over an already active SOL payload. Input is transmitted
@@ -38,6 +41,85 @@ func (c *Client) SOLStream(ctx context.Context, in io.Reader, out io.Writer, opt
 type solConsoleInput struct {
 	value byte
 	err   error
+}
+
+// solOutputStream tracks the state of the SOL output stream.
+type solOutputStream struct {
+	writer            io.Writer
+	sequenceNumber    uint8
+	acceptedCharCount uint8
+}
+
+// nextSOLSequenceNumber returns the next SOL sequence number, wrapping from 15 to 1.
+func nextSOLSequenceNumber(sequenceNumber uint8) uint8 {
+	sequenceNumber = (sequenceNumber + 1) & solSequenceMask
+	if sequenceNumber == 0 {
+		return 1
+	}
+
+	return sequenceNumber
+}
+
+func (s *solOutputStream) process(response *types.SOLPayloadResponse) error {
+	if response == nil {
+		return fmt.Errorf("nil SOL payload response")
+	}
+
+	// These status bits mean the stream cannot deliver complete console output.
+	if response.ControlByte&solStatusDeactivating != 0 {
+		return fmt.Errorf("BMC reported SOL deactivation")
+	}
+
+	if response.ControlByte&solStatusTransmitOverrun != 0 {
+		return fmt.Errorf("BMC reported SOL transmit overrun, console output was lost")
+	}
+
+	sequenceNumber := response.SequenceNumber & solSequenceMask
+	data := response.CharacterData
+	// Sequence number zero acknowledges console input and must not carry BMC output.
+	if sequenceNumber == 0 {
+		if len(data) != 0 {
+			return fmt.Errorf("BMC sent %d SOL data bytes with ACK-only sequence 0", len(data))
+		}
+		return nil
+	}
+
+	// AcceptedCharacterCount is one byte, so larger packets cannot be acknowledged.
+	if len(data) > 255 {
+		return fmt.Errorf("BMC sent %d SOL data bytes, acknowledgement count is limited to 255", len(data))
+	}
+
+	writeOffset := 0
+	switch {
+	// No BMC output sequence has been received yet.
+	case s.sequenceNumber == 0:
+	case sequenceNumber == s.sequenceNumber:
+		// A retransmission may append data. Write only bytes not previously delivered.
+		if len(data) < int(s.acceptedCharCount) {
+			return fmt.Errorf("BMC shortened retried SOL sequence %d from %d to %d bytes",
+				sequenceNumber, s.acceptedCharCount, len(data))
+		}
+		writeOffset = int(s.acceptedCharCount)
+	case sequenceNumber != nextSOLSequenceNumber(s.sequenceNumber):
+		// A gap means BMC output was lost before it reached the writer.
+		return fmt.Errorf("unexpected BMC SOL sequence %d after %d", sequenceNumber, s.sequenceNumber)
+	}
+
+	dataToWrite := data[writeOffset:]
+	if len(dataToWrite) > 0 {
+		n, err := s.writer.Write(dataToWrite)
+		if err != nil {
+			return fmt.Errorf("write SOL output: %w", err)
+		}
+
+		if n != len(dataToWrite) {
+			return fmt.Errorf("write SOL output: %w", io.ErrShortWrite)
+		}
+	}
+	s.sequenceNumber = sequenceNumber
+	s.acceptedCharCount = uint8(len(data))
+
+	return nil
 }
 
 func readSOLInput(ctx context.Context, in io.Reader) <-chan solConsoleInput {
@@ -79,15 +161,14 @@ func (c *Client) runSOLStream(
 	defer ticker.Stop()
 
 	var localSeq uint8 = 1
-	var remoteSeq uint8
-	var pendingAckCount uint8
+	output := solOutputStream{writer: out}
 
 	sendPacket := func(chars []byte) (*types.SOLPayloadResponse, error) {
 		req := &types.SOLPayloadRequest{
 			SOLPayloadPacket: types.SOLPayloadPacket{
 				SequenceNumber:         localSeq,
-				AckedSequenceNumber:    remoteSeq,
-				AcceptedCharacterCount: pendingAckCount,
+				AckedSequenceNumber:    output.sequenceNumber,
+				AcceptedCharacterCount: output.acceptedCharCount,
 				CharacterData:          chars,
 			},
 		}
@@ -95,19 +176,10 @@ func (c *Client) runSOLStream(
 		if err != nil {
 			return nil, err
 		}
-		localSeq++
-		if localSeq > 0x0f {
-			localSeq = 1
-		}
-		pendingAckCount = 0
+		localSeq = nextSOLSequenceNumber(localSeq)
 
-		remoteSeq = res.SequenceNumber & 0x0f
-		pendingAckCount = uint8(len(res.CharacterData))
-
-		if len(res.CharacterData) > 0 {
-			if _, err := out.Write(res.CharacterData); err != nil {
-				return nil, err
-			}
+		if err := output.process(res); err != nil {
+			return nil, err
 		}
 		return res, nil
 	}

--- a/pkg/client/sol_stream_test.go
+++ b/pkg/client/sol_stream_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+func TestSOLOutputStreamSuppressesRetransmittedData(t *testing.T) {
+	var out bytes.Buffer
+	stream := solOutputStream{writer: &out}
+
+	for _, response := range []*types.SOLPayloadResponse{
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("abc")}},
+		{},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("abc")}},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("abcde")}},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("f")}},
+	} {
+		if err := stream.process(response); err != nil {
+			t.Fatalf("process() error = %v", err)
+		}
+	}
+
+	if got := out.String(); got != "abcdef" {
+		t.Fatalf("SOL output = %q, want %q", got, "abcdef")
+	}
+}
+
+func TestSOLOutputStreamRejectsInvalidResponse(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		response *types.SOLPayloadResponse
+		want     string
+	}{
+		{
+			name:     "deactivating",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{ControlByte: solStatusDeactivating}},
+			want:     "deactivation",
+		},
+		{
+			name:     "transmit overrun",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{ControlByte: solStatusTransmitOverrun}},
+			want:     "output was lost",
+		},
+		{
+			name:     "data with ACK-only sequence",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{CharacterData: []byte("x")}},
+			want:     "ACK-only sequence 0",
+		},
+		{
+			name: "shortened retransmission",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{
+				SequenceNumber: 1,
+				CharacterData:  []byte("ab"),
+			}},
+			want: "shortened retried",
+		},
+		{
+			name: "sequence gap",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{
+				SequenceNumber: 3,
+				CharacterData:  []byte("gap"),
+			}},
+			want: "unexpected BMC SOL sequence",
+		},
+		{
+			name: "oversized data",
+			response: &types.SOLPayloadResponse{SOLPayloadPacket: types.SOLPayloadPacket{
+				SequenceNumber: 2,
+				CharacterData:  bytes.Repeat([]byte("x"), 256),
+			}},
+			want: "limited to 255",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := solOutputStream{writer: io.Discard, sequenceNumber: 1, acceptedCharCount: 3}
+			err := stream.process(tt.response)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("process() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Track BMC sequence numbers and accepted character counts to suppress retransmitted data. Detect sequence gaps, invalid retransmissions, and status conditions that indicate console output was lost.