### PR TITLE
Fix ThresholdStatus reporting upper critical for every threshold

### DIFF
--- a/pkg/command/sensor/get_sensor_reading.go
+++ b/pkg/command/sensor/get_sensor_reading.go
@@ -105,24 +105,28 @@ func (res *GetSensorReadingResponse) Unpack(msg []byte) error {
 	return nil
 }
 
+// ThresholdStatus returns the threshold status of the sensor, that is, the most
+// severe threshold the reading has crossed. A reading beyond a non-recoverable
+// threshold is normally reported as being beyond the critical and non-critical
+// ones as well, so the checks are ordered from the most severe to the least.
 func (r *GetSensorReadingResponse) ThresholdStatus() types.SensorThresholdStatus {
+	if r.Above_UNR {
+		return types.SensorThresholdStatus_UNR
+	}
+	if r.Below_LNR {
+		return types.SensorThresholdStatus_LNR
+	}
 	if r.Above_UCR {
 		return types.SensorThresholdStatus_UCR
 	}
-	if r.Above_UNC {
-		return types.SensorThresholdStatus_UCR
-	}
-	if r.Above_UNR {
-		return types.SensorThresholdStatus_UCR
-	}
 	if r.Below_LCR {
-		return types.SensorThresholdStatus_UCR
+		return types.SensorThresholdStatus_LCR
+	}
+	if r.Above_UNC {
+		return types.SensorThresholdStatus_UNC
 	}
 	if r.Below_LNC {
-		return types.SensorThresholdStatus_UCR
-	}
-	if r.Below_LNR {
-		return types.SensorThresholdStatus_UCR
+		return types.SensorThresholdStatus_LNC
 	}
 	return types.SensorThresholdStatus_OK
 }

--- a/pkg/command/sensor/get_sensor_reading_test.go
+++ b/pkg/command/sensor/get_sensor_reading_test.go
@@ -1,0 +1,83 @@
+package sensor
+
+import (
+	"testing"
+
+	"github.com/bougou/go-ipmi/pkg/types"
+)
+
+// TestGetSensorReadingResponseThresholdStatus checks the threshold comparison
+// status decoded from byte 3 of the Get Sensor Reading response (IPMI v2.0
+// section 35.14), where bits 5-0 mean, in order, at or above UNR, UCR and UNC,
+// and at or below LNR, LCR and LNC. Every asserted threshold must map to its own
+// status, and when several are asserted at once the most severe one wins.
+func TestGetSensorReadingResponseThresholdStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		// data is the response starting at the reading byte. Byte 1 has the
+		// reading valid and sensor scanning enabled bits set (0xc0).
+		data []byte
+		want types.SensorThresholdStatus
+	}{
+		{
+			name: "no threshold crossed",
+			data: []byte{0x40, 0xc0, 0x00},
+			want: types.SensorThresholdStatus_OK,
+		},
+		{
+			name: "at or above upper non-critical",
+			data: []byte{0x50, 0xc0, 0x08},
+			want: types.SensorThresholdStatus_UNC,
+		},
+		{
+			name: "at or above upper critical",
+			data: []byte{0x60, 0xc0, 0x18},
+			want: types.SensorThresholdStatus_UCR,
+		},
+		{
+			name: "at or above upper non-recoverable",
+			data: []byte{0x70, 0xc0, 0x38},
+			want: types.SensorThresholdStatus_UNR,
+		},
+		{
+			name: "at or below lower non-critical",
+			data: []byte{0x20, 0xc0, 0x01},
+			want: types.SensorThresholdStatus_LNC,
+		},
+		{
+			name: "at or below lower critical",
+			data: []byte{0x10, 0xc0, 0x03},
+			want: types.SensorThresholdStatus_LCR,
+		},
+		{
+			name: "at or below lower non-recoverable",
+			data: []byte{0x00, 0xc0, 0x07},
+			want: types.SensorThresholdStatus_LNR,
+		},
+		{
+			// Only the critical bit asserted, without the non-critical one
+			// below it: some BMCs report just the threshold that was crossed.
+			name: "upper critical without upper non-critical",
+			data: []byte{0x60, 0xc0, 0x10},
+			want: types.SensorThresholdStatus_UCR,
+		},
+		{
+			// A response without the optional threshold comparison byte.
+			name: "no comparison status byte",
+			data: []byte{0x40, 0xc0},
+			want: types.SensorThresholdStatus_OK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := &GetSensorReadingResponse{}
+			if err := res.Unpack(tc.data); err != nil {
+				t.Fatalf("Unpack failed: %v", err)
+			}
+			if got := res.ThresholdStatus(); got != tc.want {
+				t.Errorf("ThresholdStatus() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
All six branches of `GetSensorReadingResponse.ThresholdStatus()` returned `SensorThresholdStatus_UCR`, so whichever threshold the reading had crossed, the status said upper critical:

```go
if r.Above_UNC {
	return types.SensorThresholdStatus_UCR   // should be UNC
}
if r.Above_UNR {
	return types.SensorThresholdStatus_UCR   // should be UNR
}
if r.Below_LCR {
	return types.SensorThresholdStatus_UCR   // should be LCR
}
```

So a non-critical reading could not be told apart from a critical or a non-recoverable one, and a reading below a lower threshold was reported as being above an upper one. `Sensor.Status()` passes the value straight through, so every caller of `GetSensors` saw it. v0.8.3 and v0.9.0 are affected as well.

In prometheus-community/ipmi_exporter's native mode, for instance, `ipmi_*_state` can only ever be 0 (nominal), 2 (critical) or NaN. Its warning and non-recoverable branches never run, and its `docs/native.md` promises a state of 3 ("non-recoverable") that no released go-ipmi can produce.

`Unpack` reads the comparison bits of byte 3 correctly (IPMI v2.0 section 35.14), only this mapping was wrong. This returns the status that matches each bit, checking the most severe threshold first (UNR, LNR, UCR, LCR, UNC, LNC), since a reading past a non-recoverable threshold is normally reported as past the critical and non-critical ones as well.

The new table test covers each threshold bit on its own, a reading past several thresholds at once, a critical assertion without the non-critical bit below it, and a response that leaves out the optional comparison byte. Five of its nine cases fail without the fix.

Disclaimer: this was written with the help of an AI agent. I have read and audited all of it myself before opening this PR.
