### PR TITLE
fix(client): preserve and acknowledge asynchronous SOL output

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -84,6 +84,9 @@ type Client struct {
 	// starts from defaultFRUReadSize and remembers reductions across chunks.
 	fruMaxReadSize uint8
 
+	// activeSOLStream is protected by l.
+	activeSOLStream *solStream
+
 	// openBackendPref selects which Windows Open Interface transport to use
 	// when Interface == InterfaceOpen. Valid values: "" / "auto" (default;
 	// try native COM, fall back to PowerShell), "wmi-com", "wmi-ps".

--- a/pkg/client/interface_lan.go
+++ b/pkg/client/interface_lan.go
@@ -183,11 +183,9 @@ func (c *Client) tryMatchIPMILANResponse(recv []byte, wantSeq, wantCmd uint8) (b
 // acknowledging the pending request. A data request is acknowledged by
 // echoing its sequence number (spec v2.0 §15.9/§15.11), so the response to
 // the request with sequence number wantAck always carries
-// AckedSequenceNumber == wantAck. Async retransmissions of earlier packets
-// (which reuse the original sequence number per §15.9 and are sent before the
-// request was processed) carry older acked sequence numbers and are discarded
-// here — consuming them as the response would re-display already-delivered
-// character data and lag the ACK bookkeeping.
+// AckedSequenceNumber == wantAck. Asynchronous BMC output may acknowledge an
+// earlier request, so it is preserved for the active stream to process after
+// the pending request completes.
 //
 // ACK-only requests (sequence 0h) carry no number for the BMC to echo: it
 // answers with the last accepted data sequence instead (which is non-zero
@@ -222,6 +220,9 @@ func (c *Client) tryMatchSOLResponse(recv []byte, wantAck uint8) (bool, error) {
 		return false, nil
 	}
 	if wantAck != 0 && sol.AckedSequenceNumber != wantAck {
+		if sol.SequenceNumber != 0 {
+			c.deliverSOLOutput(&types.SOLPayloadResponse{SOLPayloadPacket: sol})
+		}
 		c.DebugfYellow("drop recv: SOL ack mismatch (got ack %d, want ack %d)\n", sol.AckedSequenceNumber, wantAck)
 		return false, nil
 	}

--- a/pkg/client/server_sol_test.go
+++ b/pkg/client/server_sol_test.go
@@ -171,6 +171,37 @@ func TestSOLSessionLoopback(t *testing.T) {
 	waitForCondition(t, "console conn close", fake.IsClosed)
 }
 
+func TestSOLStreamImmediatelyAcknowledgesOutput(t *testing.T) {
+	c, _, fake := newSOLTestServer(t)
+	ctx := context.Background()
+	if _, err := c.ActivatePayload(ctx, &transport.ActivatePayloadRequest{
+		PayloadType:     types.PayloadTypeSOL,
+		PayloadInstance: 1,
+	}); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = c.DeactivatePayload(ctx, &transport.DeactivatePayloadRequest{
+			PayloadType:     types.PayloadTypeSOL,
+			PayloadInstance: 1,
+		})
+	})
+
+	want := bytes.Repeat([]byte("x"), 2*bmc.SOLMaxPayloadChars+1)
+	fake.FeedRX(want)
+
+	var out bytes.Buffer
+	err := c.SOLStream(ctx, strings.NewReader(""), &out, &SOLStreamOptions{
+		PollInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("SOLStream() error = %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatalf("SOL output length = %d, want %d", out.Len(), len(want))
+	}
+}
+
 type rejectingConsole struct {
 	mock.FakeConsoleConn
 

--- a/pkg/client/sol_stream.go
+++ b/pkg/client/sol_stream.go
@@ -19,11 +19,12 @@ type SOLStreamOptions struct {
 }
 
 const (
-	defaultSOLTransmitRetryCount    = 3
-	defaultSOLTransmitRetryInterval = 100 * time.Millisecond
-	solSequenceMask                 = 0x0f
-	solStatusDeactivating           = 1 << 4 // IPMI v2.0 Table 15-2, status bit 4
-	solStatusTransmitOverrun        = 1 << 3 // IPMI v2.0 Table 15-2, status bit 3
+	defaultSOLTransmitRetryCount        = 3
+	defaultSOLTransmitRetryInterval     = 100 * time.Millisecond
+	defaultSOLAcknowledgementRetryCount = 3
+	solSequenceMask                     = 0x0f
+	solStatusDeactivating               = 1 << 4 // IPMI v2.0 Table 15-2, status bit 4
+	solStatusTransmitOverrun            = 1 << 3 // IPMI v2.0 Table 15-2, status bit 3
 )
 
 // SOLStream exchanges console data over an already active SOL payload. Input is transmitted
@@ -169,7 +170,7 @@ func (c *Client) runSOLStream(
 	return stream.run(ctx)
 }
 
-func (s *solStream) sendPacket(ctx context.Context, chars []byte) (*types.SOLPayloadResponse, error) {
+func (s *solStream) exchangePacket(ctx context.Context, chars []byte) (*types.SOLPayloadResponse, error) {
 	req := &types.SOLPayloadRequest{
 		SOLPayloadPacket: types.SOLPayloadPacket{
 			SequenceNumber:         s.localSequenceNumber,
@@ -188,6 +189,48 @@ func (s *solStream) sendPacket(ctx context.Context, chars []byte) (*types.SOLPay
 		return nil, err
 	}
 	return res, nil
+}
+
+// acknowledgeOutput immediately acknowledges and drains BMC console output.
+func (s *solStream) acknowledgeOutput(ctx context.Context, response *types.SOLPayloadResponse) error {
+	repeatedResponses := 0
+	for response.SequenceNumber&solSequenceMask != 0 {
+		previousSequenceNumber := s.remoteSequenceNumber
+		previousAcceptedCharCount := s.acceptedCharCount
+
+		// A nonzero empty packet carries the acknowledgement and requires a response from the BMC.
+		var err error
+		response, err = s.exchangePacket(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if response.SequenceNumber&solSequenceMask == 0 {
+			return nil
+		}
+
+		if s.remoteSequenceNumber == previousSequenceNumber &&
+			s.acceptedCharCount == previousAcceptedCharCount {
+			repeatedResponses++
+			if repeatedResponses > defaultSOLAcknowledgementRetryCount {
+				return fmt.Errorf("BMC repeated SOL sequence %d after %d acknowledgement retries",
+					s.remoteSequenceNumber, defaultSOLAcknowledgementRetryCount)
+			}
+		} else {
+			repeatedResponses = 0
+		}
+	}
+	return nil
+}
+
+func (s *solStream) sendPacket(ctx context.Context, chars []byte) (*types.SOLPayloadResponse, error) {
+	response, err := s.exchangePacket(ctx, chars)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.acknowledgeOutput(ctx, response); err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 func (s *solStream) sendData(ctx context.Context, chars []byte) error {

--- a/pkg/client/sol_stream.go
+++ b/pkg/client/sol_stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/bougou/go-ipmi/pkg/types"
@@ -23,8 +24,13 @@ const (
 	defaultSOLTransmitRetryInterval     = 100 * time.Millisecond
 	defaultSOLAcknowledgementRetryCount = 3
 	solSequenceMask                     = 0x0f
-	solStatusDeactivating               = 1 << 4 // IPMI v2.0 Table 15-2, status bit 4
-	solStatusTransmitOverrun            = 1 << 3 // IPMI v2.0 Table 15-2, status bit 3
+	// Sequence numbers wrap from 15 to 1, so 0 is not part of the cycle and the
+	// cycle holds 15 values. A packet more than half the cycle ahead of the last
+	// one received is read as trailing it rather than skipping past it.
+	solSequenceSpace         = 15
+	solSequenceHalfSpace     = solSequenceSpace / 2
+	solStatusDeactivating    = 1 << 4 // IPMI v2.0 Table 15-2, status bit 4
+	solStatusTransmitOverrun = 1 << 3 // IPMI v2.0 Table 15-2, status bit 3
 )
 
 // SOLStream exchanges console data over an already active SOL payload. Input is transmitted
@@ -54,6 +60,10 @@ type solStream struct {
 	localSequenceNumber  uint8
 	remoteSequenceNumber uint8
 	acceptedCharCount    uint8
+	outputAckPending     bool
+
+	pendingOutputMu sync.Mutex
+	pendingOutput   []*types.SOLPayloadResponse
 }
 
 // nextSOLSequenceNumber returns the next SOL sequence number, wrapping from 15 to 1.
@@ -64,6 +74,14 @@ func nextSOLSequenceNumber(sequenceNumber uint8) uint8 {
 	}
 
 	return sequenceNumber
+}
+
+// solSequenceDistance returns how many steps separate sequenceNumber from
+// previous, counting forward through the wrapping sequence space. Both must be
+// valid data sequence numbers (1 to 15). A result above solSequenceHalfSpace
+// means sequenceNumber trails previous.
+func solSequenceDistance(sequenceNumber, previous uint8) uint8 {
+	return uint8((int(sequenceNumber) - int(previous) + solSequenceSpace) % solSequenceSpace)
 }
 
 func (s *solStream) processOutput(response *types.SOLPayloadResponse) error {
@@ -106,7 +124,15 @@ func (s *solStream) processOutput(response *types.SOLPayloadResponse) error {
 				sequenceNumber, s.acceptedCharCount, len(data))
 		}
 		writeOffset = int(s.acceptedCharCount)
-	case sequenceNumber != nextSOLSequenceNumber(s.remoteSequenceNumber):
+	case sequenceNumber == nextSOLSequenceNumber(s.remoteSequenceNumber):
+	case solSequenceDistance(sequenceNumber, s.remoteSequenceNumber) > solSequenceHalfSpace:
+		// The BMC retransmits unacknowledged output (spec v2.0 §15.9) reusing the
+		// original sequence number, so a packet trailing the current one is a
+		// duplicate sent before our acknowledgement arrived. Its data was already
+		// delivered, and it says nothing about what the BMC has since accepted, so
+		// drop it without disturbing the acknowledgement bookkeeping.
+		return nil
+	default:
 		// A gap means BMC output was lost before it reached the writer.
 		return fmt.Errorf("unexpected BMC SOL sequence %d after %d", sequenceNumber, s.remoteSequenceNumber)
 	}
@@ -124,8 +150,48 @@ func (s *solStream) processOutput(response *types.SOLPayloadResponse) error {
 	}
 	s.remoteSequenceNumber = sequenceNumber
 	s.acceptedCharCount = uint8(len(data))
+	s.outputAckPending = true
 
 	return nil
+}
+
+func (c *Client) registerSOLStream(stream *solStream) error {
+	c.lock()
+	defer c.unlock()
+	if c.activeSOLStream != nil {
+		return fmt.Errorf("SOL stream is already active")
+	}
+	c.activeSOLStream = stream
+	return nil
+}
+
+func (c *Client) unregisterSOLStream() {
+	c.lock()
+	defer c.unlock()
+	c.activeSOLStream = nil
+}
+
+func (c *Client) deliverSOLOutput(response *types.SOLPayloadResponse) {
+	c.lock()
+	stream := c.activeSOLStream
+	c.unlock()
+	if stream != nil {
+		stream.queueOutput(response)
+	}
+}
+
+func (s *solStream) queueOutput(response *types.SOLPayloadResponse) {
+	s.pendingOutputMu.Lock()
+	defer s.pendingOutputMu.Unlock()
+	s.pendingOutput = append(s.pendingOutput, response)
+}
+
+func (s *solStream) takePendingOutput() []*types.SOLPayloadResponse {
+	s.pendingOutputMu.Lock()
+	defer s.pendingOutputMu.Unlock()
+	responses := s.pendingOutput
+	s.pendingOutput = nil
+	return responses
 }
 
 func readSOLInput(ctx context.Context, in io.Reader) <-chan solConsoleInput {
@@ -167,6 +233,11 @@ func (c *Client) runSOLStream(
 		interrupt:           interrupt,
 		localSequenceNumber: 1,
 	}
+	if err := c.registerSOLStream(stream); err != nil {
+		return err
+	}
+	defer c.unregisterSOLStream()
+
 	return stream.run(ctx)
 }
 
@@ -184,6 +255,14 @@ func (s *solStream) exchangePacket(ctx context.Context, chars []byte) (*types.SO
 		return nil, err
 	}
 	s.localSequenceNumber = nextSOLSequenceNumber(s.localSequenceNumber)
+	// The request carried the acknowledgement for output received so far.
+	s.outputAckPending = false
+
+	for _, pending := range s.takePendingOutput() {
+		if err := s.processOutput(pending); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := s.processOutput(res); err != nil {
 		return nil, err
@@ -192,23 +271,20 @@ func (s *solStream) exchangePacket(ctx context.Context, chars []byte) (*types.SO
 }
 
 // acknowledgeOutput immediately acknowledges and drains BMC console output.
-func (s *solStream) acknowledgeOutput(ctx context.Context, response *types.SOLPayloadResponse) error {
+func (s *solStream) acknowledgeOutput(ctx context.Context) error {
 	repeatedResponses := 0
-	for response.SequenceNumber&solSequenceMask != 0 {
+	for s.outputAckPending {
 		previousSequenceNumber := s.remoteSequenceNumber
 		previousAcceptedCharCount := s.acceptedCharCount
 
 		// A nonzero empty packet carries the acknowledgement and requires a response from the BMC.
-		var err error
-		response, err = s.exchangePacket(ctx, nil)
+		_, err := s.exchangePacket(ctx, nil)
 		if err != nil {
 			return err
 		}
-		if response.SequenceNumber&solSequenceMask == 0 {
-			return nil
-		}
 
-		if s.remoteSequenceNumber == previousSequenceNumber &&
+		if s.outputAckPending &&
+			s.remoteSequenceNumber == previousSequenceNumber &&
 			s.acceptedCharCount == previousAcceptedCharCount {
 			repeatedResponses++
 			if repeatedResponses > defaultSOLAcknowledgementRetryCount {
@@ -227,7 +303,7 @@ func (s *solStream) sendPacket(ctx context.Context, chars []byte) (*types.SOLPay
 	if err != nil {
 		return nil, err
 	}
-	if err := s.acknowledgeOutput(ctx, response); err != nil {
+	if err := s.acknowledgeOutput(ctx); err != nil {
 		return nil, err
 	}
 	return response, nil

--- a/pkg/client/sol_stream_test.go
+++ b/pkg/client/sol_stream_test.go
@@ -30,6 +30,46 @@ func TestSOLOutputStreamSuppressesRetransmittedData(t *testing.T) {
 	}
 }
 
+func TestSOLOutputStreamDropsTrailingRetransmission(t *testing.T) {
+	var out bytes.Buffer
+	stream := solStream{output: &out}
+
+	for _, response := range []*types.SOLPayloadResponse{
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 14, CharacterData: []byte("abc")}},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("def")}},
+		// Retransmissions the BMC sent before our acknowledgement arrived, delayed
+		// past newer output. Redelivering them would repeat character data, and
+		// treating them as a gap would tear down the stream.
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 14, CharacterData: []byte("abc")}},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 1, CharacterData: []byte("ghi")}},
+		{SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("def")}},
+	} {
+		if err := stream.processOutput(response); err != nil {
+			t.Fatalf("processOutput() error = %v", err)
+		}
+	}
+
+	if got := out.String(); got != "abcdefghi" {
+		t.Fatalf("SOL output = %q, want %q", got, "abcdefghi")
+	}
+	if stream.remoteSequenceNumber != 1 || stream.acceptedCharCount != 3 {
+		t.Fatalf("stream acked sequence %d with %d chars, want sequence 1 with 3 chars",
+			stream.remoteSequenceNumber, stream.acceptedCharCount)
+	}
+
+	// A dropped duplicate carries no news about what the BMC accepted, so it must
+	// not schedule an acknowledgement of its own.
+	stream.outputAckPending = false
+	if err := stream.processOutput(&types.SOLPayloadResponse{
+		SOLPayloadPacket: types.SOLPayloadPacket{SequenceNumber: 15, CharacterData: []byte("def")},
+	}); err != nil {
+		t.Fatalf("processOutput() error = %v", err)
+	}
+	if stream.outputAckPending {
+		t.Fatal("dropped duplicate left an acknowledgement pending")
+	}
+}
+
 func TestSOLOutputStreamRejectsInvalidResponse(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
@@ -83,5 +123,56 @@ func TestSOLOutputStreamRejectsInvalidResponse(t *testing.T) {
 				t.Fatalf("process() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestSOLStreamPreservesAsynchronousOutput(t *testing.T) {
+	client := &Client{}
+	stream := &solStream{client: client}
+	if err := client.registerSOLStream(stream); err != nil {
+		t.Fatalf("registerSOLStream() error = %v", err)
+	}
+	defer client.unregisterSOLStream()
+
+	payload := (&types.SOLPayloadPacket{
+		SequenceNumber:      1,
+		AckedSequenceNumber: 0,
+		CharacterData:       []byte("output"),
+	}).Pack()
+	packet := (&types.Rmcp{
+		RmcpHeader: types.NewRmcpHeader(),
+		Session20: &types.Session20{
+			SessionHeader20: &types.SessionHeader20{
+				AuthType:      types.AuthTypeRMCPPlus,
+				PayloadType:   types.PayloadTypeSOL,
+				PayloadLength: uint16(len(payload)),
+			},
+			SessionPayload: payload,
+		},
+	}).Pack()
+
+	matched, err := client.tryMatchSOLResponse(packet, 2)
+	if err != nil {
+		t.Fatalf("tryMatchSOLResponse() error = %v", err)
+	}
+	if matched {
+		t.Fatal("tryMatchSOLResponse() matched asynchronous output")
+	}
+
+	responses := stream.takePendingOutput()
+	if len(responses) != 1 || string(responses[0].CharacterData) != "output" {
+		t.Fatalf("pending SOL responses = %#v, want asynchronous output", responses)
+	}
+}
+
+func TestRegisterSOLStreamRejectsActiveStream(t *testing.T) {
+	client := &Client{}
+	if err := client.registerSOLStream(&solStream{}); err != nil {
+		t.Fatalf("registerSOLStream() error = %v", err)
+	}
+	defer client.unregisterSOLStream()
+
+	if err := client.registerSOLStream(&solStream{}); err == nil {
+		t.Fatal("registerSOLStream() accepted a second active stream")
 	}
 }


### PR DESCRIPTION
A BMC can send console output while the client is waiting for a response that acknowledges a newer request. Preserve these packets for the active stream, promptly acknowledge processed output, and ignore delayed retransmissions without disturbing acknowledgement state. 
